### PR TITLE
fix(deps): patch ajv ReDoS advisory (Dependabot #18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7613,9 +7613,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19649,7 +19649,8 @@
         "ethers": "^6.4.0",
         "express": "^5.2.1",
         "helmet": "^8.1.0",
-        "pg": "^8.18.0"
+        "pg": "^8.18.0",
+        "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",


### PR DESCRIPTION
## Summary
- bumps transitive `ajv` from `8.17.1` to `8.18.0` in `package-lock.json`
- addresses Dependabot alert #18 (`GHSA-2g4f-4pwh-qvx6`: ReDoS when using `$data` option)

## Why
Dependabot reports vulnerable range `< 8.18.0`. This patch moves lockfile resolution to the first patched release.

## Validation
- `npm ls ajv --all --depth=4` shows `ajv@8.18.0`
- `npm run lint` passes

## Scope
- dependency lockfile change only
- no contract/ABI/business logic changes
