### PR TITLE
ci(roadmap): auto-sync weighted milestone progress and gate fields

### DIFF
--- a/.github/workflows/roadmap-weighted-progress-sync.yml
+++ b/.github/workflows/roadmap-weighted-progress-sync.yml
@@ -1,0 +1,296 @@
+name: Roadmap Weighted Progress Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 */6 * * *'
+  push:
+    branches:
+      - main
+  issues:
+    types: [opened, edited, reopened, closed, milestoned, demilestoned, labeled, unlabeled]
+
+jobs:
+  sync-weighted-progress:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' || github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      repository-projects: write
+    steps:
+      - name: Detect roadmap app credentials
+        id: app_config
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_id='${{ secrets.ROADMAP_APP_ID }}'
+          app_key='${{ secrets.ROADMAP_APP_PRIVATE_KEY }}'
+          if [[ -n "$app_id" && -n "$app_key" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create roadmap app token (preferred)
+        id: app_token
+        if: ${{ steps.app_config.outputs.enabled == 'true' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ROADMAP_APP_ID }}
+          private-key: ${{ secrets.ROADMAP_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.ROADMAP_APP_INSTALLATION_ID }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Resolve sync auth token
+        id: auth
+        shell: bash
+        run: |
+          set -euo pipefail
+          token='${{ steps.app_token.outputs.token }}'
+          if [[ -z "$token" ]]; then
+            token='${{ github.token }}'
+            source='github-token'
+          else
+            source='github-app'
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+
+      - name: Sync weighted progress
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          export GH_TOKEN='${{ steps.auth.outputs.token }}'
+
+          repo='${{ github.repository }}'
+          project_id='${{ vars.ROADMAP_PROJECT_ID }}'
+
+          percent_field_id='${{ vars.ROADMAP_PERCENT_FIELD_ID }}'
+          status_field_id='${{ vars.ROADMAP_STATUS_FIELD_ID }}'
+          status_option_backlog='${{ vars.ROADMAP_STATUS_OPTION_BACKLOG }}'
+          status_option_in_progress='${{ vars.ROADMAP_STATUS_OPTION_IN_PROGRESS }}'
+          status_option_done='${{ vars.ROADMAP_STATUS_OPTION_DONE }}'
+
+          : "${percent_field_id:=PVTF_lADODMhsg84BPnYZzg9-UNo}"
+          : "${status_field_id:=PVTSSF_lADODMhsg84BPnYZzg9-TYk}"
+          : "${status_option_backlog:=2dd59073}"
+          : "${status_option_in_progress:=b980ce69}"
+          : "${status_option_done:=f573a3e8}"
+
+          gate_for_milestone() {
+            local milestone="$1"
+            case "$milestone" in
+              1) echo 70 ;;
+              2) echo 71 ;;
+              3) echo 72 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          weighted_progress() {
+            local milestone="$1"
+            local gate="$2"
+            gh api "/repos/${repo}/issues?milestone=${milestone}&state=all&per_page=100" --paginate \
+              | jq -s -r --argjson gate "$gate" '
+                  [.[][]
+                    | select(.pull_request | not)
+                    | select(.number != $gate)
+                    | (try (.body | capture("% Complete:\\s*(?<p>[0-9]+)"; "m").p) catch "0" | tonumber)
+                  ]
+                  | if length == 0 then 0 else ((add / length) + 0.5 | floor) end
+                '
+          }
+
+          status_text_for_pct() {
+            local pct="$1"
+            if (( pct <= 0 )); then
+              echo "Backlog (Not Started)"
+            elif (( pct >= 100 )); then
+              echo "Done"
+            else
+              echo "In Progress"
+            fi
+          }
+
+          status_label_for_pct() {
+            local pct="$1"
+            if (( pct <= 0 )); then
+              echo "status:backlog"
+            elif (( pct >= 100 )); then
+              echo "status:done"
+            else
+              echo "status:in-progress"
+            fi
+          }
+
+          status_option_for_pct() {
+            local pct="$1"
+            if (( pct <= 0 )); then
+              echo "$status_option_backlog"
+            elif (( pct >= 100 )); then
+              echo "$status_option_done"
+            else
+              echo "$status_option_in_progress"
+            fi
+          }
+
+          update_gate_issue() {
+            local gate="$1"
+            local pct="$2"
+            local status_text status_label progress_line body updated
+
+            status_text="$(status_text_for_pct "$pct")"
+            status_label="$(status_label_for_pct "$pct")"
+            progress_line="- Progress basis: average of milestone deliverable issue \`% Complete\` values (excluding this gate), auto-synced by \`.github/workflows/roadmap-weighted-progress-sync.yml\`."
+
+            body="$(gh issue view "$gate" --repo "$repo" --json body --jq '.body')"
+            updated="$(STATUS_TEXT="$status_text" PERCENT="$pct" PROGRESS_LINE="$progress_line" printf '%s' "$body" \
+              | perl -0777 -pe 's/^- Status:.*$/- Status: $ENV{STATUS_TEXT}/m; s/^- % Complete:.*$/- % Complete: $ENV{PERCENT}/m; s/^- Progress basis:.*$/$ENV{PROGRESS_LINE}/m;')"
+
+            if ! grep -q '^- Status:' <<<"$updated"; then
+              updated+=$'\n'"- Status: ${status_text}"
+            fi
+            if ! grep -q '^- % Complete:' <<<"$updated"; then
+              updated+=$'\n'"- % Complete: ${pct}"
+            fi
+            if ! grep -q '^- Progress basis:' <<<"$updated"; then
+              updated+=$'\n'"${progress_line}"
+            fi
+
+            if [[ "$updated" != "$body" ]]; then
+              gh issue edit "$gate" --repo "$repo" --body "$updated" >/dev/null
+            fi
+
+            gh issue edit "$gate" --repo "$repo" \
+              --remove-label "status:backlog" \
+              --remove-label "status:in-progress" \
+              --remove-label "status:blocked" \
+              --remove-label "status:done" \
+              --add-label "$status_label" >/dev/null
+          }
+
+          milestone_description() {
+            local milestone="$1"
+            local pct="$2"
+            case "$milestone" in
+              1)
+                printf '%s\n' \
+                  "Core protocol and bridge architecture milestone." \
+                  "Includes Escrow contract hardening, Ricardian PDF/hash service, AssetHub interaction modules, indexer/reconciliation foundations, SDK interfaces, and production readiness tests/deployment runbooks." \
+                  "Target outcome: deterministic on-chain lock/release flow with reproducible off-chain state sync." \
+                  "" \
+                  "Authoritative delivery status (weighted): ${pct}% complete (deliverable issue rollup; source: docs/runbooks/architecture-coverage-matrix.md)." \
+                  "" \
+                  "Note: GitHub milestone bar remains native closed/open ratio and is not configurable."
+                ;;
+              2)
+                printf '%s\n' \
+                  "End-to-end non-custodial settlement milestone." \
+                  "Includes Web3Auth-powered signing UX, unified checkout, oracle-driven release flow, treasury bridge/payout records, and mainnet pilot execution workflows." \
+                  "Target outcome: one buyer lock action drives supplier + treasury split settlement with operational traceability." \
+                  "" \
+                  "Authoritative delivery status (weighted): ${pct}% complete (deliverable issue rollup; source: docs/runbooks/architecture-coverage-matrix.md)." \
+                  "" \
+                  "Note: GitHub milestone bar remains native closed/open ratio and is not configurable."
+                ;;
+              3)
+                printf '%s\n' \
+                  "Production pilot and legal/operational validation milestone." \
+                  "Includes pilot environment/runbooks, KPI reporting (MPC success, settlement latency, gas profile), legal technical support for enforceability memo, and community-facing demo assets." \
+                  "Target outcome: validated real-world lifecycle and publishable pilot evidence." \
+                  "" \
+                  "Authoritative delivery status (weighted): ${pct}% complete (deliverable issue rollup; source: docs/runbooks/architecture-coverage-matrix.md)." \
+                  "" \
+                  "Note: GitHub milestone bar remains native closed/open ratio and is not configurable."
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          project_item_id_for_issue() {
+            local issue_node_id="$1"
+            local cursor=""
+            local item_id=""
+            while :; do
+              local query response has_next end_cursor
+              if [[ -n "$cursor" ]]; then
+                query='query($projectId:ID!,$after:String!){ node(id:$projectId){ ... on ProjectV2 { items(first:100, after:$after){ nodes { id content { ... on Issue { id number } } } pageInfo { hasNextPage endCursor } } } } }'
+                response="$(gh api graphql -f query="$query" -F projectId="$project_id" -F after="$cursor")"
+              else
+                query='query($projectId:ID!){ node(id:$projectId){ ... on ProjectV2 { items(first:100){ nodes { id content { ... on Issue { id number } } } pageInfo { hasNextPage endCursor } } } } }'
+                response="$(gh api graphql -f query="$query" -F projectId="$project_id")"
+              fi
+
+              item_id="$(jq -r --arg issue_id "$issue_node_id" '.data.node.items.nodes[]? | select(.content.id == $issue_id) | .id' <<<"$response" | head -n1)"
+              if [[ -n "$item_id" ]]; then
+                echo "$item_id"
+                return 0
+              fi
+
+              has_next="$(jq -r '.data.node.items.pageInfo.hasNextPage // false' <<<"$response")"
+              end_cursor="$(jq -r '.data.node.items.pageInfo.endCursor // empty' <<<"$response")"
+              if [[ "$has_next" != "true" || -z "$end_cursor" ]]; then
+                return 1
+              fi
+              cursor="$end_cursor"
+            done
+          }
+
+          update_project_gate_fields() {
+            local gate="$1"
+            local pct="$2"
+            local status_option item_id issue_node_id
+
+            if [[ -z "$project_id" ]]; then
+              echo "::warning::ROADMAP_PROJECT_ID is not set; skipping project field sync."
+              return 0
+            fi
+
+            issue_node_id="$(gh issue view "$gate" --repo "$repo" --json id --jq '.id')"
+            if ! item_id="$(project_item_id_for_issue "$issue_node_id")"; then
+              echo "::warning::Could not locate project item for gate issue #${gate}; skipping project field sync."
+              return 0
+            fi
+
+            if ! gh api graphql \
+              -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$value:Float!){ updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{number:$value}}){ projectV2Item { id } } }' \
+              -F projectId="$project_id" \
+              -F itemId="$item_id" \
+              -F fieldId="$percent_field_id" \
+              -F value="$pct" >/dev/null 2>/tmp/roadmap_project_err.log; then
+              echo "::warning::Failed to update project % Complete for gate issue #${gate}."
+              sed -n '1,10p' /tmp/roadmap_project_err.log | sed 's/^/::warning::/g'
+              return 0
+            fi
+
+            status_option="$(status_option_for_pct "$pct")"
+            if ! gh api graphql \
+              -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){ updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optionId}}){ projectV2Item { id } } }' \
+              -F projectId="$project_id" \
+              -F itemId="$item_id" \
+              -F fieldId="$status_field_id" \
+              -F optionId="$status_option" >/dev/null 2>/tmp/roadmap_project_status_err.log; then
+              echo "::warning::Failed to update project Status for gate issue #${gate}."
+              sed -n '1,10p' /tmp/roadmap_project_status_err.log | sed 's/^/::warning::/g'
+            fi
+          }
+
+          for milestone in 1 2 3; do
+            gate="$(gate_for_milestone "$milestone")"
+            pct="$(weighted_progress "$milestone" "$gate")"
+            echo "milestone=${milestone} gateIssue=${gate} weighted=${pct}"
+
+            update_gate_issue "$gate" "$pct"
+            update_project_gate_fields "$gate" "$pct"
+
+            description="$(milestone_description "$milestone" "$pct")"
+            gh api --method PATCH "/repos/${repo}/milestones/${milestone}" -f description="$description" >/dev/null
+          done
+
+          echo "Roadmap weighted progress sync completed."

