### PR TITLE
fix: resolve AI findings across sdk, oracle, and indexer

### DIFF
--- a/indexer/src/main.ts
+++ b/indexer/src/main.ts
@@ -453,6 +453,7 @@ async function handleDisputeOpenedByBuyer(
         blockNumber: block.header.height,
         timestamp,
         txHash,
+        extrinsicHash,
         extrinsicIndex
     }));
 

--- a/oracle/src/core/trigger-manager.ts
+++ b/oracle/src/core/trigger-manager.ts
@@ -432,7 +432,7 @@ export class TriggerManager {
 
                 if (nextStatus === TriggerStatus.EXHAUSTED_NEEDS_REDRIVE) {
                     const exhaustedMessage =
-                        "Exhausted " + this.maxAttempts + " attempts: " + oracleError.message + ". Use re-drive endpoint to retry.";
+                        `Exhausted ${this.maxAttempts} attempts: ${oracleError.message}. Use re-drive endpoint to retry.`;
                     incrementOracleExhaustedRetries(actionKey);
                     await this.notifyTerminalStatus(trigger, actionKey, nextStatus, exhaustedMessage, attempt);
                     return {
@@ -485,7 +485,7 @@ export class TriggerManager {
             source: 'oracle',
             type: eventType,
             severity: 'critical',
-            dedupKey: 'oracle:' + status + ':' + actionKey,
+            dedupKey: `oracle:${status}:${actionKey}`,
             message,
             correlation: {
                 tradeId: trigger.trade_id,

--- a/sdk/src/modules/adminSDK.ts
+++ b/sdk/src/modules/adminSDK.ts
@@ -249,7 +249,7 @@ export class AdminSDK extends Client {
             
         } catch (error: any) {
             throw new ContractError(
-                `Failed to approve dispute: ${error.message}`,
+                `Failed to approve dispute solution: ${error.message}`,
                 { proposalId: proposalId.toString(), error: error.message }
             );
         }

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -48,6 +48,7 @@ export class BuyerSDK extends Client {
     }
     
     async getUSDCAllowance(buyerAddress: string): Promise<bigint> {
+        validateAddress(buyerAddress, 'buyer');
         try {
             const usdcContract = IERC20__factory.connect(
                 this.config.usdcAddress,
@@ -68,6 +69,7 @@ export class BuyerSDK extends Client {
     }
     
     async getUSDCBalance(buyerAddress: string): Promise<bigint> {
+        validateAddress(buyerAddress, 'buyer');
         try {
             const usdcContract = IERC20__factory.connect(
                 this.config.usdcAddress,

--- a/sdk/tests/manualAdminSDK.test.ts
+++ b/sdk/tests/manualAdminSDK.test.ts
@@ -5,8 +5,10 @@ import { AdminSDK } from '../src/modules/adminSDK';
 import { DisputeStatus } from '../src/types/dispute';
 import { TEST_CONFIG, assertRequiredEnv, getAdminSigner, hasRequiredEnv } from './setup';
 
-const runManualE2E = process.env.RUN_E2E === 'true';
-const describeIntegration = runManualE2E && hasRequiredEnv ? describe : describe.skip;
+const isManualE2ERequested = process.env.RUN_E2E === 'true';
+const hasEnvForManualE2E = hasRequiredEnv;
+const shouldRunManualE2E = isManualE2ERequested && hasEnvForManualE2E;
+const describeIntegration = shouldRunManualE2E ? describe : describe.skip;
 
 describeIntegration('AdminSDK', () => {
     let adminSDK: AdminSDK;
@@ -29,43 +31,36 @@ describeIntegration('AdminSDK', () => {
         
         expect(isAdmin1).toBe(true);
         expect(isAdmin2).toBe(true);
-        
-        console.log(`admins verified`);
     });
 
     test.skip('should pause protocol', async () => {
         const result = await adminSDK.pause(adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`protocol paused: ${result.txHash}`);
     });
 
     test.skip('should propose unpause', async () => {
         const result = await adminSDK.proposeUnpause(adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`unpause proposed: ${result.txHash}`);
     });
 
     test.skip('should approve unpause', async () => {
         const result = await adminSDK.approveUnpause(adminSigner2);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`unpause approved: ${result.txHash}`);
     });
 
     test.skip('should cancel unpause proposal', async () => {
         const result = await adminSDK.cancelUnpauseProposal(adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`unpause proposal cancelled: ${result.txHash}`);
     });
 
     test.skip('should disable oracle emergency', async () => {
         const result = await adminSDK.disableOracleEmergency(adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`oracle disabled: ${result.txHash}`);
     });
 
     test.skip('should propose dispute solution', async () => {
@@ -74,7 +69,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.proposeDisputeSolution(tradeId, DisputeStatus.REFUND, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`dispute solution proposed: ${result.txHash}`);
     });
 
     test.skip('should approve dispute solution', async () => {
@@ -83,7 +77,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.approveDisputeSolution(proposalId, adminSigner2);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`dispute solution approved: ${result.txHash}`);
     });
 
     test.skip('should cancel expired dispute proposal', async () => {
@@ -92,7 +85,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.cancelExpiredDisputeProposal(proposalId, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`expired dispute proposal cancelled: ${result.txHash}`);
     });
 
     test.skip('should propose oracle update', async () => {
@@ -101,7 +93,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.proposeOracleUpdate(newOracle, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`oracle update proposed: ${result.txHash}`);
     });
 
     test.skip('should approve oracle update', async () => {
@@ -110,7 +101,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.approveOracleUpdate(proposalId, adminSigner2);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`oracle update approved: ${result.txHash}`);
     });
 
     test.skip('should execute oracle update', async () => {
@@ -119,7 +109,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.executeOracleUpdate(proposalId, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`oracle update executed: ${result.txHash}`);
     });
 
     test.skip('should cancel expired oracle update proposal', async () => {
@@ -128,7 +117,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.cancelExpiredOracleUpdateProposal(proposalId, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`expired oracle update proposal cancelled: ${result.txHash}`);
     });
 
     test.skip('should propose add admin', async () => {
@@ -137,7 +125,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.proposeAddAdmin(newAdmin, adminSigner1);
 
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`admin add proposed: ${result.txHash}`);
     });
 
     test.skip('should approve add admin', async () => {
@@ -146,7 +133,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.approveAddAdmin(proposalId, adminSigner2);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`admin add approved: ${result.txHash}`);
     });
 
     test.skip('should execute add admin', async () => {
@@ -155,7 +141,6 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.executeAddAdmin(proposalId, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`admin add executed: ${result.txHash}`);
     });
 
     test.skip('should cancel expired add admin proposal', async () => {
@@ -164,13 +149,11 @@ describeIntegration('AdminSDK', () => {
         const result = await adminSDK.cancelExpiredAddAdminProposal(proposalId, adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`expired admin add proposal cancelled: ${result.txHash}`);
     });
 
     test.skip('should claim', async () => {
         const result = await adminSDK.claim(adminSigner1);
         
         expect(result.txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
-        console.log(`claimed: ${result.txHash}`);
     });
 });


### PR DESCRIPTION
## Summary
- add missing buyerAddress validation in SDK buyer methods: getUSDCAllowance and getUSDCBalance
- improve SDK admin error wording for dispute solution approval
- clean manual Admin SDK test behavior and remove noisy console logs
- convert Oracle trigger-manager string concatenations to template literals for consistency
- add missing extrinsicHash in indexer DisputeOpenedByBuyer TradeEvent

## Validation
- npm run -w sdk lint
- npm run -w oracle lint
- npm run -w indexer lint

## Notes
- batched from security/quality AI findings provided in review
