### PR TITLE
fix(foundry): align pull-over-push test invariants and runbook

### DIFF
--- a/contracts/foundry/foundry.toml
+++ b/contracts/foundry/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 libs = ["lib"]
 
 remappings = [
+  "forge-std/=lib/forge-std/src/",
   "@openzeppelin/=lib/openzeppelin-contracts/",
 ]
 

--- a/contracts/foundry/test/AgroasysEscrowFuzz.t.sol
+++ b/contracts/foundry/test/AgroasysEscrowFuzz.t.sol
@@ -148,6 +148,8 @@ contract FuzzTest is Test {
         uint256 supplierBeforeReleaseFundsStage1Balance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeReleaseFundsStage1Balance = usdc.balanceOf(treasury);
         uint256 escrowBeforeReleaseFundsStage1Balance = usdc.balanceOf(address(escrow));
+        uint256 supplierBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(supplier);
+        uint256 treasuryBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(treasury);
 
         vm.prank(oracle);
         escrow.releaseFundsStage1(tradeId);
@@ -157,9 +159,11 @@ contract FuzzTest is Test {
         assertEq(uint8(_status2), uint8(AgroasysEscrow.TradeStatus.IN_TRANSIT), "status should be IN_TRANSIT");
         // check that balances are correct
         assertEq(usdc.balanceOf(buyer),buyerBeforeReleaseFundsStage1Balance,"buyer balance mismatch");
-        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance+tranche1,"supplier balance mismatch");
-        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance+fees+logistics,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance-tranche1-logistics-fees,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance,"supplier balance mismatch");
+        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance,"treasury balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(supplier),supplierBeforeReleaseFundsStage1Claimable + tranche1,"supplier claimableUsdc mismatch");
+        assertEq(escrow.claimableUsdc(treasury),treasuryBeforeReleaseFundsStage1Claimable + fees + logistics,"treasury claimableUsdc mismatch");
 
 
         // ######################## 3) CONFIRM ARRIVAL #########################################
@@ -187,6 +191,7 @@ contract FuzzTest is Test {
         uint256 supplierBeforeReleaseFundsStage2Balance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeReleaseFundsStage2Balance = usdc.balanceOf(treasury);
         uint256 escrowBeforeReleaseFundsStage2Balance = usdc.balanceOf(address(escrow));
+        uint256 supplierBeforeReleaseFundsStage2Claimable = escrow.claimableUsdc(supplier);
 
         // increase time by 24 hours
         vm.warp(block.timestamp + 24 hours + 1);
@@ -199,9 +204,10 @@ contract FuzzTest is Test {
         assertEq(uint8(_status4), uint8(AgroasysEscrow.TradeStatus.CLOSED), "status should be CLOSED");
         // check that balances are correct
         assertEq(usdc.balanceOf(buyer),buyerBeforeReleaseFundsStage2Balance,"buyer balance mismatch");
-        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage2Balance+tranche2,"supplier balance mismatch");
+        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage2Balance,"supplier balance mismatch");
         assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage2Balance,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage2Balance-tranche2,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage2Balance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(supplier),supplierBeforeReleaseFundsStage2Claimable + tranche2,"supplier claimableUsdc mismatch");
     }
 
 
@@ -249,6 +255,8 @@ contract FuzzTest is Test {
         uint256 supplierBeforeReleaseFundsStage1Balance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeReleaseFundsStage1Balance = usdc.balanceOf(treasury);
         uint256 escrowBeforeReleaseFundsStage1Balance = usdc.balanceOf(address(escrow));
+        uint256 supplierBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(supplier);
+        uint256 treasuryBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(treasury);
 
         vm.prank(oracle);
         escrow.releaseFundsStage1(tradeId);
@@ -258,9 +266,11 @@ contract FuzzTest is Test {
         assertEq(uint8(_status2), uint8(AgroasysEscrow.TradeStatus.IN_TRANSIT), "status should be IN_TRANSIT");
         // check that balances are correct
         assertEq(usdc.balanceOf(buyer),buyerBeforeReleaseFundsStage1Balance,"buyer balance mismatch");
-        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance+tranche1,"supplier balance mismatch");
-        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance+logistics+fees,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance-tranche1-logistics-fees,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance,"supplier balance mismatch");
+        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance,"treasury balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(supplier),supplierBeforeReleaseFundsStage1Claimable + tranche1,"supplier claimableUsdc mismatch");
+        assertEq(escrow.claimableUsdc(treasury),treasuryBeforeReleaseFundsStage1Claimable + logistics + fees,"treasury claimableUsdc mismatch");
 
 
         // ######################## 3) CONFIRM ARRIVAL #########################################
