### PR TITLE
docs(runbooks): define API gateway orchestration boundary + guard (closes #78)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -84,8 +84,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Check deprecated profile names in docs
-        run: scripts/tests/docs-profile-name-guard.sh
+      - name: Run docs/profile boundary guards
+        shell: bash
+        run: |
+          set +e
+          mkdir -p ci-reports
+          report="ci-reports/docs-profile-guard.txt"
+          fail=0
+
+          run_check() {
+            local label="$1"
+            shift
+            echo "[$label] command: $*" | tee -a "$report"
+            if "$@" 2>&1 | tee -a "$report"; then
+              echo "[$label] PASS" | tee -a "$report"
+            else
+              echo "[$label] FAIL" | tee -a "$report"
+              fail=1
+            fi
+            echo "" >> "$report"
+          }
+
+          run_check docs-profile-name scripts/tests/docs-profile-name-guard.sh
+          run_check api-gateway-boundary scripts/tests/api-gateway-boundary-guard.sh
+
+          if [[ "$fail" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Upload docs/profile guard report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: ci-report-docs-profile-guard
+          path: ci-reports/docs-profile-guard.txt
 
   arch-roadmap-consistency:
     name: ci/arch-roadmap-consistency

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ npm run -w treasury build
 - `docs/runbooks/docker-profiles.md`
 - `docs/runbooks/asset-conversion-fee-validation.md`
 - `docs/runbooks/production-readiness-checklist.md`
+- `docs/runbooks/api-gateway-boundary.md`
 - `docs/runbooks/polkavm-deploy-verification.md`
 - `docs/runbooks/hybrid-split-walkthrough.md`
 - `docs/runbooks/treasury-to-fiat-sop.md`

--- a/docs/runbooks/api-gateway-boundary.md
+++ b/docs/runbooks/api-gateway-boundary.md
@@ -1,0 +1,116 @@
+# API Gateway Orchestration Boundary
+
+## Purpose and scope
+Define the operational boundary for API orchestration between the Web2 ingress layer and core services (`oracle`, `treasury`, `reconciliation`, `indexer`, `notifications`).
+
+This runbook is the source of truth for boundary behavior under issue #78. A dedicated gateway runtime control plane is not implemented in-repo yet (tracked by #123), and a centralized dead-letter/error-handler workflow is tracked by #124.
+
+## Routing ownership and service contract
+Current runtime behavior is service-directed (no single in-repo gateway binary). The boundary contract below defines ownership and expected routing:
+
+| Request class | Current endpoint owner | Contract boundary |
+| --- | --- | --- |
+| Oracle settlement actions | `oracle` (`/api/oracle/*`) | Mutating calls must carry idempotency context (`tradeId`, `requestId`) and service auth headers. |
+| Treasury ledger + payout ops | `treasury` (`/api/treasury/v1/*`) | Calls must satisfy treasury auth policy when enabled; payout state changes are append-only. |
+| Reconciliation execution | `reconciliation` worker (CLI/job) | No public HTTP mutation surface; execution is scheduled/operator-controlled. |
+| Indexer reads | `indexer-graphql` (`/graphql`) | Read-only query surface for state evidence, never mutation authority. |
+| Notifications emission | library/runtime hooks | Service-local emission with deterministic routing metadata; no direct public mutation API in this repo. |
+
+Ownership rule:
+- Gateway orchestration policy ownership: platform/ops maintainers (Milestone B governance scope).
+- Service behavior ownership: each service owner remains responsible for validation and idempotency inside their runtime.
+
+## Authentication propagation rules (headers/claims, what must never be forwarded)
+Rules that apply to gateway-mediated traffic:
+- Preserve only required upstream auth material:
+  - Oracle contract: `Authorization: Bearer <API_KEY>`, `X-Timestamp`, `X-Signature`.
+  - Treasury contract (when `AUTH_ENABLED=true`): `x-agroasys-timestamp`, `x-agroasys-signature`, optional `x-agroasys-nonce`, optional `X-Api-Key`.
+- Never forward raw secrets, private keys, or internal signing material in headers/body logs.
+- Never forward user cookies/session tokens to internal services that do not require them.
+- For internal retries/replays, regenerate service signatures per request; do not replay stale signed headers.
+
+## Correlation IDs + request IDs (exact fields, generation, logging expectations)
+Correlation fields must align with `docs/observability/logging-schema.md`:
+- `tradeId`
+- `actionKey`
+- `requestId`
+- `txHash`
+- `traceId`
+
+Operational rules:
+- Mutating oracle calls must include `requestId` in request body (already required by oracle API contract).
+- If ingress receives no request correlation header, generate one at ingress and attach to downstream logs as `traceId`.
+- Keep `requestId` stable across retry attempts for the same client intent; use `actionKey`/idempotency logic in downstream services to prevent duplication.
+
+## Timeouts and retries (default ceilings; per-service overrides; retry budget)
+Current deterministic behavior in-repo:
+- Oracle retry loop: bounded by `RETRY_ATTEMPTS` (default `3`) with exponential backoff from `RETRY_DELAY` (default `1000ms`, max `30000ms`).
+- Reconciliation: no mutating retry loop; reruns are daemon/one-shot controlled.
+- Notifications: bounded retries per notifier configuration (`retryAttempts`, `retryDelayMs`, `maxRetryDelayMs`).
+- Staging gate readiness retries use bounded shell retries (for example, `retry_cmd 30 2` in `scripts/staging-e2e-real-gate.sh`).
+
+Boundary rule for future gateway runtime (#123):
+- Do not add unbounded gateway retries for mutating endpoints.
+- Keep gateway retry budget lower than or equal to downstream idempotent safety model.
+
+## Failure modes: fallback, dead-letter, and "who owns the incident"
+Current state:
+- Full cross-service dead-letter queue is not implemented yet (tracked by #124).
+- Oracle provides deterministic exhaustion state (`EXHAUSTED_NEEDS_REDRIVE`) plus manual redrive controls (`docs/runbooks/oracle-redrive.md`).
+- Reconciliation and staging gate outputs provide drift/error evidence for incident triage.
+
+Fallback policy:
+- If gateway/orchestration behavior is unclear, route incident through runbooks with deterministic evidence:
+  - `docs/incidents/first-15-minutes-checklist.md`
+  - `docs/runbooks/oracle-redrive.md`
+  - `docs/runbooks/reconciliation.md`
+
+Incident ownership:
+- Gateway boundary incident commander: platform/ops on-call.
+- Service-specific correctness owner: affected service owner (oracle/treasury/reconciliation/indexer).
+
+## Error taxonomy (client vs upstream vs infra) and expected response mapping
+Use this classification for deterministic handoff:
+
+| Error class | Typical source | Expected handling |
+| --- | --- | --- |
+| Client/contract error | Missing required fields, invalid auth headers, invalid request shape | Return deterministic 4xx with stable error code; do not retry automatically. |
+| Upstream business/state error | Trade state precondition fails, idempotency conflict, payout transition invalid | Return deterministic error body; classify as service-owned incident if persistent. |
+| Infrastructure/transient error | RPC timeout, DB connectivity, indexer unavailable | Retry only within bounded policy; escalate to on-call if threshold exceeded. |
+
+## Observability requirements (log fields, metrics, traces)
+Minimum log requirements:
+- Include correlation fields from `docs/observability/logging-schema.md`.
+- Redact auth/signature secrets from logs and artifacts.
+
+Required operational evidence for gateway-boundary incidents:
+- health/readiness outputs for affected services
+- correlated logs using `tradeId`, `actionKey`, `requestId`, `txHash`, `traceId`
+- release-gate reports when incident overlaps staging validation
+
+Metric references (existing schema baseline):
+- `auth_failures_total`
+- `replay_rejects_total`
+- `oracle_exhausted_retries_total`
+- `oracle_redrive_attempts_total`
+- `reconciliation_drift_classifications_total`
+
+## Operational ownership matrix (RACI: gateway owner vs service owner vs on-call)
+| Activity | Gateway owner (Ops/Platform) | Service owner | On-call |
+| --- | --- | --- | --- |
+| Define ingress-to-service routing contract | A/R | C | I |
+| Maintain service auth contracts | C | A/R | I |
+| Correlation field compliance in logs | A/R | A/R | C |
+| Retry budget and timeout policy updates | A/R | C | C |
+| Redrive/recovery execution during incident | C | A/R | A/R |
+| Post-incident runbook update | A/R | C | C |
+
+Legend: `A` accountable, `R` responsible, `C` consulted, `I` informed.
+
+## Runbook quick actions (first 15 minutes checklist links)
+1. Run incident triage baseline: `docs/incidents/first-15-minutes-checklist.md`.
+2. If oracle path is impacted, execute `docs/runbooks/oracle-redrive.md`.
+3. If drift/indexing mismatch is suspected, execute `docs/runbooks/reconciliation.md`.
+4. Validate profile health and release-gate diagnostics:
+   - `docs/runbooks/staging-e2e-release-gate.md`
+   - `docs/runbooks/staging-e2e-real-release-gate.md`

--- a/docs/runbooks/oracle-redrive.md
+++ b/docs/runbooks/oracle-redrive.md
@@ -3,6 +3,8 @@
 ## Purpose
 Handle `EXHAUSTED_NEEDS_REDRIVE` oracle triggers with explicit ownership, bounded retries, and on-chain verification safeguards.
 
+Gateway-boundary handoff: when failures indicate routing/auth propagation/correlation drift across services (not oracle business-state logic), follow `docs/runbooks/api-gateway-boundary.md` first, then return here for redrive actions with the same `tradeId`/`actionKey`/`requestId` evidence.
+
 ## Ownership And Intervention Rules
 - `Operator`:
   - Runs health/diagnostic checks.
@@ -160,4 +162,3 @@ All approve and reject actions are also emitted as `audit`-level log entries
 | Trigger approved but blockchain action fails and exhausts retries | Use standard redrive flow  |
 | Same `actionKey` appears in `PENDING_APPROVAL` a second time | Do **not** approve. Escalate to Service Owner, indicates a duplicate submission at the API layer |
 | On-chain state does not match expected pre-condition | Reject with reason, escalate to Service Owner for hotfix decision |
-

--- a/docs/runbooks/reconciliation.md
+++ b/docs/runbooks/reconciliation.md
@@ -3,6 +3,7 @@
 ## Purpose
 Operate reconciliation safely in local/staging and diagnose drift failures.
 For lifecycle checkpoints across lock, stage-1, and final settlement, see `docs/runbooks/hybrid-split-walkthrough.md`.
+If a mismatch may be caused by routing/auth propagation/correlation breakdown between services, use `docs/runbooks/api-gateway-boundary.md` first to classify the handoff boundary before remediating reconciliation state.
 
 ## Preconditions
 - Postgres is reachable.

--- a/scripts/tests/api-gateway-boundary-guard.sh
+++ b/scripts/tests/api-gateway-boundary-guard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DOC_PATH="docs/runbooks/api-gateway-boundary.md"
+fail=0
+
+if [[ ! -f "$DOC_PATH" ]]; then
+  echo "[FAIL] Missing required runbook: ${DOC_PATH}" >&2
+  exit 1
+fi
+
+required_headings=(
+  "## Purpose and scope"
+  "## Routing ownership and service contract"
+  "## Authentication propagation rules (headers/claims, what must never be forwarded)"
+  "## Correlation IDs + request IDs (exact fields, generation, logging expectations)"
+  "## Timeouts and retries (default ceilings; per-service overrides; retry budget)"
+  "## Failure modes: fallback, dead-letter, and \"who owns the incident\""
+  "## Error taxonomy (client vs upstream vs infra) and expected response mapping"
+  "## Observability requirements (log fields, metrics, traces)"
+  "## Operational ownership matrix (RACI: gateway owner vs service owner vs on-call)"
+  "## Runbook quick actions (first 15 minutes checklist links)"
+)
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fqx "$heading" "$DOC_PATH"; then
+    echo "[FAIL] Missing required heading in ${DOC_PATH}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "api gateway boundary guard: pass"
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Closes #78

## Summary
Defines the API gateway orchestration boundary as a runbook contract, adds deterministic heading drift guard automation, and wires the guard into CI with an uploaded report artifact.

## Acceptance Criteria Mapping
| Criterion | Evidence |
| --- | --- |
| Gateway boundary contract is documented (request routing, auth propagation, correlation IDs). | `docs/runbooks/api-gateway-boundary.md` sections: routing/auth/correlation ([docs/runbooks/api-gateway-boundary.md](docs/runbooks/api-gateway-boundary.md):8, :23, :32). |
| Error handoff rules are explicit (retries, fallback, dead-letter/incident path). | `docs/runbooks/api-gateway-boundary.md` retry/failure/error taxonomy sections ([docs/runbooks/api-gateway-boundary.md](docs/runbooks/api-gateway-boundary.md):45, :56, :72). |
| Runbooks map gateway failures to service owners and remediation playbooks. | RACI + quick actions in boundary runbook ([docs/runbooks/api-gateway-boundary.md](docs/runbooks/api-gateway-boundary.md):98, :110); cross-links added in [docs/runbooks/oracle-redrive.md](docs/runbooks/oracle-redrive.md):6 and [docs/runbooks/reconciliation.md](docs/runbooks/reconciliation.md):6; index link in [README.md](README.md):169. |
| Drift guard enforces required runbook headings. | New guard script [scripts/tests/api-gateway-boundary-guard.sh](scripts/tests/api-gateway-boundary-guard.sh):1 and CI integration in [release-gate.yml](.github/workflows/release-gate.yml):80-120. |

## Local Validation
All commands executed with Node `v20.20.0` / npm `10.8.2` (see `/tmp/issue-78-evidence-20260301-185441/env.log`).

- `bash scripts/tests/api-gateway-boundary-guard.sh` -> exit `0`
- `bash scripts/tests/docs-profile-name-guard.sh` -> exit `0`
- `node scripts/architecture-roadmap-consistency-check.mjs --offline --out /tmp/issue-78-evidence-20260301-185441/arch-roadmap-consistency.json` -> exit `0`
- CI-step simulation (docs profile guard block from workflow) -> exit `0`

Evidence logs:
- `/tmp/issue-78-evidence-20260301-185441/guard-api-gateway-boundary.log`
- `/tmp/issue-78-evidence-20260301-185441/guard-docs-profile-name.log`
- `/tmp/issue-78-evidence-20260301-185441/arch-roadmap-consistency.log`
- `/tmp/issue-78-evidence-20260301-185441/ci-docs-profile-guard-simulated.log`

## CI Artifacts (Expected)
- `ci-report-docs-profile-guard` (new)
- Existing artifacts remain unchanged.

## Rollback Plan
If this introduces unwanted gate behavior:
1. Revert this PR commit.
2. Confirm `ci/docs-profile-guard` returns to previous single-script behavior.
3. Keep issue #78 open and restore prior docs state while regrouping on heading contract semantics.

## Scope/Non-goals
- Docs + guard + CI wiring only.
- No runtime gateway implementation (tracked in #123).
- No centralized dead-letter/error-handler implementation (tracked in #124).
