### PR TITLE
chore(deps-dev): split low-risk @types/node + nodemon updates

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -26,7 +26,7 @@
     "@subsquid/substrate-typegen": "^8.1.0",
     "@subsquid/typeorm-codegen": "^2.0.1",
     "@types/minimatch": "^6.0.0",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "typescript": "^5.5.2"
   }
 }

--- a/notifications/package.json
+++ b/notifications/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "typescript": ">=4.5.0"
   }
 }

--- a/oracle/package.json
+++ b/oracle/package.json
@@ -27,11 +27,11 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/cors": "^2.8.17",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "@types/pg": "^8.10.9",
     "typescript": ">=4.5.0",
     "ts-node": "^10.9.2",
-    "nodemon": "^3.0.2",
+    "nodemon": "^3.1.14",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@subsquid/substrate-typegen": "^8.1.0",
         "@subsquid/typeorm-codegen": "^2.0.1",
         "@types/minimatch": "^6.0.0",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "typescript": "^5.5.2"
       },
       "engines": {
@@ -8281,9 +8281,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -17301,9 +17301,9 @@
       "license": "MIT"
     },
     "node_modules/nodemon": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.13.tgz",
-      "integrity": "sha512-nPN6L7A9cTA3BnJ3zZIibH5FiDh3GbmibeS17bl5YEU1IRO2mcfvR0ZJXH3ndoeKItjUcaX81FSKc/Kq/IiG6g==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22996,7 +22996,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "typescript": ">=4.5.0"
       }
     },
@@ -23018,10 +23018,10 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "@types/pg": "^8.10.9",
         "jest": "^30.2.0",
-        "nodemon": "^3.0.2",
+        "nodemon": "^3.1.14",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": ">=4.5.0"
@@ -23037,7 +23037,7 @@
         "pg": "^8.18.0"
       },
       "devDependencies": {
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "@types/pg": "^8.10.9",
         "ts-node": "^10.9.2",
         "typescript": ">=4.5.0"
@@ -23059,7 +23059,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "@types/pg": "^8.10.9",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",
@@ -23156,7 +23156,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.3",
         "@types/pg": "^8.10.9",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",

--- a/reconciliation/package.json
+++ b/reconciliation/package.json
@@ -19,7 +19,7 @@
     "@agroasys/notifications": "^1.0.0"
   },
   "devDependencies": {
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "@types/pg": "^8.10.9",
     "ts-node": "^10.9.2",
     "typescript": ">=4.5.0"

--- a/ricardian/package.json
+++ b/ricardian/package.json
@@ -23,7 +23,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "@types/pg": "^8.10.9",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",

--- a/treasury/package.json
+++ b/treasury/package.json
@@ -24,7 +24,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.3",
     "@types/pg": "^8.10.9",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",


### PR DESCRIPTION
Split from #190 to isolate low-risk dependency updates for faster merge.

## Included
- @types/node: ^25.3.0 -> ^25.3.3 in non-contract workspaces
- nodemon: ^3.0.2 -> ^3.1.14 in oracle workspace
- package-lock refresh for only those updates

## Validation
- npm install
- npm run -w contracts compile
- npm run -w contracts test -- --grep ""

## Follow-up
- Hardhat 3 / chai major upgrade remains in a separate migration PR.