### PR TITLE
fix(deps): override lodash to 4.17.23 (Dependabot #14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,13 +3141,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@nomicfoundation/ignition-core/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@nomicfoundation/ignition-ui": {
       "version": "0.15.13",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.13.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "@nomicfoundation/hardhat-ignition": "0.15.16",
     "@nomicfoundation/hardhat-ignition-ethers": "0.15.17",
     "glob": "11.1.0",
-    "minimatch": "10.2.1"
+    "minimatch": "10.2.1",
+    "lodash": "4.17.23",
+    "@nomicfoundation/ignition-core": {
+      "lodash": "4.17.23"
+    }
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert #14 (moderate, lodash prototype pollution).

- Added root overrides to force `lodash@4.17.23` everywhere.
- Added a targeted nested override for `@nomicfoundation/ignition-core` so its pinned `lodash@4.17.21` resolves to `4.17.23`.
- Regenerated `package-lock.json` via clean `npm install` (no manual lockfile edits).
- Verified no vulnerable lodash versions remain.
- All workspace tests pass.

**Verification output:**
```bash
$ npm ls lodash --all | grep -E "lodash@4\.17\.(21|22)" || echo "No vulnerable lodash found"
No vulnerable lodash found
```
```bash
$ npm ls @nomicfoundation/ignition-core lodash --all | rg '@nomicfoundation/ignition-core|lodash@4\.17\.23'
  │ └─┬ @nomicfoundation/ignition-core@0.15.15
  │   └── lodash@4.17.23 deduped invalid: "4.17.21" from node_modules/@nomicfoundation/ignition-core
```
`npm ls` marks this as `invalid` because the override intentionally supersedes a strict upstream pin; resolved version is `4.17.23`.

**Test results:**
```bash
npm run test --workspaces --if-present
```
Succeeded.
