### PR TITLE
fix(contracts): make PRIVATE_KEY vars optional for local tests

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -5,6 +5,19 @@ import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import { vars } from 'hardhat/config';
 
+function optionalVar(name: string): string | undefined {
+  try {
+    const v = vars.get(name);
+    return v && v.trim() ? v : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const pk1 = optionalVar("PRIVATE_KEY");
+const pk2 = optionalVar("PRIVATE_KEY2");
+const polkadotAccounts = [pk1, pk2].filter(Boolean) as string[];
+
 const config: HardhatUserConfig = {
   solidity: {
     version:"0.8.28",
@@ -26,16 +39,7 @@ const config: HardhatUserConfig = {
     polkadotTestnet: {
       url: 'https://services.polkadothub-rpc.com/testnet',
       chainId: 420420417,
-      accounts: (() => {
-        const accounts = [vars.get('PRIVATE_KEY')];
-        try {
-          const secondKey = vars.get('PRIVATE_KEY2');
-          if (secondKey) accounts.push(secondKey);
-        } catch {
-          // PRIVATE_KEY2 is optional
-        }
-        return accounts;
-      })(),
+      accounts: polkadotAccounts,
     },
   },
 };


### PR DESCRIPTION
## Summary
- add `optionalVar` helper in `contracts/hardhat.config.ts`
- read `PRIVATE_KEY` and `PRIVATE_KEY2` with optional semantics
- build `polkadotAccounts` from present keys only and use it in `networks.polkadotTestnet.accounts`

## Why
`vars.get()` throws when a variable is missing, which broke `npm -w contracts test` even on local/default network usage.

## Validation
- `npm -w contracts test` (passes with no Hardhat vars set)
- `npx hardhat test --network polkadotTestnet` without vars (fails naturally due to no signer/account)
- `npx hardhat vars set PRIVATE_KEY 0x1111111111111111111111111111111111111111111111111111111111111111`
- `npx hardhat test --network polkadotTestnet` (proceeds using configured account)
- `npx hardhat vars delete PRIVATE_KEY`
- `npm run test --workspaces --if-present` (passes)
