### PR TITLE
docs(readme): fix docker profile command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ npm run -w treasury lint && npm run -w treasury test && npm run -w treasury buil
 Use these profile commands for deterministic runtime checks:
 
 ```bash
-scripts/docker-services.sh up local
-scripts/docker-services.sh health local
+scripts/docker-services.sh up local-dev
+scripts/docker-services.sh health local-dev
 
 scripts/docker-services.sh up staging-e2e
 scripts/docker-services.sh health staging-e2e


### PR DESCRIPTION
## Summary
- updates root README docker commands to use the supported `local-dev` profile name
- aligns docs with `scripts/docker-services.sh` accepted profile values

## Why
README examples used `local`, while the script expects `local-dev`, which can cause operator confusion.

## Scope
- docs only (`README.md`)
- no code, contract, ABI, or business-logic changes
