### PR TITLE
fix(ci): SHA-pin remaining GitHub Actions references

### DIFF
--- a/.github/workflows/pr-roadmap-policy.yml
+++ b/.github/workflows/pr-roadmap-policy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create roadmap app token (preferred)
         id: app_token
         if: ${{ steps.app_config.outputs.enabled == 'true' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         with:
           app-id: ${{ secrets.ROADMAP_APP_ID }}
           private-key: ${{ secrets.ROADMAP_APP_PRIVATE_KEY }}

--- a/.github/workflows/roadmap-weighted-progress-sync.yml
+++ b/.github/workflows/roadmap-weighted-progress-sync.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create roadmap app token (preferred)
         id: app_token
         if: ${{ steps.app_config.outputs.enabled == 'true' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         with:
           app-id: ${{ secrets.ROADMAP_APP_ID }}
           private-key: ${{ secrets.ROADMAP_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Closes audit finding Medium #10 (GitHub Actions tag pinning) by SHA-pinning remaining unpinned action references repo-wide.

## What changed
- Pinned `actions/create-github-app-token@v2` to commit SHA in:
  - `.github/workflows/pr-roadmap-policy.yml`
  - `.github/workflows/roadmap-weighted-progress-sync.yml`
- Added inline tag comments for maintainability:
  - `# v2`

## Verification
- YAML parse check:
  - `ruby -e "require 'yaml'; YAML.load_file(...)"` for all workflows
- Unpinned-use scan:
  - `rg -nP "^\s*uses:\s*[^@\s]+/[^@\s]+@(?!(?:[0-9a-f]{40})(?:\s|$))" .github/workflows/*.yml`
  - returned no matches

## Scope guardrails
- Workflows only.
- No application code changes.
- No dependency or lockfile changes.

## Risk / rollback
- Risk: low; action resolution hardening only.
- Rollback: revert commit `fed216c`.
