### PR TITLE
fix(deps): resolve bn.js infinite-loop advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,11 @@
         "notifications",
         "ricardian",
         "treasury"
-      ]
+      ],
+      "engines": {
+        "node": ">=20 <23",
+        "npm": ">=10 <12"
+      }
     },
     "contracts": {
       "version": "1.0.0",
@@ -9616,12 +9620,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -10199,13 +10197,6 @@
         "node": ">=6.5.0",
         "npm": ">=3"
       }
-    },
-    "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
@@ -14617,13 +14608,6 @@
         "npm": ">=3"
       }
     },
-    "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/obj-case": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
@@ -17353,12 +17337,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/tiny-secp256k1/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "security:deps": "node scripts/security-deps-report.mjs"
   },
   "overrides": {
+    "bn.js": "5.2.3",
     "hardhat": "2.28.6",
     "@nomicfoundation/hardhat-ethers": "3.1.3",
     "@nomicfoundation/hardhat-verify": "2.1.3",


### PR DESCRIPTION
## Summary
This PR remediates Dependabot alert #21 (bn.js infinite loop / GHSA-378v-28hj-76wf) by pinning bn.js to 5.2.3 across the dependency tree.

## Changes
- Added root override in package.json:
  - "bn.js": "5.2.3"
- Regenerated package-lock.json via npm so transitive bn.js 4.x copies are removed.

## Evidence
Before:
- npm audit reported bn.js vulnerable (range: <5.2.3) via:
  - node_modules/elliptic/node_modules/bn.js
  - node_modules/ethjs-unit/node_modules/bn.js
  - node_modules/number-to-bn/node_modules/bn.js
  - node_modules/tiny-secp256k1/node_modules/bn.js

After:
- npm ls bn.js --all shows only bn.js@5.2.3 in tree.
- npm audit --json confirms bn.js present: false.

## Validation (Node 20)
- nvm use 20
- npm ci
- npm run lint --workspaces --if-present
- npm run typecheck --workspaces --if-present
- npm run test --workspaces --if-present

All passed locally.

## Scope
Only dependency resolution files were changed:
- package.json
- package-lock.json
