### PR TITLE
docs(runbooks): add production readiness checklist and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ npm run -w treasury build
 - `docs/runbooks/oracle-redrive.md`
 - `docs/runbooks/emergency-disable-unpause.md`
 - `docs/runbooks/docker-profiles.md`
+- `docs/runbooks/production-readiness-checklist.md`
 - `docs/runbooks/github-roadmap-governance.md`
 
 ## **Contributing**
@@ -218,6 +219,7 @@ scripts/staging-e2e-real-gate.sh
 ```
 
 See `docs/docker-services.md`, `docs/runbooks/staging-e2e-release-gate.md`, and `docs/runbooks/staging-e2e-real-release-gate.md` for triage and rollback instructions.
+Production readiness criteria are tracked in `docs/runbooks/production-readiness-checklist.md`.
 
 ## Commit Convention
 

--- a/docs/runbooks/architecture-coverage-matrix.md
+++ b/docs/runbooks/architecture-coverage-matrix.md
@@ -12,6 +12,9 @@ Status legend:
 - `Blocked`: depends on missing in-repo surface or external dependency.
 - `Backlog`: not started.
 
+Production readiness checklist:
+- `docs/runbooks/production-readiness-checklist.md`
+
 ## Component Mapping
 
 | Component | Milestone Target | Status | % Complete | Roadmap Issue(s) | Evidence | Remaining Gap |
@@ -22,7 +25,7 @@ Status legend:
 | Reconciliation drift remediation | A/B | In Progress | 60 | #45 | `reconciliation/src/core/classifier.ts`, `reconciliation/src/core/reconciler.ts`, `reconciliation/src/tests/classifier-address-validation.test.ts`, `scripts/staging-e2e-gate.sh` | Deterministic retry/redrive state machine documentation + tests still incomplete |
 | SDK typed modules + ABI parity | A | Done | 100 | #46, #50 | `sdk/src/modules/`, `sdk/tests/abiAlignment.test.ts`, `sdk/README.md`, PR #12, PR #15, CI run 22197616358 (`ci/sdk` success) | Unified checkout frontend integration remains blocked in #50 |
 | Release gates + profile health determinism | A/B | In Progress | 75 | #47, #55 | `scripts/docker-services.sh`, `scripts/staging-e2e-gate.sh`, `scripts/tests/docker-services-args.test.sh`, PR #28, PR #39, PR #41 (open) | Staging-real gate promotion and full CI enforcement are not complete |
-| Core docs + runbooks + developer guidance | A | In Progress | 60 | #49, #65 | `README.md`, `docs/docker-services.md`, `docs/runbooks/staging-e2e-release-gate.md`, PR #31, PR #34 | Production-readiness checklist remains open in #65 |
+| Core docs + runbooks + developer guidance | A | In Progress | 80 | #49, #65 | `README.md`, `docs/docker-services.md`, `docs/runbooks/staging-e2e-release-gate.md`, `docs/runbooks/production-readiness-checklist.md`, PR #31, PR #34 | Keep checklist and runbook links updated as release controls evolve |
 | Dashboard + unified checkout + settlement tracker | B | Blocked | 25 | #50 | SDK support exists (`sdk/src/modules/`, `sdk/README.md`), Web3Auth dependency present | No in-repo dashboard surface; end-to-end checkout UX not implemented here |
 | Web3Auth signing/session architecture | B | In Progress | 50 | #50 | `sdk/README.md` Web3Auth section, `@web3auth/modal` in `sdk/package.json`, PR #15 | Full frontend/session lifecycle and operational runbook still missing |
 | Oracle trigger + approval + retry controls | B/C | In Progress | 70 | #51, #56, #61 | `oracle/src/core/trigger-manager.ts`, `oracle/src/worker/confirmation-worker.ts`, `oracle/src/api/routes.ts`, `docs/runbooks/oracle-redrive.md`, PR #14 | Pilot manual-approval mode and complete SOP hardening still open |

--- a/docs/runbooks/docker-profiles.md
+++ b/docs/runbooks/docker-profiles.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Run deterministic build/start/health/log actions for each supported compose profile.
+Production launch criteria are defined in `docs/runbooks/production-readiness-checklist.md`.
 
 ## Profiles
 - `local-dev`: lightweight mock indexer responder (`indexer`) for fast iteration.
@@ -56,3 +57,6 @@ scripts/docker-services.sh down <profile>
 ```
 2. Restore last known-good env values.
 3. Re-run profile startup and health commands.
