### PR TITLE
docs(roadmap): align architecture matrix scope and roadmap issue mapping

### DIFF
--- a/docs/runbooks/architecture-coverage-matrix.md
+++ b/docs/runbooks/architecture-coverage-matrix.md
@@ -1,16 +1,18 @@
 # Architecture Coverage Matrix
 
-Snapshot date: 2026-02-22
+Snapshot date: 2026-02-26
 
 Scope:
 - Source of truth is repository code, merged/open PRs, and roadmap issues.
-- KYC/KYB/AML vendor systems are intentionally excluded from this matrix.
+- Third-party KYC/KYB/AML vendor internals are excluded, but integration boundaries are tracked.
+- External pilot execution deliverables are excluded from repo completion scoring: legal consultation/memo delivery, live KPI report execution, and live community demo production.
 
 Status legend:
 - `Done`: acceptance criteria implemented and evidenced in repo/CI.
 - `In Progress`: partial implementation with measurable gaps.
 - `Blocked`: depends on missing in-repo surface or external dependency.
 - `Backlog`: not started.
+- `Out of Scope`: intentionally tracked but excluded from repo completion scoring.
 
 Production readiness checklist:
 - `docs/runbooks/production-readiness-checklist.md`
@@ -20,30 +22,34 @@ Production readiness checklist:
 | Component | Milestone Target | Status | % Complete | Roadmap Issue(s) | Evidence | Remaining Gap |
 | --- | --- | --- | --- | --- | --- | --- |
 | Escrow lifecycle + split-settlement safety | A | Done | 100 | #42, #54 | `contracts/tests/AgroasysEscrow.ts`, `contracts/foundry/test/AgroasysEscrowFuzz.t.sol`, PR #8, PR #13, CI run 22197616358 (`ci/contracts` success) | None for milestone-A baseline |
-| Ricardian PDF/hash service | A | In Progress | 75 | #43 | `ricardian/src/utils/hash.ts`, `ricardian/src/utils/canonicalize.ts`, `ricardian/tests/canonicalize.test.ts`, `sdk/src/modules/ricardianClient.ts`, PR #21 | Production storage/retrieval failure-handling documentation still incomplete |
+| Ricardian PDF/hash service | A | In Progress | 75 | #43, #132 | `ricardian/src/utils/hash.ts`, `ricardian/src/utils/canonicalize.ts`, `ricardian/tests/canonicalize.test.ts`, `sdk/src/modules/ricardianClient.ts`, PR #21 | DocumentStore retrieval resiliency and legal-evidence availability hardening still pending |
 | Indexer pipeline + GraphQL schema correctness | A/B | In Progress | 50 | #44 | `indexer/src/main.ts`, `indexer/schema.graphql`, `indexer/db/migrations/1771180205323-Data.js`, PR #23 | `extrinsic_hash` is not a first-class field; tx/extrinsic semantics still conflated in storage/API |
 | Reconciliation drift remediation | A/B | In Progress | 60 | #45 | `reconciliation/src/core/classifier.ts`, `reconciliation/src/core/reconciler.ts`, `reconciliation/src/tests/classifier-address-validation.test.ts`, `scripts/staging-e2e-gate.sh` | Deterministic retry/redrive state machine documentation + tests still incomplete |
 | SDK typed modules + ABI parity | A | Done | 100 | #46, #50 | `sdk/src/modules/`, `sdk/tests/abiAlignment.test.ts`, `sdk/README.md`, PR #12, PR #15, CI run 22197616358 (`ci/sdk` success) | Unified checkout frontend integration remains blocked in #50 |
 | Release gates + profile health determinism | A/B | In Progress | 75 | #47, #55 | `scripts/docker-services.sh`, `scripts/staging-e2e-gate.sh`, `scripts/tests/docker-services-args.test.sh`, PR #28, PR #39, PR #41 (open) | Staging-real gate promotion and full CI enforcement are not complete |
 | Core docs + runbooks + developer guidance | A | In Progress | 80 | #49, #65 | `README.md`, `docs/docker-services.md`, `docs/runbooks/staging-e2e-release-gate.md`, `docs/runbooks/production-readiness-checklist.md`, PR #31, PR #34 | Keep checklist and runbook links updated as release controls evolve |
