### PR TITLE
fix(oracle): bound retry backoff and enforce HMAC nonce replay protection

### DIFF
--- a/oracle/src/config.ts
+++ b/oracle/src/config.ts
@@ -39,6 +39,9 @@ export function loadConfig(): OracleConfig {
         const indexerGraphqlTimeoutMinMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MIN_MS', 1000);
         const indexerGraphqlTimeoutMaxMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MAX_MS', 60000);
         const indexerGraphqlRequestTimeoutMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MS', 10000);
+        const retryAttempts = validateEnvNumber('RETRY_ATTEMPTS', 3);
+        const retryDelay = validateEnvNumber('RETRY_DELAY', 1000);
+        const hmacNonceTtlSeconds = validateEnvNumber('HMAC_NONCE_TTL_SECONDS', 600);
 
         if (notificationsEnabled) {
             assert(notificationsWebhookUrl, 'NOTIFICATIONS_WEBHOOK_URL is required when NOTIFICATIONS_ENABLED=true');
@@ -81,8 +84,9 @@ export function loadConfig(): OracleConfig {
             indexerGraphqlRequestTimeoutMs,
             
             // retry
-            retryAttempts: validateEnvNumber('RETRY_ATTEMPTS'),
-            retryDelay: validateEnvNumber('RETRY_DELAY'),
+            retryAttempts,
+            retryDelay,
+            hmacNonceTtlSeconds,
 
             // notifications
             notificationsEnabled,
@@ -91,6 +95,9 @@ export function loadConfig(): OracleConfig {
             notificationsRequestTimeoutMs: validateEnvNumber('NOTIFICATIONS_REQUEST_TIMEOUT_MS', 5000),
         };
 
+        assert(config.retryAttempts >= 0 && config.retryAttempts <= 10, 'RETRY_ATTEMPTS must be between 0 and 10');
+        assert(config.retryDelay >= 100 && config.retryDelay <= 30000, 'RETRY_DELAY must be between 100 and 30000');
+        assert(config.hmacNonceTtlSeconds >= 60 && config.hmacNonceTtlSeconds <= 3600, 'HMAC_NONCE_TTL_SECONDS must be between 60 and 3600');
         assert(config.notificationsCooldownMs >= 0, 'NOTIFICATIONS_COOLDOWN_MS must be >= 0');
         assert(config.notificationsRequestTimeoutMs >= 1000, 'NOTIFICATIONS_REQUEST_TIMEOUT_MS must be >= 1000');
         

--- a/oracle/src/database/schema.sql
+++ b/oracle/src/database/schema.sql
@@ -49,6 +49,17 @@ CREATE INDEX IF NOT EXISTS idx_exhausted_needs_redrive
 ON oracle_triggers(status, updated_at) 
 WHERE status = 'EXHAUSTED_NEEDS_REDRIVE';
 
+CREATE TABLE IF NOT EXISTS oracle_hmac_nonces (
+    api_key VARCHAR(128) NOT NULL,
+    nonce VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (api_key, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oracle_hmac_nonces_expires_at
+ON oracle_hmac_nonces(expires_at);
+
 DO $$ 
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'check_status') THEN

--- a/oracle/src/middleware/middleware.ts
+++ b/oracle/src/middleware/middleware.ts
@@ -1,22 +1,36 @@
 import { Request, Response, NextFunction } from 'express';
 import { config } from '../config';
+import { consumeHmacNonce } from '../database/queries';
 import { Logger } from '../utils/logger';
 import { ErrorResponse } from '../types';
-import { verifyRequestSignature } from '../utils/crypto';
+import { deriveRequestNonce, verifyRequestSignature } from '../utils/crypto';
 
 
 declare global {
     namespace Express {
         interface Request {
+            apiKeyToken?: string;
             hmacSignature?: string;
+            hmacNonce?: string;
         }
     }
 }
 
-export function authMiddleware(req: Request, res: Response<ErrorResponse>, next: NextFunction): void {
-    const authHeader = req.headers.authorization;
-
+function extractBearerToken(authHeader?: string): string | null {
     if (!authHeader) {
+        return null;
+    }
+
+    if (!authHeader.startsWith('Bearer ')) {
+        return null;
+    }
+
+    return authHeader.replace('Bearer ', '');
+}
+
+export function authMiddleware(req: Request, res: Response<ErrorResponse>, next: NextFunction): void {
+    const token = extractBearerToken(req.headers.authorization);
+    if (!token) {
         Logger.warn('Missing authorization header', { ip: req.ip });
         res.status(401).json({
             success: false,
@@ -26,8 +40,6 @@ export function authMiddleware(req: Request, res: Response<ErrorResponse>, next:
         });
         return;
     }
-
-    const token = authHeader.replace('Bearer ', '');
 
     if (token !== config.apiKey) {
         Logger.warn('Invalid API key', { ip: req.ip });
@@ -40,12 +52,15 @@ export function authMiddleware(req: Request, res: Response<ErrorResponse>, next:
         return;
     }
 
+    req.apiKeyToken = token;
     next();
 }
 
-export function hmacMiddleware(req: Request, res: Response<ErrorResponse>, next: NextFunction): void {
+export async function hmacMiddleware(req: Request, res: Response<ErrorResponse>, next: NextFunction): Promise<void> {
     const timestamp = req.headers['x-timestamp'] as string;
     const signature = req.headers['x-signature'] as string;
+    const providedNonce = (req.headers['x-nonce'] as string | undefined)?.trim();
+    const apiKeyToken = req.apiKeyToken || extractBearerToken(req.headers.authorization) || 'oracle-service';
 
     if (!timestamp || !signature) {
         Logger.warn('Missing HMAC headers', { ip: req.ip });
@@ -61,25 +76,73 @@ export function hmacMiddleware(req: Request, res: Response<ErrorResponse>, next:
     try {
         const body = JSON.stringify(req.body);
         verifyRequestSignature(timestamp, body, signature, config.hmacSecret);
+        const nonce = providedNonce || deriveRequestNonce(timestamp, body, signature);
+
+        if (!nonce || nonce.length > 255) {
+            Logger.warn('Invalid nonce format', { ip: req.ip });
+            res.status(401).json({
+                success: false,
+                error: 'Unauthorized',
+                message: 'Invalid X-Nonce header',
+                timestamp: new Date().toISOString(),
+            });
+            return;
+        }
+
+        const nonceAccepted = await consumeHmacNonce(apiKeyToken, nonce, config.hmacNonceTtlSeconds);
+        if (!nonceAccepted) {
+            Logger.warn('Replay detected for nonce', {
+                ip: req.ip,
+                nonce: nonce.substring(0, 16) + '...',
+            });
+            res.status(401).json({
+                success: false,
+                error: 'Unauthorized',
+                message: 'Replay detected for nonce',
+                timestamp: new Date().toISOString(),
+            });
+            return;
+        }
         
         req.hmacSignature = signature;
+        req.hmacNonce = nonce;
         
         Logger.info('HMAC signature verified', { 
             timestamp,
             ip: req.ip,
+            nonce: nonce.substring(0, 16) + '...',
             signature: signature.substring(0, 16) + '...'
         });
         
         next();
-    } catch (error: any) {
+    } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isTimestampOrSignatureError =
+            errorMessage.includes('Request timestamp') ||
+            errorMessage.includes('Invalid HMAC signature');
+
+        if (!isTimestampOrSignatureError) {
+            Logger.error('HMAC nonce persistence failed', {
+                error: errorMessage,
+                ip: req.ip,
+            });
+            res.status(503).json({
+                success: false,
+                error: 'ServiceUnavailable',
+                message: 'Authentication nonce store unavailable',
+                timestamp: new Date().toISOString(),
+            });
+            return;
+        }
+
         Logger.warn('HMAC verification failed', { 
-            error: error.message,
+            error: errorMessage,
             ip: req.ip 
         });
         res.status(401).json({
             success: false,
             error: 'Unauthorized',
-            message: error.message,
+            message: errorMessage,
             timestamp: new Date().toISOString(),
         });
     }

--- a/oracle/src/types/config.ts
+++ b/oracle/src/types/config.ts
@@ -25,6 +25,7 @@ export interface OracleConfig {
     // retry
     retryAttempts: number;
     retryDelay: number;
+    hmacNonceTtlSeconds: number;
 
     // notifications
     notificationsEnabled: boolean;

--- a/oracle/tests/crypto.backoff.test.ts
+++ b/oracle/tests/crypto.backoff.test.ts
@@ -1,0 +1,26 @@
+import { calculateBackoff } from '../src/utils/crypto';
+
+describe('calculateBackoff', () => {
+    const originalRandom = Math.random;
+
+    afterEach(() => {
+        Math.random = originalRandom;
+    });
+
+    test('caps exponential backoff at maxDelayMs', () => {
+        Math.random = () => 0.99;
+
+        const backoff = calculateBackoff(6, 1000, 3000, 500);
+
+        expect(backoff).toBeLessThanOrEqual(3000);
+        expect(backoff).toBeGreaterThanOrEqual(1000);
+    });
+
+    test('returns deterministic floor when jitter budget is zero', () => {
+        Math.random = () => 0.5;
+
+        const backoff = calculateBackoff(1, 3000, 3000, 500);
+
+        expect(backoff).toBe(3000);
+    });
+});

--- a/oracle/tests/hmac-middleware.test.ts
+++ b/oracle/tests/hmac-middleware.test.ts
@@ -1,0 +1,161 @@
+import { NextFunction, Request, Response } from 'express';
+import { authMiddleware, hmacMiddleware } from '../src/middleware/middleware';
+import { generateRequestHash } from '../src/utils/crypto';
+import { consumeHmacNonce } from '../src/database/queries';
+
+jest.mock('../src/config', () => ({
+    config: {
+        apiKey: 'test-api-key',
+        hmacSecret: 'test-hmac-secret',
+        hmacNonceTtlSeconds: 600,
+    },
+}));
+
+jest.mock('../src/database/queries', () => ({
+    consumeHmacNonce: jest.fn(),
+}));
+
+interface MockResponse extends Response {
+    status: jest.Mock;
+    json: jest.Mock;
+}
+
+type MockRequest = Partial<Request> & {
+    headers: Record<string, string>;
+    body: Record<string, unknown>;
+    ip: string;
+    apiKeyToken?: string;
+    hmacSignature?: string;
+    hmacNonce?: string;
+};
+
+function createMockResponse(): MockResponse {
+    const response = {} as MockResponse;
+    response.status = jest.fn().mockReturnValue(response);
+    response.json = jest.fn().mockReturnValue(response);
+    return response;
+}
+
+function createSignedRequest(overrides?: {
+    body?: Record<string, unknown>;
+    timestamp?: string;
+    signature?: string;
+    nonce?: string;
+    authorization?: string;
+}): MockRequest {
+    const body = overrides?.body ?? { tradeId: '1', requestId: 'req-1' };
+    const timestamp = overrides?.timestamp ?? Date.now().toString();
+    const authHeader = overrides?.authorization ?? 'Bearer test-api-key';
+    const bodyText = JSON.stringify(body);
+    const signature =
+        overrides?.signature ?? generateRequestHash(timestamp, bodyText, 'test-hmac-secret');
+
+    const headers: Record<string, string> = {
+        authorization: authHeader,
+        'x-timestamp': timestamp,
+        'x-signature': signature,
+    };
+
+    if (overrides?.nonce !== undefined) {
+        headers['x-nonce'] = overrides.nonce;
+    }
+
+    return {
+        headers,
+        body,
+        ip: '127.0.0.1',
+    };
+}
+
+describe('oracle hmac middleware', () => {
+    const mockConsumeHmacNonce = consumeHmacNonce as jest.MockedFunction<typeof consumeHmacNonce>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('request with nonce succeeds', async () => {
+        mockConsumeHmacNonce.mockResolvedValue(true);
+
+        const req = createSignedRequest({ nonce: 'nonce-1' });
+        const res = createMockResponse();
+        const authNext = jest.fn() as NextFunction;
+        const hmacNext = jest.fn() as NextFunction;
+
+        authMiddleware(req as Request, res, authNext);
+        expect(authNext).toHaveBeenCalledTimes(1);
+
+        await hmacMiddleware(req as Request, res, hmacNext);
+
+        expect(hmacNext).toHaveBeenCalledTimes(1);
+        expect(mockConsumeHmacNonce).toHaveBeenCalledWith('test-api-key', 'nonce-1', 600);
+        expect(req.hmacSignature).toBeDefined();
+        expect(req.hmacNonce).toBe('nonce-1');
+    });
+
+    test('same request replay fails', async () => {
+        mockConsumeHmacNonce.mockResolvedValue(false);
+
+        const req = createSignedRequest({ nonce: 'nonce-replay' });
+        const res = createMockResponse();
+        const authNext = jest.fn() as NextFunction;
+        const hmacNext = jest.fn() as NextFunction;
+
+        authMiddleware(req as Request, res, authNext);
+        expect(authNext).toHaveBeenCalledTimes(1);
+
+        await hmacMiddleware(req as Request, res, hmacNext);
+
+        expect(hmacNext).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Replay detected for nonce' }),
+        );
+    });
+
+    test('old timestamp fails', async () => {
+        mockConsumeHmacNonce.mockResolvedValue(true);
+        const staleTimestamp = (Date.now() - (6 * 60 * 1000)).toString();
+
+        const req = createSignedRequest({ timestamp: staleTimestamp, nonce: 'nonce-old' });
+        const res = createMockResponse();
+        const authNext = jest.fn() as NextFunction;
+        const hmacNext = jest.fn() as NextFunction;
+
+        authMiddleware(req as Request, res, authNext);
+        expect(authNext).toHaveBeenCalledTimes(1);
+
+        await hmacMiddleware(req as Request, res, hmacNext);
+
+        expect(hmacNext).not.toHaveBeenCalled();
+        expect(mockConsumeHmacNonce).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ message: expect.stringContaining('Request timestamp too old') }),
+        );
+    });
+
+    test('invalid signature fails', async () => {
+        mockConsumeHmacNonce.mockResolvedValue(true);
+
+        const req = createSignedRequest({
+            nonce: 'nonce-bad-signature',
+            signature: '0'.repeat(64),
+        });
+        const res = createMockResponse();
+        const authNext = jest.fn() as NextFunction;
+        const hmacNext = jest.fn() as NextFunction;
+
+        authMiddleware(req as Request, res, authNext);
+        expect(authNext).toHaveBeenCalledTimes(1);
+
+        await hmacMiddleware(req as Request, res, hmacNext);
+
+        expect(hmacNext).not.toHaveBeenCalled();
+        expect(mockConsumeHmacNonce).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Invalid HMAC signature' }),
+        );
+    });
+});


### PR DESCRIPTION
## Audit references
- Medium #1: Oracle retry/backoff under-bounded
- Medium #2: Oracle request auth lacks nonce replay consumption

## What changed
1. **Retry/backoff bounds**
- Added safe defaults + bounds validation in `oracle/src/config.ts`:
  - `RETRY_ATTEMPTS` default `3`, bounded `0..10`
  - `RETRY_DELAY` default `1000`, bounded `100..30000`
  - `HMAC_NONCE_TTL_SECONDS` default `600`, bounded `60..3600`
- Added `hmacNonceTtlSeconds` to `OracleConfig` (`oracle/src/types/config.ts`).
- Capped exponential backoff in `oracle/src/utils/crypto.ts` and ensured jitter cannot push beyond cap.
- Updated `TriggerManager` retry path to use capped backoff and improved loop-exit error context.

2. **HMAC nonce replay consumption**
- Added nonce storage table + expiry index in `oracle/src/database/schema.sql` (`oracle_hmac_nonces`).
- Added atomic nonce consume query in `oracle/src/database/queries.ts` (`consumeHmacNonce`).
- Hardened middleware in `oracle/src/middleware/middleware.ts`:
  - consumes nonce per API key + TTL;
  - rejects replay with 401;
  - keeps existing signature and timestamp verification;
  - returns 503 if nonce store is unavailable.

3. **Tests added**
- `oracle/tests/crypto.backoff.test.ts` for capped backoff behavior.
- `oracle/tests/hmac-middleware.test.ts` for:
  - nonce success,
  - replay reject,
  - old timestamp reject,
  - invalid signature reject.

## Why this is safe
- Scope is limited to `oracle` service files plus focused tests.
- No dependency upgrades and no lockfile edits.
- Existing request signature checks remain in place; replay defense is additive.
- Retry semantics are preserved; only bounded for deterministic behavior.

## Evidence (commands + results)
```bash
$ npm -w oracle test --if-present
# exit 0
```
```bash
$ npm run -w contracts compile
# exit 0 (required once after clean checkout to restore typechain for contracts lint)
```
```bash
$ npm run lint --workspaces --if-present
# exit 0
```
```bash
$ npm run typecheck --workspaces --if-present
# exit 0
```
```bash
$ npm run test --workspaces --if-present
# exit 0
```
```bash
$ npm -w oracle run build --if-present
# exit 0
```

## Key file evidence
- Retry bounds: `oracle/src/config.ts:39`, `oracle/src/config.ts:82`
- Config type: `oracle/src/types/config.ts:27`
- Backoff cap: `oracle/src/utils/crypto.ts:79`
- Retry usage: `oracle/src/core/trigger-manager.ts:348`
- Nonce table: `oracle/src/database/schema.sql:52`
- Nonce consume query: `oracle/src/database/queries.ts:100`
- Replay rejection: `oracle/src/middleware/middleware.ts:92`
- Middleware replay tests: `oracle/tests/hmac-middleware.test.ts:96`

## CI parity note
Local environment is Node `v25.3.0`; Hardhat warns this is unsupported (warning observed during contracts compile/tests). CI remains Node 20 in workflow matrix.

## Risk / rollback
- Risk: low-to-medium (auth behavior now rejects replayed nonce and may return 503 if nonce persistence fails).
- Rollback: revert commit `7ee2e8b`.