+
+## Related
+- Production readiness checklist: `docs/runbooks/production-readiness-checklist.md`

--- a/docs/runbooks/production-readiness-checklist.md
+++ b/docs/runbooks/production-readiness-checklist.md
@@ -1,0 +1,102 @@
+# Production Readiness Checklist
+
+Purpose:
+- Define deterministic go-live criteria for Agroasys.Web3layer production deployments.
+- Provide a single source of truth for security, fee behavior, operations, and rollback readiness.
+
+## 1) Security Prerequisites
+
+### Secrets management
+- No plaintext secrets in repository files, Docker images, CI logs, or artifacts.
+- Runtime secrets must be injected through environment management and rotated on schedule.
+- `.env*` templates must contain placeholders only.
+
+### Access control
+- Least privilege required for CI tokens, cloud credentials, database users, and service accounts.
+- Protected branches require mandatory checks and peer review.
+- Admin access to production infra/services is restricted and auditable.
+
+### Dependency vulnerability posture
+- Block release on known High/Critical production dependency vulnerabilities without an approved exception.
+- Moderate/Low vulnerabilities require documented risk acceptance or remediation plan.
+- `npm audit fix --force` is disallowed for release preparation.
+
+### Audit and remediation gates
+- Security findings must map to tracked issues with owner, severity, and due date.
+- Release gate includes explicit verification that blocker findings are resolved or waived by policy owner.
+
+### Signing key custody and rotation
+- Private key access is role-limited and logged.
+- Emergency rotation procedure is documented and tested in non-production first.
+- Shared test/dev keys are never reused for production environments.
+
+## 2) Gas and Fee Expectations
+
+### Baseline transaction expectations
+- Core contract actions (`createTrade`, release/dispute milestones) have baseline gas observations documented from latest test/staging runs.
+- Changes that materially increase gas costs require release-note justification and approval.
+
+### Fee anomaly alerting
+- Alert if observed fees exceed baseline thresholds for sustained periods.
+- Alert if RPC fee estimation diverges significantly from executed fee outcomes.
+
+### Fallback fee policy
+- If fee thresholds are exceeded, operators must pause non-critical execution paths and run fallback review.
+- Fallback decision outcomes must be logged: continue, delay, or rollback.
+
+### RPC reliability assumptions
+- Production requires redundant RPC endpoints or a documented failover strategy.
+- Release readiness checks include RPC health, latency, and timeout behavior.
+
+## 3) Operational Prerequisites
+
+### Monitoring requirements
+- Required visibility: service health endpoints, Postgres/Redis health, indexer lag, reconciliation drift summary, and RPC latency/errors.
+- Dashboards must support quick triage for oracle, reconciliation, treasury, and indexer paths.
+
+### Alerting and escalation
+- Alerts route to on-call channel with severity mapping and primary/secondary responders.
+- Escalation path includes defined ownership for app, data, and infrastructure incidents.
+
+### Backup policy
+- Postgres backups are scheduled, retained by policy, and restoration is periodically tested.
+- Ricardian/legal document storage backup and restore path is documented and tested.
+
+### Logging and correlation
+- Structured logs include correlation identifiers (request ID, trade ID, tx hash where applicable).
+- Logs must redact secrets and sensitive key material.
+- Retention windows must satisfy operational and audit requirements.
+
+### Operational SLOs
+- Availability SLO is defined per critical service.
+- Latency/error budget expectations are defined for API and reconciliation/oracle loops.
+- Breach handling procedure (stabilize, mitigate, retrospective) is documented.
+
+## 4) Rollback Gates
+
+### Rollback triggers
+- Trigger rollback on deterministic release-gate failure, critical runtime regressions, data integrity anomalies, or unresolved security blockers.
+
+### Rollback procedure
+- Stop affected profiles/services.
+- Revert to last known-good deploy artifact and configuration.
+- Re-run health and gate checks before reopening traffic.
+
+### Data rollback policy
+- Schema/database changes require reversible migration strategy or forward-fix plan approved before release.
+- Data reconciliation steps must be documented for partial-failure scenarios.
+
+### Safe mode and circuit breakers
+- Emergency controls (pause paths / trigger disable modes) must be verified and documented before release.
+- Operators must know exact commands/runbooks to place system in safe mode.
+
+## Verification Before Marking Ready
+- Node parity checks run under Node 20.
+- Workspace validation passes: lint, typecheck, and tests.
+- Profile checks pass for local and staging release-gate paths.
+- Required runbooks are linked and up to date:
+  - `docs/runbooks/docker-profiles.md`
+  - `docs/runbooks/staging-e2e-release-gate.md`
+  - `docs/runbooks/staging-e2e-real-release-gate.md`
+  - `docs/runbooks/oracle-redrive.md`
+  - `docs/incidents/first-15-minutes-checklist.md`