-| Dashboard + unified checkout + settlement tracker | B | Blocked | 25 | #50 | SDK support exists (`sdk/src/modules/`, `sdk/README.md`), Web3Auth dependency present | No in-repo dashboard surface; end-to-end checkout UX not implemented here |
-| Web3Auth signing/session architecture | B | In Progress | 50 | #50 | `sdk/README.md` Web3Auth section, `@web3auth/modal` in `sdk/package.json`, PR #15 | Full frontend/session lifecycle and operational runbook still missing |
+| Dashboard + unified checkout + settlement tracker | B | Blocked | 25 | #50, #129 | SDK support exists (`sdk/src/modules/`, `sdk/README.md`), Web3Auth dependency present | No in-repo dashboard surface; cross-repo dependency governance still required for closure |
+| Identity service + user profile persistence | B | Backlog | 0 | #122 | `shared-auth/`, `sdk/`, architecture reference in `web3layer.mmd` | No dedicated Auth Service and User Profile persistence module is implemented yet |
+| Web3Auth signing/session architecture | B | In Progress | 50 | #50, #122, #105 | `sdk/README.md` Web3Auth section, `@web3auth/modal` in `sdk/package.json`, PR #15 | Full frontend/session lifecycle and operational runbook still missing |
 | Oracle trigger + approval + retry controls | B/C | In Progress | 70 | #51, #56, #61 | `oracle/src/core/trigger-manager.ts`, `oracle/src/worker/confirmation-worker.ts`, `oracle/src/api/routes.ts`, `docs/runbooks/oracle-redrive.md`, PR #14 | Pilot manual-approval mode and complete SOP hardening still open |
-| Treasury payout queue + audit traceability | B/C | Blocked | 40 | #52, #67 | `treasury/src/database/schema.sql`, `treasury/src/database/queries.ts`, `treasury/src/core/payout.ts`, PR #22 | Processing/audit workflow requires missing operator UI/workflow integration |
+| Treasury payout queue + audit traceability | B/C | Blocked | 40 | #52, #67, #126, #127 | `treasury/src/database/schema.sql`, `treasury/src/database/queries.ts`, `treasury/src/core/payout.ts`, PR #22 | Processing/audit workflow requires missing operator UI/workflow integration and bank/fiat boundary finalization |
 | Reconciliation reports (on-chain ↔ fiat evidence) | B | Backlog | 10 | #53 | Reconciliation run/drift persistence exists in `reconciliation/src/database/queries.ts` | No deterministic report generator + review cadence artifacts |
 | AssetHub assets + USDC fee conversion validation | A | Backlog | 0 | #63 | Conceptual references in `README.md` only | No automated validation flow across local-dev/staging for fee-in-USDC path |
 | PolkaVM deployment verification + smoke checks | A | Backlog | 0 | #64 | CI exists but no deployment-verification artifact workflow | No deterministic deploy verification bundle and smoke automation |
 | Mainnet pilot execution evidence | B | Backlog | 0 | #66 | None in repo yet | No transaction evidence package or pilot proof artifacts |
 | Hybrid split walkthrough + treasury-to-fiat SOP | B | Done | 100 | #67 | `docs/runbooks/hybrid-split-walkthrough.md`, `docs/runbooks/treasury-to-fiat-sop.md`, `README.md` runbook links | None for issue-#67 scope |
-| Pilot environment + legal evidence + KPI/demo/case study package | C | In Progress | 55 | #57, #58, #59, #60, #68, #69 | `docs/runbooks/pilot-environment-onboarding.md`, `docs/runbooks/staging-e2e-real-release-gate.md`, `docs/runbooks/pilot-kpi-report-template.md`, `docs/runbooks/demo/community-demo-checklist.md`, `docs/runbooks/demo/community-demo-script.md`, `docs/runbooks/non-custodial-pilot-user-guide.md`, `docs/runbooks/legal-evidence-package-template.md` | Remaining pending artifacts are #69 (lessons-learned case study) |
-| Infrastructure controls (CI/CD, roadmap governance, release controls) | A/B/C | In Progress | 70 | #70, #71, #72, #73 | `.github/workflows/ci.yml`, `.github/workflows/pr-roadmap-policy.yml`, `docs/runbooks/github-roadmap-governance.md`, PR #62, PR #76 | Coverage matrix + gate linkage is now established but milestones not yet fully satisfied |
-| Notifications service behavior + operational controls | A/B | In Progress | 50 | #77 | `notifications/src/`, `notifications/tests/`, PR #20 | Needs dedicated roadmap completion criteria and runbook hardening |
-| API gateway orchestration + error handoff boundary | A/B | Backlog | 0 | #78 | Architectural requirement documented in `web3layer.mmd`; no dedicated in-repo service boundary document | Define boundary contract, ownership, and failure handoff rules |
+| Pilot documentation package (env + legal/KPI/demo templates + user guide) | C | Done | 100 | #57, #58, #59, #60, #68 | `docs/runbooks/pilot-environment-onboarding.md`, `docs/runbooks/staging-e2e-real-release-gate.md`, `docs/runbooks/pilot-kpi-report-template.md`, `docs/runbooks/demo/community-demo-checklist.md`, `docs/runbooks/demo/community-demo-script.md`, `docs/runbooks/non-custodial-pilot-user-guide.md`, `docs/runbooks/legal-evidence-package-template.md` | No repo-side gap for documentation scope |
+| Pilot lessons-learned case study (post-live execution) | Post-C | Out of Scope | 0 | #69 | None in repo yet | Deferred until real pilot execution evidence exists |
+| Infrastructure controls (CI/CD, roadmap governance, release controls) | A/B/C | In Progress | 70 | #70, #71, #72, #73, #100, #104, #125, #131 | `.github/workflows/ci.yml`, `.github/workflows/pr-roadmap-policy.yml`, `docs/runbooks/github-roadmap-governance.md`, PR #62, PR #76 | Coverage matrix + gate linkage exists, but monitoring baseline, dependency major-upgrade backlog, and consistency enforcement are still open |
+| Primary DB operations + recovery evidence | C | Backlog | 0 | #133 | `postgres/init/10-service-databases.sql`, `docs/runbooks/production-readiness-checklist.md` | Backup/restore, migration safety, and recovery evidence are not yet hardened as roadmap deliverables |
+| Notifications service behavior + operational controls | A/B | In Progress | 50 | #77, #130 | `notifications/src/`, `notifications/tests/`, PR #20 | Runtime profile integration and release-gate notification evidence are still open |
+| API gateway orchestration + error handoff boundary | A/B | Backlog | 0 | #78, #123, #124 | Architectural requirement documented in `web3layer.mmd`; no dedicated in-repo service boundary document | Define and implement runtime gateway and error-handler control plane |
+| Compliance boundary (KYB/KYT/Sanctions integration) | C | Backlog | 0 | #128 | Architecture reference in `web3layer.mmd`; matrix scope policy | External-provider boundary, allow/deny semantics, and fallback governance are not yet formalized |
 
 ## Milestone Rollup (evidence-based)
 
