### PR TITLE
chore(license): adopt Apache-2.0 repo licensing baseline

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Agroasys.Web3layer
+Copyright (c) Agroasys contributors
+
+This product includes software developed by the Agroasys contributors.
+Licensed under the Apache License, Version 2.0.
+See LICENSE for terms and conditions.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,17 @@
+# Third-Party Notices
+
+This repository depends on third-party open-source packages.
+
+## Node.js Dependencies
+- Source of truth: `package-lock.json`
+- Licenses and attributions for transitive dependencies are provided by each dependency package.
+
+To inspect dependency licenses locally, you can use tooling such as:
+
+```bash
+npm ls --all
+npm view <package-name> license
+```
+
+## Container Images
+If you distribute container images, include upstream base image notices in your downstream distribution process.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,7 @@
+# Trademarks
+
+Agroasys name, logos, and brand assets are trademarks (or registered trademarks) of Agroasys and its affiliates.
+
+This repository's Apache-2.0 license grants rights to use the source code, but does **not** grant trademark rights.
+
+You may not use Agroasys trademarks in a way that implies endorsement, sponsorship, or affiliation without prior written permission.

--- a/contracts/LICENSE
+++ b/contracts/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -475,3 +475,7 @@ npm run test:buyer
 npm run test:admin
 npm run test:oracle
 ```
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import { vars } from 'hardhat/config';

--- a/contracts/ignition/modules/AgroasysEscrow.ts
+++ b/contracts/ignition/modules/AgroasysEscrow.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 
 export default buildModule("AgroasysEscrowModule", (m) => {

--- a/contracts/ignition/modules/MockUSDC.ts
+++ b/contracts/ignition/modules/MockUSDC.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 
 export default buildModule("MockUSDCModule", (m) => {

--- a/contracts/scripts/mintUSDC.ts
+++ b/contracts/scripts/mintUSDC.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ethers } from "hardhat";
 
 async function main() {

--- a/contracts/tests/AgroasysEscrow.ts
+++ b/contracts/tests/AgroasysEscrow.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { AgroasysEscrow, MockUSDC } from "../typechain-types";

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,36 @@
+# Licensing Model
+
+## Repository License
+This repository is licensed under Apache License 2.0 (`Apache-2.0`).
+See the root `LICENSE` file.
+
+## Open Source Scope
+All source files in this repository are Apache-2.0 unless explicitly stated otherwise.
+
+This includes protocol/core and service modules, including:
+- `contracts/`
+- `sdk/`
+- `oracle/`
+- `indexer/`
+- `reconciliation/`
+- `ricardian/`
+- `treasury/`
+- `notifications/`
+
+## Commercial Offerings Boundary
+Commercial offerings may be provided outside this repository, including:
+- managed hosting/operations
+- enterprise SLA and support
+- compliance integrations
+- proprietary deployment automation
+- proprietary monitoring dashboards
+- audits/runbooks delivered as a service
+
+These offerings do not change the Apache-2.0 license of this repository.
+
+## Trademark Notice
+Code is Apache-2.0 licensed; trademark rights are reserved.
+See `TRADEMARKS.md`.
+
+## Third-Party Dependencies
+Third-party dependency notices are summarized in `THIRD_PARTY_NOTICES.md`.

--- a/indexer/LICENSE
+++ b/indexer/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -204,3 +204,7 @@ The indexer exposes a GraphQL endpoint for read-only queries. Use it from the ba
 - Full event timelines for audits
 
 > Do not expose write/mutation operations from this indexer.
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/notifications/LICENSE
+++ b/notifications/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/notifications/README.md
+++ b/notifications/README.md
@@ -1,0 +1,7 @@
+# Notifications Library
+
+Shared notifications module used by Web3 services in this monorepo.
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/oracle/LICENSE
+++ b/oracle/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -146,3 +146,7 @@ Correlation keys are emitted when available:
 - `actionKey`
 - `requestId`
 - `txHash`
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/reconciliation/LICENSE
+++ b/reconciliation/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/reconciliation/README.md
+++ b/reconciliation/README.md
@@ -43,3 +43,7 @@ Correlation keys are emitted by reconciliation findings when available:
 
 ## Docker
 See `docs/docker-services.md` and `docs/runbooks/reconciliation.md`.
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/ricardian/LICENSE
+++ b/ricardian/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/ricardian/README.md
+++ b/ricardian/README.md
@@ -54,3 +54,7 @@ Correlation keys are emitted by call path when available:
 
 ## Docker
 See `docs/docker-services.md` and `docs/runbooks/docker-profiles.md` for runtime operations.
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/scripts/add-spdx-headers.mjs
+++ b/scripts/add-spdx-headers.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+
+const roots = process.argv.slice(2);
+const targetRoots = roots.length > 0 ? roots : ['contracts', 'sdk'];
+
+const skipDirNames = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'artifacts',
+  'cache',
+  'coverage',
+  'typechain',
+  'typechain-types',
+  'lib',
+  'out',
+  '.next',
+]);
+
+const jsTsExtensions = new Set(['.js', '.ts', '.tsx']);
+
+const jsTsHeader = '/**\n * SPDX-License-Identifier: Apache-2.0\n */\n';
+const solHeader = '// SPDX-License-Identifier: Apache-2.0\n';
+const spdxRegex = /SPDX-License-Identifier:/;
+
+let changed = 0;
+let skipped = 0;
+let scanned = 0;
+
+async function walk(currentPath) {
+  const stats = await fs.stat(currentPath);
+  if (stats.isDirectory()) {
+    const dirName = path.basename(currentPath);
+    if (skipDirNames.has(dirName)) {
+      return;
+    }
+
+    const entries = await fs.readdir(currentPath);
+    for (const entry of entries) {
+      await walk(path.join(currentPath, entry));
+    }
+    return;
+  }
+
+  await processFile(currentPath);
+}
+
+async function processFile(filePath) {
+  const ext = path.extname(filePath);
+  const isSolidity = ext === '.sol';
+  const isJsTs = jsTsExtensions.has(ext);
+
+  if (!isSolidity && !isJsTs) {
+    return;
+  }
+
+  scanned += 1;
+  const original = await fs.readFile(filePath, 'utf8');
+
+  if (spdxRegex.test(original)) {
+    skipped += 1;
+    return;
+  }
+
+  let updated;
+  if (isSolidity) {
+    updated = `${solHeader}${original}`;
+  } else {
+    if (original.startsWith('#!')) {
+      const newlineIndex = original.indexOf('\n');
+      if (newlineIndex === -1) {
+        updated = `${original}\n${jsTsHeader}`;
+      } else {
+        const shebang = original.slice(0, newlineIndex + 1);
+        const remainder = original.slice(newlineIndex + 1);
+        updated = `${shebang}${jsTsHeader}${remainder}`;
+      }
+    } else {
+      updated = `${jsTsHeader}${original}`;
+    }
+  }
+
+  if (updated !== original) {
+    await fs.writeFile(filePath, updated, 'utf8');
+    changed += 1;
+  }
+}
+
+async function main() {
+  for (const root of targetRoots) {
+    await walk(root);
+  }
+
+  console.log(`SPDX scan complete: scanned=${scanned} changed=${changed} skipped=${skipped}`);
+}
+
+main().catch((error) => {
+  console.error('Failed to add SPDX headers:', error);
+  process.exit(1);
+});

--- a/sdk/LICENSE
+++ b/sdk/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -164,3 +164,7 @@ ADMIN2_PRIVATE_KEY=
 CLIENT_ID=
 WEB3AUTH_NETWORK=SAPPHIRE_DEVNET
 ```
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 require('dotenv').config();
 
 module.exports = {

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ethers, JsonRpcProvider } from 'ethers';
 import { Config } from './config';
 import { ContractError } from './types/errors';

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export interface Config {
     // network
     rpc: string;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 // 3 SDK roles
 export { BuyerSDK } from './modules/buyerSDK';
 export { AdminSDK } from './modules/adminSDK';

--- a/sdk/src/modules/adminSDK.ts
+++ b/sdk/src/modules/adminSDK.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { Client } from '../client';
 import { ethers } from 'ethers';
 import { DisputeStatus, DisputeResult, DisputeProposal } from '../types/dispute';

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { Client } from '../client';
 import { TradeParameters, TradeResult, Trade, TradeStatus } from '../types/trade';
 import { ethers } from 'ethers';

--- a/sdk/src/modules/oracleSDK.ts
+++ b/sdk/src/modules/oracleSDK.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { Client } from '../client';
 import { ethers } from 'ethers';
 import { ContractError, AuthorizationError } from '../types/errors';

--- a/sdk/src/modules/ricardianClient.ts
+++ b/sdk/src/modules/ricardianClient.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { RicardianHashEnvelope, RicardianHashRecord, RicardianHashRequest } from '../types/ricardian';
 
 export interface RicardianClientConfig {

--- a/sdk/src/modules/serviceAuth.ts
+++ b/sdk/src/modules/serviceAuth.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import crypto from 'crypto';
 
 export interface ServiceAuthHeaders {

--- a/sdk/src/types/dispute.ts
+++ b/sdk/src/types/dispute.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export enum DisputeStatus {
     REFUND = 0,
     RESOLVE = 1

--- a/sdk/src/types/errors.ts
+++ b/sdk/src/types/errors.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export class AgroasysSDKError extends Error {
     constructor(
         message: string,

--- a/sdk/src/types/governance.ts
+++ b/sdk/src/types/governance.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export interface OracleUpdateProposal {
     proposalId: string;
     newOracle: string;

--- a/sdk/src/types/oracle.ts
+++ b/sdk/src/types/oracle.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export interface OracleResult {
     txHash: string;
     blockNumber: number;

--- a/sdk/src/types/ricardian.ts
+++ b/sdk/src/types/ricardian.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export interface RicardianHashRequest {
   requestId?: string;
   documentRef: string;

--- a/sdk/src/types/trade.ts
+++ b/sdk/src/types/trade.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 export interface TradeParameters {
     supplier: string;
     totalAmount: bigint;

--- a/sdk/src/utils/signature.ts
+++ b/sdk/src/utils/signature.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ethers } from 'ethers';
 import { TradeParameters } from '../types/trade';
 import { SignatureError } from '../types/errors';

--- a/sdk/src/utils/validation.ts
+++ b/sdk/src/utils/validation.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ethers } from 'ethers';
 import { ValidationError } from '../types/errors';
 import { TradeParameters } from '../types/trade';

--- a/sdk/src/wallet/wallet-provider.ts
+++ b/sdk/src/wallet/wallet-provider.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { Web3Auth, WEB3AUTH_NETWORK } from '@web3auth/modal';
 import { ethers } from 'ethers';
 

--- a/sdk/tests/abiAlignment.test.ts
+++ b/sdk/tests/abiAlignment.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { AgroasysEscrow__factory } from '../src/types/typechain-types/factories/src/AgroasysEscrow__factory';
 
 describe('Escrow ABI alignment', () => {

--- a/sdk/tests/adminSDK.test.ts
+++ b/sdk/tests/adminSDK.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { AdminSDK } from '../src/modules/adminSDK';
 import { DisputeStatus } from '../src/types/dispute';
 import { AuthorizationError, ValidationError } from '../src/types/errors';

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { BuyerSDK } from '../src/modules/buyerSDK';
 import {
   TEST_CONFIG,

--- a/sdk/tests/manualAdminSDK.test.ts
+++ b/sdk/tests/manualAdminSDK.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { AdminSDK } from '../src/modules/adminSDK';
 import { DisputeStatus } from '../src/types/dispute';
 import { TEST_CONFIG, assertRequiredEnv, getAdminSigner, hasRequiredEnv } from './setup';

--- a/sdk/tests/manualBuyerSDK.test.ts
+++ b/sdk/tests/manualBuyerSDK.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { BuyerSDK } from '../src/modules/buyerSDK';
 import {
     TEST_CONFIG,

--- a/sdk/tests/oracleSDK.test.ts
+++ b/sdk/tests/oracleSDK.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { OracleSDK } from '../src/modules/oracleSDK';
 import { TEST_CONFIG, assertRequiredEnv, getOracleSigner, hasRequiredEnv } from './setup';
 

--- a/sdk/tests/ricardianClient.test.ts
+++ b/sdk/tests/ricardianClient.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { RicardianClient } from '../src/modules/ricardianClient';
 
 describe('RicardianClient', () => {

--- a/sdk/tests/serviceAuth.test.ts
+++ b/sdk/tests/serviceAuth.test.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import {
   buildServiceAuthCanonicalString,
   createServiceAuthHeaders,

--- a/sdk/tests/setup.ts
+++ b/sdk/tests/setup.ts
@@ -1,3 +1,6 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ethers } from 'ethers';
 import { Config } from '../src/config';
 import dotenv from 'dotenv';

--- a/treasury/LICENSE
+++ b/treasury/LICENSE
@@ -1,0 +1,2 @@
+This package is licensed under Apache-2.0.
+See the repository root LICENSE file for full terms.

--- a/treasury/README.md
+++ b/treasury/README.md
@@ -46,3 +46,7 @@ Correlation keys are emitted by call path when available:
 
 ## Docker
 See `docs/docker-services.md` and `docs/runbooks/docker-profiles.md` for runtime operations.
+
+## License
+Licensed under Apache-2.0.
+See the repository root `LICENSE` file.


### PR DESCRIPTION
## Summary
Implements the licensing baseline for permissive core adoption with Apache-2.0 repo hygiene.

### Added
- `NOTICE`
- `THIRD_PARTY_NOTICES.md`
- `TRADEMARKS.md`
- `docs/licensing.md`
- package-level `LICENSE` pointer files for all active workspaces
- `notifications/README.md` (license section)
- `scripts/add-spdx-headers.mjs` to insert SPDX headers safely

### Updated
- README license sections across workspace READMEs where missing
- SPDX headers (Apache-2.0) added to scoped code files in `contracts` and `sdk`

## Scope and Boundaries
- docs/license/header/metadata only
- no runtime logic changes
- no contract ABI/economics/token-flow changes

## Verification
Executed locally:
- `npm run lint`
- `HARDHAT_VAR_PRIVATE_KEY=... HARDHAT_VAR_PRIVATE_KEY2=... npm run -w contracts test`
- `npm run -w sdk test`
- `npm run -w oracle test`
- `npm run -w ricardian test`
- `npm run -w treasury test`

All passed.

## Notes
- SPDX rollout is intentionally scoped to `contracts` + `sdk` in this PR for reviewability.
- If needed, the same script can be run in follow-up PRs for the remaining workspaces.