### PR DESCRIPTION
## Summary
- Add a new production launch source-of-truth checklist at:
  - `docs/runbooks/production-readiness-checklist.md`
- Integrate checklist links into:
  - `README.md`
  - `docs/runbooks/docker-profiles.md`
  - `docs/runbooks/architecture-coverage-matrix.md`

## Issue Mapping
- Closes #65
- Follow-up closure: #49 will be closed after #65 merges (checklist linked and discoverable from README/runbooks).

## #65 Acceptance Criteria -> Evidence
- Security prerequisites defined:
  - See section **1) Security Prerequisites** in `docs/runbooks/production-readiness-checklist.md`.
- Gas/fee expectations defined:
  - See section **2) Gas and Fee Expectations** in `docs/runbooks/production-readiness-checklist.md`.
- Operational prerequisites defined:
  - See section **3) Operational Prerequisites** in `docs/runbooks/production-readiness-checklist.md`.
- Rollback gates defined:
  - See section **4) Rollback Gates** in `docs/runbooks/production-readiness-checklist.md`.
- Link integration completed:
  - `README.md` (Operational Runbooks + Docker Profiles section)
  - `docs/runbooks/docker-profiles.md` (Purpose + Related)
  - `docs/runbooks/architecture-coverage-matrix.md` (top-level checklist reference + core docs evidence row)

## Validation
Node parity:
- `nvm use 20` -> `v20.20.0`
- `npm -v` -> `10.8.2`

Commands run:
- `npm ci`
- `npm run lint --workspaces --if-present`
- `npm run typecheck --workspaces --if-present`
- `npm run test --workspaces --if-present`

Key outputs:
- Workspace lint completed without failures.
- Typecheck completed without failures.
- Tests passed (including contracts/oracle/reconciliation/ricardian/treasury suites).

## Rollback Plan
- Revert this PR commit to remove checklist and link references:
  - `git revert 5471bda`
- No schema, runtime, dependency, or lockfile changes are included.

## Local Evidence Logs
- /tmp/65-49-20260221-212546-rerun/node-parity.log
- /tmp/65-49-20260221-212546-rerun/npm-ci.log
- /tmp/65-49-20260221-212546-rerun/lint.log
- /tmp/65-49-20260221-212546-rerun/typecheck.log
- /tmp/65-49-20260221-212546-rerun/test.log