-- Milestone A: 56% (issue rollup from A deliverables excluding gate)
-- Milestone B: 41% (issue rollup from B deliverables excluding gate)
+- Milestone A: 52% (issue rollup from A deliverables excluding gate)
+- Milestone B: 23% (issue rollup from B deliverables excluding gate)
 - Milestone C: 0% (issue rollup from C deliverables excluding gate)
 
 Computation method:
@@ -56,9 +62,9 @@ Computation method:
 - Gate `#70` (Milestone A) maps to:
   Escrow lifecycle + split-settlement safety; Ricardian PDF/hash service; Indexer pipeline + GraphQL schema correctness; Reconciliation drift remediation; SDK typed modules + ABI parity; Release gates + profile health determinism; Core docs + runbooks + developer guidance; AssetHub assets + USDC fee conversion validation; PolkaVM deployment verification + smoke checks.
 - Gate `#71` (Milestone B) maps to:
-  Dashboard + unified checkout + settlement tracker; Web3Auth signing/session architecture; Oracle trigger + approval + retry controls; Treasury payout queue + audit traceability; Reconciliation reports; Mainnet pilot execution evidence; Hybrid split walkthrough + treasury-to-fiat SOP.
+  Dashboard + unified checkout + settlement tracker; Identity service + user profile persistence; Web3Auth signing/session architecture; Oracle trigger + approval + retry controls; Treasury payout queue + audit traceability; Reconciliation reports; Mainnet pilot execution evidence; Hybrid split walkthrough + treasury-to-fiat SOP; API gateway orchestration + error handoff boundary; Notifications service behavior + operational controls.
 - Gate `#72` (Milestone C) maps to:
-  Pilot environment + legal evidence + KPI/demo/case study package; Oracle trigger + approval + retry controls (pilot-safe mode); Treasury payout queue + audit traceability (pilot operations); Infrastructure controls (CI/CD, roadmap governance, release controls).
+  Pilot documentation package (env + legal/KPI/demo templates + user guide); Oracle trigger + approval + retry controls (pilot-safe mode); Treasury payout queue + audit traceability (pilot operations); Infrastructure controls (CI/CD, roadmap governance, release controls); Primary DB operations + recovery evidence; Compliance boundary (KYB/KYT/Sanctions integration).
 
 ## Maintenance Rule
 


### PR DESCRIPTION
## What this changes
- Marks these as out-of-repo completion scope in the architecture matrix:
  - legal consultation/memo delivery
  - real KPI report execution
  - actual community demo production
- Splits pilot docs package from post-live execution outputs.
- Tracks #69 as deferred/post-live in the matrix.
- Adds missing roadmap issues #100 and #104 to matrix mapping.
- Updates Gate #72 mapping to the docs-only pilot package row.

## Why
- Keeps completion scoring aligned to repository-deliverable scope.
- Ensures every open roadmap issue with milestone/triage assignment is represented in the matrix table.

## Verification
- Matrix issue coverage check:
  - open roadmap issues (Milestone A/B/C + Needs Triage) minus matrix issue refs = empty set
- Confirmed project item sync for #69 roadmap milestone field is set to `Needs Triage`.

## Related
- #72
- #73
- #69
- #100
- #104
