### PR TITLE
docs(runbooks): clarify Foundry examples vs dashboard/AdminSDK execution

### DIFF
--- a/docs/runbooks/pull-over-push-claim-flow.md
+++ b/docs/runbooks/pull-over-push-claim-flow.md
@@ -49,6 +49,8 @@ This runbook describes the escrow payout model after issue `#142` migration from
 
 Use these checks during incident triage or release verification:
 
+**Production execution:** Admins run these actions through the Web2 admin dashboard, which calls the AdminSDK to submit transactions (`sdk/src/modules/adminSDK.ts`). The Foundry commands below are a reproducible fallback for audits, incident response, or manual verification when the dashboard path is unavailable.
+
 ```bash
 cast call <ESCROW_ADDRESS> "claimableUsdc(address)(uint256)" <RECIPIENT>
 ```


### PR DESCRIPTION
## Summary\n- Add a production-execution clarification above the first Foundry () command example in the pull-over-push runbook.\n- Clarify that normal operations run through the Web2 admin dashboard via AdminSDK, with Foundry as fallback for audits/incident response/manual verification.\n\n## Files changed\n- docs/runbooks/pull-over-push-claim-flow.md\n\nDocs-only clarification; no runtime behavior changes.