### PR TITLE
test(reconciliation): prevent staging gate SQL drift

### DIFF
--- a/reconciliation/src/tests/helpers/stagingGateSqlContract.ts
+++ b/reconciliation/src/tests/helpers/stagingGateSqlContract.ts
@@ -7,28 +7,54 @@ export type StagingGateSqlContract = {
   driftSummarySql: string;
 };
 
-const RUN_SUMMARY_SQL_MARKER = `RUN_SUMMARY_SQL="$(cat <<'SQL'`;
-const DRIFT_SUMMARY_SQL_MARKER = `DRIFT_SUMMARY_SQL="$(cat <<'SQL'`;
+type SqlBlockConfig = {
+  variableName: string;
+  label: string;
+  requiredFragment: string;
+};
+
+const RUN_SUMMARY_SQL_BLOCK: SqlBlockConfig = {
+  variableName: 'RUN_SUMMARY_SQL',
+  label: 'RUN_SUMMARY_SQL',
+  requiredFragment: 'FROM reconcile_runs',
+};
+
+const DRIFT_SUMMARY_SQL_BLOCK: SqlBlockConfig = {
+  variableName: 'DRIFT_SUMMARY_SQL',
+  label: 'DRIFT_SUMMARY_SQL',
+  requiredFragment: 'FROM reconcile_drifts',
+};
+
+const SQL_HEREDOC_PATTERN = /cat\s*<<-?\s*'SQL'/;
 
 function normalizeLineEndings(input: string): string {
   return input.replace(/\r\n/g, '\n');
 }
 
