### PR TITLE
chore(security): patch Dependabot high alerts in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16854,15 +16854,15 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -19779,13 +19779,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@nomicfoundation/hardhat-ignition": "0.15.16",
     "@nomicfoundation/hardhat-ignition-ethers": "0.15.17",
     "glob": "11.1.0",
-    "minimatch": "10.2.1",
+    "minimatch": "10.2.3",
+    "serialize-javascript": "7.0.3",
     "lodash": "4.17.23",
     "@nomicfoundation/ignition-core": {
       "lodash": "4.17.23"


### PR DESCRIPTION
## Summary
- bump root override minimatch from 10.2.1 to 10.2.3
- add root override serialize-javascript at 7.0.3
- refresh package-lock.json transitive resolutions

## Why
Fixes the three open Dependabot high-severity alerts on package-lock.json:
- minimatch ReDoS advisories (2 alerts)
- serialize-javascript RCE advisory (1 alert)

## Validation
- npm run -w contracts compile
- npm -w contracts test -- tests/AgroasysEscrow.ts (63 passing)
- npm audit --json no longer reports minimatch or serialize-javascript advisories

## Risk control
- minimal-change approach: only package.json overrides and package-lock.json were touched
- no contract source/runtime logic changes