@@ -328,6 +338,7 @@ contract FuzzTest is Test {
         uint256 supplierBeforeApproveSolutionBalance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeApproveSolutionBalance = usdc.balanceOf(treasury);
         uint256 escrowBeforeApproveSolutionBalance = usdc.balanceOf(address(escrow));
+        uint256 supplierBeforeApproveSolutionClaimable = escrow.claimableUsdc(supplier);
 
         vm.prank(admin2);
         escrow.approveDisputeSolution(proposalId);
@@ -337,9 +348,10 @@ contract FuzzTest is Test {
         assertEq(uint8(_status6), uint8(AgroasysEscrow.TradeStatus.CLOSED), "status should be CLOSED");
         // check that balances are correct
         assertEq(usdc.balanceOf(buyer),buyerBeforeApproveSolutionBalance,"buyer balance mismatch");
-        assertEq(usdc.balanceOf(supplier),supplierBeforeApproveSolutionBalance+tranche2,"supplier balance mismatch");
+        assertEq(usdc.balanceOf(supplier),supplierBeforeApproveSolutionBalance,"supplier balance mismatch");
         assertEq(usdc.balanceOf(treasury),treasuryBeforeApproveSolutionBalance,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeApproveSolutionBalance-tranche2,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeApproveSolutionBalance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(supplier),supplierBeforeApproveSolutionClaimable + tranche2,"supplier claimableUsdc mismatch");
     }
 
 
@@ -386,6 +398,8 @@ contract FuzzTest is Test {
         uint256 supplierBeforeReleaseFundsStage1Balance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeReleaseFundsStage1Balance = usdc.balanceOf(treasury);
         uint256 escrowBeforeReleaseFundsStage1Balance = usdc.balanceOf(address(escrow));
+        uint256 supplierBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(supplier);
+        uint256 treasuryBeforeReleaseFundsStage1Claimable = escrow.claimableUsdc(treasury);
 
         vm.prank(oracle);
         escrow.releaseFundsStage1(tradeId);
@@ -395,9 +409,11 @@ contract FuzzTest is Test {
         assertEq(uint8(_status2), uint8(AgroasysEscrow.TradeStatus.IN_TRANSIT), "status should be IN_TRANSIT");
         // check that balances are correct
         assertEq(usdc.balanceOf(buyer),buyerBeforeReleaseFundsStage1Balance,"buyer balance mismatch");
-        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance+tranche1,"supplier balance mismatch");
-        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance+logistics+fees,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance-tranche1-logistics-fees,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(supplier),supplierBeforeReleaseFundsStage1Balance,"supplier balance mismatch");
+        assertEq(usdc.balanceOf(treasury),treasuryBeforeReleaseFundsStage1Balance,"treasury balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeReleaseFundsStage1Balance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(supplier),supplierBeforeReleaseFundsStage1Claimable + tranche1,"supplier claimableUsdc mismatch");
+        assertEq(escrow.claimableUsdc(treasury),treasuryBeforeReleaseFundsStage1Claimable + logistics + fees,"treasury claimableUsdc mismatch");
 
 
         // ######################## 3) CONFIRM ARRIVAL #########################################
@@ -466,6 +482,7 @@ contract FuzzTest is Test {
         uint256 supplierBeforeApproveSolutionBalance = usdc.balanceOf(supplier);
         uint256 treasuryBeforeApproveSolutionBalance = usdc.balanceOf(treasury);
         uint256 escrowBeforeApproveSolutionBalance = usdc.balanceOf(address(escrow));
+        uint256 buyerBeforeApproveSolutionClaimable = escrow.claimableUsdc(buyer);
 
         vm.prank(admin2);
         escrow.approveDisputeSolution(proposalId);
@@ -474,10 +491,11 @@ contract FuzzTest is Test {
 
         assertEq(uint8(_status6), uint8(AgroasysEscrow.TradeStatus.CLOSED), "status should be CLOSED");
         // check that balances are correct
-        assertEq(usdc.balanceOf(buyer),buyerBeforeApproveSolutionBalance+tranche2,"buyer balance mismatch");
+        assertEq(usdc.balanceOf(buyer),buyerBeforeApproveSolutionBalance,"buyer balance mismatch");
         assertEq(usdc.balanceOf(supplier),supplierBeforeApproveSolutionBalance,"supplier balance mismatch");
         assertEq(usdc.balanceOf(treasury),treasuryBeforeApproveSolutionBalance,"treasury balance mismatch");
-        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeApproveSolutionBalance-tranche2,"escrow balance mismatch");
+        assertEq(usdc.balanceOf(address(escrow)),escrowBeforeApproveSolutionBalance,"escrow balance mismatch");
+        assertEq(escrow.claimableUsdc(buyer),buyerBeforeApproveSolutionClaimable + tranche2,"buyer claimableUsdc mismatch");
     }
 
 
@@ -601,6 +619,7 @@ contract FuzzTest is Test {
         
         uint256 buyerBalanceBefore = usdc.balanceOf(buyer);
         uint256 escrowBalanceBefore = usdc.balanceOf(address(escrow));
+        uint256 buyerClaimableBefore = escrow.claimableUsdc(buyer);
         
         vm.warp(block.timestamp + 7 days + 1);
         
@@ -610,8 +629,9 @@ contract FuzzTest is Test {
         (,,AgroasysEscrow.TradeStatus _statusAfter,,,,,,,,,) = escrow.trades(tradeId);
         
         assertEq(uint8(_statusAfter), uint8(AgroasysEscrow.TradeStatus.CLOSED), "status should be CLOSED");
-        assertEq(usdc.balanceOf(buyer), buyerBalanceBefore + total, "buyer should receive full refund");
-        assertEq(usdc.balanceOf(address(escrow)), escrowBalanceBefore - total, "escrow balance should decrease");
+        assertEq(usdc.balanceOf(buyer), buyerBalanceBefore, "buyer balance should remain unchanged before claim");
+        assertEq(usdc.balanceOf(address(escrow)), escrowBalanceBefore, "escrow balance should remain unchanged before claim");
+        assertEq(escrow.claimableUsdc(buyer), buyerClaimableBefore + total, "buyer claimable should include full refund");
     }
 
 
@@ -632,8 +652,9 @@ contract FuzzTest is Test {
         
         uint256 buyerBalanceBefore = usdc.balanceOf(buyer);
         uint256 escrowBalanceBefore = usdc.balanceOf(address(escrow));
+        uint256 buyerClaimableBefore = escrow.claimableUsdc(buyer);
         
-        assertEq(escrowBalanceBefore, tranche2, "only tranche2 should remain in escrow");
+        assertEq(escrowBalanceBefore, logistics + fees + tranche1 + tranche2, "escrow balance should remain fully locked before claim");
         
         vm.warp(block.timestamp + 14 days + 1);
         
@@ -643,8 +664,9 @@ contract FuzzTest is Test {
         (,,AgroasysEscrow.TradeStatus _statusAfter,,,,,,,,,) = escrow.trades(tradeId);
         
         assertEq(uint8(_statusAfter), uint8(AgroasysEscrow.TradeStatus.CLOSED), "status should be CLOSED");
-        assertEq(usdc.balanceOf(buyer), buyerBalanceBefore + tranche2, "buyer should receive tranche2 refund");
-        assertEq(usdc.balanceOf(address(escrow)), 0, "escrow should be empty");
+        assertEq(usdc.balanceOf(buyer), buyerBalanceBefore, "buyer balance should remain unchanged before claim");
+        assertEq(usdc.balanceOf(address(escrow)), escrowBalanceBefore, "escrow balance should remain unchanged before claim");
+        assertEq(escrow.claimableUsdc(buyer), buyerClaimableBefore + tranche2, "buyer claimable should include tranche2 refund");
     }
 
 

--- a/contracts/foundry/test/AgroasysEscrowInvariant.t.sol
+++ b/contracts/foundry/test/AgroasysEscrowInvariant.t.sol
@@ -24,6 +24,7 @@ contract Handler is Test {
 
     uint256 public totalDeposited;
     uint256 public totalWithdrawn;
+    uint256 public totalClaimableUsdc;
     uint256 public tradesCreated;
     uint256 public releaseStage1Triggered;
     uint256 public releaseStage2Triggered;
@@ -117,7 +118,7 @@ contract Handler is Test {
         vm.prank(oracle);
         escrow.releaseFundsStage1(tradeId);
         (,,,,,, uint256 logistics,uint256 fees, uint256 tranche1,,,) = escrow.trades(tradeId);
-        totalWithdrawn += logistics + tranche1 + fees;
+        totalClaimableUsdc += logistics + tranche1 + fees;
         releaseStage1Triggered++;
     }
 
@@ -149,7 +150,7 @@ contract Handler is Test {
         vm.prank(oracle);
         escrow.finalizeAfterDisputeWindow(tradeId);
         (,,,,,,,,,uint256 tranche2,,) = escrow.trades(tradeId);
-        totalWithdrawn += tranche2;
+        totalClaimableUsdc += tranche2;
         releaseStage2Triggered++;
     }
 
@@ -199,7 +200,7 @@ contract Handler is Test {
         
         if (executedNow && !executed) {
             disputeSolved++;
-            totalWithdrawn += tranche2;
+            totalClaimableUsdc += tranche2;
         }
     }
 }
@@ -257,6 +258,7 @@ contract InvariantTest is Test {
         console2.log("Total locked in the escrow (USDC):", uint256(usdc.balanceOf(address(escrow))/1e6));
         console2.log("Total deposited (USDC):", uint256(handler.totalDeposited()/1e6));
         console2.log("Total withdrawn (USDC):", uint256(handler.totalWithdrawn()/1e6));
+        console2.log("Total claimable accrued (USDC):", uint256(handler.totalClaimableUsdc()/1e6));
         console2.log("Total triger stage 1:", uint256(handler.releaseStage1Triggered()));
         console2.log("Total triger stage 2:", uint256(handler.releaseStage2Triggered()));
         console2.log("Total dispute raised:", uint256(handler.disputedRaised()));
@@ -265,29 +267,32 @@ contract InvariantTest is Test {
 
 
     function invariant_EscrowBalanceMatchesLockedFunds() public view {
-        uint256 totalLocked = 0;
+        uint256 totalReserved = 0;
         
         for (uint256 i = 0; i < escrow.tradeCounter(); i++) {
             (,,AgroasysEscrow.TradeStatus status,,,uint256 total,,,,uint256 tranche2,,) = escrow.trades(i);
             
             if (status == AgroasysEscrow.TradeStatus.LOCKED) {
-                totalLocked += total;
+                totalReserved += total;
             } else if (
                 status == AgroasysEscrow.TradeStatus.IN_TRANSIT || 
                 status == AgroasysEscrow.TradeStatus.ARRIVAL_CONFIRMED || 
                 status == AgroasysEscrow.TradeStatus.FROZEN
             ) {
-                totalLocked += tranche2;
+                totalReserved += tranche2;
             }
         }
-        assertEq(usdc.balanceOf(address(escrow)), totalLocked, "escrow balance doesn't match logical locked funds");
+        uint256 expectedEscrowBalance = totalReserved + escrow.totalClaimableUsdc();
+        assertEq(usdc.balanceOf(address(escrow)), expectedEscrowBalance, "escrow balance doesn't match reserved+claimable");
         _Summary();
     }
 
     function invariant_EscrowFundsConservation() public view {
-        uint256 amountRemaining = handler.totalDeposited() - handler.totalWithdrawn();
+        uint256 totalDeposited = handler.totalDeposited();
+        uint256 totalWithdrawn = handler.totalWithdrawn();
         uint256 escrowBalance = usdc.balanceOf(address(escrow));
-        assertEq(escrowBalance, amountRemaining, "escrow balance doesn't match 'deposited - withdrawn'");
+        assertEq(totalDeposited, escrowBalance + totalWithdrawn, "escrow funds conservation violated");
+        assertEq(escrow.totalClaimableUsdc(), handler.totalClaimableUsdc(), "claimable tracking mismatch");
         _Summary();
     }
 

--- a/docs/runbooks/pull-over-push-claim-flow.md
+++ b/docs/runbooks/pull-over-push-claim-flow.md
@@ -35,7 +35,7 @@ This runbook describes the escrow payout model after issue `#142` migration from
   - Use `pause()` for protocol mutation incidents.
   - Use `pauseClaims()` only for claim/accounting/token-transfer incidents.
   - Use both if both risk surfaces are impacted.
-- This behavior is test-backed in `contracts/tests/AgroasysEscrow.ts`:
+- This behavior is test-backed in the repository-root path `./contracts/tests/AgroasysEscrow.ts`:
   - `Should allow claims while globally paused when claim freeze is not active`
   - `Should enforce dedicated claim freeze and restore claim after unpauseClaims`
 
@@ -71,5 +71,8 @@ npm -w contracts test
 - Hardhat test suites are the release gate for this migration:
   - `contracts/tests/AgroasysEscrow.ts`
   - `contracts/tests/AgroasysEscrow.claim-security.ts`
-- Foundry parity could not be executed in this environment because `forge` is unavailable (`npm run -w contracts test:foundry` fails with `forge: command not found`).
-- Treat Foundry migration/verification as a follow-up environment gate before promoting Foundry as a required check.
+- Foundry coverage for pull-over-push behavior exists in:
+  - `contracts/foundry/test/AgroasysEscrowFuzz.t.sol`
+  - `contracts/foundry/test/AgroasysEscrowInvariant.t.sol`
+- Run Foundry with `npm run -w contracts test:foundry` (requires `forge` on `PATH`).
+- Keep Foundry migration/verification as a follow-up gate before promoting Foundry as a required merge check.

--- a/scripts/polkavm-deploy-verify.mjs
+++ b/scripts/polkavm-deploy-verify.mjs
@@ -152,7 +152,15 @@ function resolveHardhatVersion() {
       encoding: "utf8",
     }).trim();
   } catch (error) {
-    fail(`unable to resolve hardhat version: ${error.message}`);
+    const stderr = error && error.stderr ? String(error.stderr).trim() : "";
+    const details = stderr ? `\nstderr:\n${stderr}` : "";
+    fail(
+      `unable to resolve hardhat version using "npx hardhat --version" in ${path.join(
+        repoRoot,
+        "contracts",
+      )}: ${error.message || "unknown error"}${details}\n` +
+        "Ensure that Hardhat is installed and that the contracts project has been bootstrapped (e.g., npm/yarn/pnpm install) in the contracts directory.",
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- align Foundry fuzz and invariant tests with pull-over-push claim accounting
- update pull-over-push runbook test-path wording and Foundry gate guidance
- improve `scripts/polkavm-deploy-verify.mjs` Hardhat version resolution error diagnostics

## What changed
- `contracts/foundry/test/AgroasysEscrowFuzz.t.sol`
  - replace stale push-model balance assertions with `claimableUsdc` assertions in stage1/stage2/dispute/timeout flows
  - ensure escrow/supplier/treasury/buyer token balances are asserted as unchanged before `claim()`
- `contracts/foundry/test/AgroasysEscrowInvariant.t.sol`
  - track claim accrual separately from actual withdrawals in handler state
  - update conservation invariants to include `totalClaimableUsdc` semantics
- `contracts/foundry/foundry.toml`
  - add `forge-std` remapping for reproducible Foundry test resolution
- `docs/runbooks/pull-over-push-claim-flow.md`
  - use explicit repo-root path format (`./contracts/tests/AgroasysEscrow.ts`)
  - document existing Foundry coverage and execution requirements clearly
- `scripts/polkavm-deploy-verify.mjs`
  - include stderr + cwd + actionable guidance when Hardhat version resolution fails

## Validation
- `node --check scripts/polkavm-deploy-verify.mjs`
- `cd contracts/foundry && forge test -vvv`
  - `18 passed, 0 failed`