-function extractHeredocSql(script: string, marker: string, label: string): string {
+function extractHeredocSql(script: string, config: SqlBlockConfig): string {
   const lines = normalizeLineEndings(script).split('\n');
-  const startIndex = lines.findIndex((line) => line.trim() === marker);
+  const startIndex = lines.findIndex(
+    (line) => line.includes(config.variableName) && SQL_HEREDOC_PATTERN.test(line),
+  );
   if (startIndex < 0) {
-    throw new Error(`Unable to find SQL marker for ${label}: ${marker}`);
+    throw new Error(
+      `Unable to find SQL marker for ${config.label}: expected ${config.variableName} with cat <<'SQL'`,
+    );
   }
 
   const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === 'SQL');
   if (endIndex < 0) {
-    throw new Error(`Unable to find heredoc terminator for ${label}`);
+    throw new Error(`Unable to find heredoc terminator for ${config.label}`);
   }
 
   const sql = lines.slice(startIndex + 1, endIndex).join('\n').trim();
   if (!sql) {
-    throw new Error(`Extracted SQL for ${label} is empty`);
+    throw new Error(`Extracted SQL for ${config.label} is empty`);
+  }
+  if (!sql.includes(config.requiredFragment)) {
+    throw new Error(
+      `Extracted SQL for ${config.label} is missing expected fragment: ${config.requiredFragment}`,
+    );
   }
 
   return sql;
@@ -40,10 +66,17 @@ export function loadStagingGateScript(): string {
 }
 
 export function loadStagingGateSqlContract(script = loadStagingGateScript()): StagingGateSqlContract {
-  return {
-    runSummarySql: extractHeredocSql(script, RUN_SUMMARY_SQL_MARKER, 'RUN_SUMMARY_SQL'),
-    driftSummarySql: extractHeredocSql(script, DRIFT_SUMMARY_SQL_MARKER, 'DRIFT_SUMMARY_SQL'),
-  };
+  try {
+    return {
+      runSummarySql: extractHeredocSql(script, RUN_SUMMARY_SQL_BLOCK),
+      driftSummarySql: extractHeredocSql(script, DRIFT_SUMMARY_SQL_BLOCK),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `staging-e2e-real gate script format changed, update markers in stagingGateSqlContract.ts. ${message}`,
+    );
+  }
 }
 
 export function sqlFingerprint(sql: string): string {

--- a/reconciliation/src/tests/staging-gate-output.test.ts
+++ b/reconciliation/src/tests/staging-gate-output.test.ts
@@ -49,8 +49,16 @@ test('staging-e2e-real gate captures drift classification snapshot output', () =
 test('staging-e2e-real gate SQL fingerprint stays stable unless SQL changes intentionally', () => {
   const sql = loadStagingGateSqlContract();
 
+  // Keep a short hash signal in CI output so SQL changes are obvious in diffs.
   assert.equal(sqlFingerprint(sql.runSummarySql), EXPECTED_SQL_FINGERPRINTS.runSummarySql);
   assert.equal(sqlFingerprint(sql.driftSummarySql), EXPECTED_SQL_FINGERPRINTS.driftSummarySql);
+});
+
+test('staging-e2e-real SQL extractor reports actionable marker errors when script format changes', () => {
+  assert.throws(
+    () => loadStagingGateSqlContract('#!/usr/bin/env bash\necho "no sql markers"\n'),
+    /staging-e2e-real gate script format changed, update markers in stagingGateSqlContract\.ts/,
+  );
 });
 
 test('staging-e2e-real gate writes deterministic reconciliation report output', () => {


### PR DESCRIPTION
## Summary
Prevention hardening for reconciliation SQL drift: tests now extract SQL directly from `scripts/staging-e2e-real-gate.sh` and validate a deterministic SQL contract + fingerprint.

## Why This Approach
Chosen approach: **extract SQL from bash heredocs (single source of truth) instead of moving SQL execution into Node**.

Reason this is lower-risk:
- avoids changing runtime gate behavior in `scripts/staging-e2e-real-gate.sh`
- removes script/test drift risk without introducing a new execution path in CI/runtime
- keeps scope tight to reconciliation test contract hardening

## What Changed
- Added SQL contract helper:
  - `reconciliation/src/tests/helpers/stagingGateSqlContract.ts`
  - Extracts `RUN_SUMMARY_SQL` and `DRIFT_SUMMARY_SQL` from bash heredocs using resilient marker matching
  - Adds sanity checks (`FROM reconcile_runs` / `FROM reconcile_drifts`)
  - Emits actionable error if script format changes
  - Provides SHA256 helper for SQL fingerprinting
- Updated test coverage:
  - `reconciliation/src/tests/staging-gate-output.test.ts`
  - Replaced whole-script regex drift checks with exact assertions on extracted SQL contract values
  - Added deterministic SQL fingerprint assertions
  - Added extractor failure-mode test with actionable remediation message

## Recurrence Prevention
- SQL read path for tests is now the script itself, so script/test SQL divergence cannot silently drift.
- Contract tests fail with explicit guidance when script marker format changes.
- Fingerprints provide quick CI diff signal for intentional SQL changes.

## Acceptance Mapping
- [x] Prevent future script/test SQL drift in reconciliation gate validation.
- [x] Shared source of truth for SQL contract (script-extracted).
- [x] Deterministic guard for intentional SQL changes (fingerprint).
- [x] Runtime gate behavior preserved.

## Validation (Node 20)
```bash
node -v
npm ci
npm run -w reconciliation lint
npm run -w reconciliation test
```
Results:
- Node: `v20.20.0`
- `npm run -w reconciliation lint`: pass
- `npm run -w reconciliation test`: `22 passed, 0 failed`
- Validation log: `/tmp/prA_validation.log`

## CI Evidence
- CI Release Gate run (PR head `84780853d6643ccbe73a32e44fddba20c8f39bc8`):
  - https://github.com/Agroasys/Cotsel/actions/runs/22552098049
- Artifacts:
  - `ci-report-docs-profile-guard`
  - `ci-report-env-profile-regression`
  - `ci-report-asset-fee-path`
  - `ci-report-postgres-recovery-smoke`
  - `ci-report-arch-roadmap-consistency`
  - `ci-report-staging-e2e-real-gate`
  - `ci-report-notifications-gate`
  - `ci-report-reconciliation-report`
  - `ci-report-reconciliation`
  - `ci-report-release-gate`

## Rollback
If needed, revert this PR by reverting both commits:
```bash
git revert 8478085
git revert 4f376fe
```