--- a/docs/runbooks/github-roadmap-governance.md
+++ b/docs/runbooks/github-roadmap-governance.md
@@ -26,6 +26,16 @@ Every PR must:
 The workflow `.github/workflows/pr-roadmap-policy.yml` enforces (1) and (2).
 During temporary rollout without GitHub App auth, project-link enforcement is advisory (warnings only); milestone enforcement remains blocking.
 
+## Weighted Progress (Authoritative)
+- Authoritative milestone delivery status is the weighted rollup, not the native GitHub closed/open ratio.
+- Source of truth for component mapping: `docs/runbooks/architecture-coverage-matrix.md`.
+- Automation workflow: `.github/workflows/roadmap-weighted-progress-sync.yml`.
+- Sync behavior:
+  1. Recompute weighted `% Complete` for Milestones A/B/C from deliverable issues.
+  2. Update milestone gate issues `#70/#71/#72` status label + `% Complete`.
+  3. Update milestone descriptions with the weighted status.
+  4. Update Project v2 gate item fields (`Status`, `% Complete`) when project access is available.
+
 ## Maintainer Steps For Each PR
 1. Assign milestone:
 ```bash
@@ -45,3 +55,14 @@ gh api graphql \
 - Repository variable: `ROADMAP_PROJECT_ID` (Project v2 node id).
 - Workflow permission: `.github/workflows/pr-roadmap-policy.yml` must keep `repository-projects: read`.
 - Roadmap policy auth/runbook: `docs/runbooks/roadmap-policy.md`.
+
+For weighted progress sync (optional overrides; defaults are built in for current project):
+- `ROADMAP_PERCENT_FIELD_ID`
+- `ROADMAP_STATUS_FIELD_ID`
+- `ROADMAP_STATUS_OPTION_BACKLOG`
+- `ROADMAP_STATUS_OPTION_IN_PROGRESS`
+- `ROADMAP_STATUS_OPTION_DONE`
+
+Auth for project field writes:
+- Preferred: `ROADMAP_APP_ID` + `ROADMAP_APP_PRIVATE_KEY` (+ optional `ROADMAP_APP_INSTALLATION_ID`).
+- Fallback: `github.token` (may be unable to write org ProjectV2 fields depending on org visibility/policy).

--- a/docs/runbooks/roadmap-policy.md
+++ b/docs/runbooks/roadmap-policy.md
@@ -12,6 +12,9 @@ Validation order is strict:
 
 If all checks fail, the workflow fails.
 
+Related automation:
+- `.github/workflows/roadmap-weighted-progress-sync.yml` keeps weighted milestone progress in sync with roadmap deliverable issues and updates gate issue/project fields.
+
 ## Temporary rollout mode (current)
 - Milestone check is always enforced (blocking).
 - Project-link check runs in advisory mode when GitHub App auth is not configured.


### PR DESCRIPTION
## Summary
- add `.github/workflows/roadmap-weighted-progress-sync.yml`
- auto-recompute weighted progress for Milestones A/B/C from deliverable issues (`% Complete` rollup)
- auto-sync milestone gate issues `#70/#71/#72` (`Status`, `% Complete`, status label)
- auto-sync milestone descriptions to authoritative weighted status
- auto-sync Project v2 gate item fields (`Status`, `% Complete`) when project access is available
- document automation and required variables in runbooks

## Triggers
- `issues` lifecycle events (open/edit/close/milestone/labels)
- `push` to `main`
- `workflow_dispatch`
- scheduled every 6 hours

## Security / auth
- prefers GitHub App token via `ROADMAP_APP_ID` + `ROADMAP_APP_PRIVATE_KEY`
- falls back to `github.token`
- no checkout or untrusted script execution in this workflow

## Validation
- YAML parse validated
- run-step bash syntax validated
- local dry-run of sync logic executed successfully against live repo metadata

## Notes
- GitHub milestone bars remain native closed/open ratio; authoritative delivery status is weighted and written into milestone descriptions
