### PR TITLE
docs(ci): harden Hardhat major deferral policy for blocked Hardhat v3 chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     ignore:
+      # Temporary Hardhat v3 migration deferral (issue #192):
+      # keep major updates muted only for the blocked Hardhat plugin chain.
       - dependency-name: "hardhat"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@parity/hardhat-polkadot"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@parity/hardhat-polkadot-resolc"
         update-types:
           - "version-update:semver-major"
       - dependency-name: "@nomicfoundation/hardhat-toolbox"
@@ -31,6 +39,15 @@ updates:
         update-types:
           - "version-update:semver-major"
       - dependency-name: "@nomicfoundation/hardhat-verify"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@typechain/hardhat"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "hardhat-gas-reporter"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "solidity-coverage"
         update-types:
           - "version-update:semver-major"
     groups:

--- a/docs/security/dependency-vuln-policy.md
+++ b/docs/security/dependency-vuln-policy.md
@@ -33,3 +33,40 @@ This command is **non-enforcing** and reports:
   - first PR introducing it
   - removal condition (upstream fix version or migration milestone)
 - Review overrides during dependency maintenance and remove when no longer required.
+
+## Hardhat Major Deferral Policy (Issue #192)
+### Deferral Rationale
+- Scope is limited to the Hardhat major-upgrade chain where the current plugin ecosystem is incompatible with Hardhat 3.
+- Deferral avoids unstable migrations that can break CI/runtime behavior and obscure vulnerability triage outcomes.
+- Current evidence basis:
+  - PR #191 merged low-risk updates separately.
+  - PR #193 merged major-version deferral in Dependabot for the blocked chain.
+  - PR #190 was closed after reproducing migration failures under the current dependency constraints.
+
+### What Is Deferred
+- Dependabot `semver-major` updates for the Hardhat chain only:
+  - `hardhat`
+  - `@parity/hardhat-polkadot`
+  - `@parity/hardhat-polkadot-resolc`
+  - `@nomicfoundation/hardhat-*` packages used in this repo
+  - `@typechain/hardhat`
+  - `hardhat-gas-reporter`
+  - `solidity-coverage`
+
+### Revisit Triggers
+- Time-based trigger: reassess monthly during dependency maintenance cadence.
+- Technical trigger: revisit immediately when plugin compatibility for Hardhat 3 is confirmed in upstream releases/changelogs.
+- Event trigger: revisit when CI or Dependabot reports indicate the deferral chain no longer blocks migration.
+
+### Cadence and Ownership
+- Owner: roadmap-maintainers.
+- Cadence: monthly dependency governance review and on-demand review when technical triggers fire.
+- Review record: each review must update the linked issue/PR notes with keep/deprecate decision and evidence.
+
+### Evidence Required to Lift Deferral
+- Compatibility evidence for all required plugins/tooling against Hardhat 3.
+- A dedicated migration PR with:
+  - full workspace checks passing (`lint`, `typecheck`, `test`, `build` where present),
+  - lockfile impact summary and rollback plan,
+  - no use of `npm audit fix --force`.
+- CI parity evidence showing no regression in contract/tooling workflows after migration.


### PR DESCRIPTION
## Summary
- Hardened Dependabot Hardhat-major deferral scope to the blocked plugin/tooling chain only, keeping patch/minor update flow unchanged.
- Added explicit enterprise policy language for deferral rationale, lift criteria, revisit triggers, and governance cadence/ownership.
- Verified supporting evidence state: PR #191 merged, PR #193 merged, PR #190 closed.
- Ran Node 20 baseline + dependency visibility command and captured logs under `/tmp/issue-192-validate/`.

## Acceptance Criteria Traceability
| Issue criterion (source) | Implementation (file + section) | Evidence |
| --- | --- | --- |
| Keep low-risk updates separate while Hardhat v3 remains blocked (proposed path #1) | `.github/dependabot.yml` `ignore` section limits deferral to `semver-major` only for explicit Hardhat chain packages (lines 11-52) | Ground-truth evidence file `/tmp/issue-192-evidence.json`; PR #191 merged: https://github.com/Agroasys/Cotsel/pull/191 |
| Temporarily ignore major Hardhat ecosystem bumps in Dependabot (proposed path #2) | `.github/dependabot.yml` comment + package-specific major ignores for Hardhat chain (lines 12-52) | PR #193 merged: https://github.com/Agroasys/Cotsel/pull/193 |
| Revisit with dedicated migration only when ecosystem support exists (proposed path #3) | `docs/security/dependency-vuln-policy.md` section `Hardhat Major Deferral Policy (Issue #192)` including `Revisit Triggers`, `Cadence and Ownership`, `Evidence Required to Lift Deferral` (lines 37-72) | Issue #190 closed evidence in `/tmp/issue-192-evidence.json` (URL: https://github.com/Agroasys/Cotsel/pull/190) |

## Validation Output Summary (Node 20 baseline)
Commands executed:
- `export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 20`
- `node -v && npm -v`
- `npm run security:deps`

Results:
- Node: `v20.20.0`
- npm: `10.8.2`
- `npm audit --omit=dev --json`: critical `0`, high `0`
- `npm audit --json`: critical `0`, high `4` (non-enforcing visibility output)
- `npm ls --all`: exit `1` (existing workspace/dependency state; no changes introduced in this PR)

Logs:
- `/tmp/issue-192-validate/nvm-use.log`
- `/tmp/issue-192-validate/node-npm.log`
- `/tmp/issue-192-validate/security-deps.log`

## Risks and Mitigations
- Risk: Deferral might become stale and hide readiness for migration.
  - Mitigation: Added monthly cadence + technical/event triggers + mandatory evidence to lift deferral.
- Risk: Over-broad Dependabot suppression could hide unrelated upgrades.
  - Mitigation: Kept ignore scope limited to `semver-major` and explicit Hardhat chain packages only.

## Rollback Plan
1. Revert this PR commit:
   - `git revert cb59dd3`
2. Confirm rollback scope:
   - `git diff --name-only HEAD~1..HEAD` (should only include `.github/dependabot.yml`, `docs/security/dependency-vuln-policy.md`)
3. Re-run baseline visibility command:
   - `npm run security:deps`

## Issue #192 Closeout Comment (ready to paste after merge)
Implemented and merged Hardhat-major deferral hardening for issue #192.

What changed:
- Restricted Dependabot deferral to `semver-major` updates only for the blocked Hardhat plugin/tooling chain.
- Added formal deferral policy in `docs/security/dependency-vuln-policy.md` covering rationale, revisit triggers, cadence/ownership, and evidence required to lift deferral.

Evidence:
- PR #191 merged: https://github.com/Agroasys/Cotsel/pull/191
- PR #193 merged: https://github.com/Agroasys/Cotsel/pull/193
- PR #190 closed: https://github.com/Agroasys/Cotsel/pull/190
- Validation logs captured under `/tmp/issue-192-validate/` (Node 20 baseline + `npm run security:deps`).

## CI Evidence (completed)
- Run URL: https://github.com/Agroasys/Cotsel/actions/runs/22680495629
- Artifacts:
  - `ci-report-docs-profile-guard`
  - `ci-report-env-profile-regression`
  - `ci-report-asset-fee-path`
  - `ci-report-postgres-recovery-smoke`
  - `ci-report-arch-roadmap-consistency`
  - `ci-report-staging-e2e-real-gate`
  - `ci-report-notifications-gate`
  - `ci-report-reconciliation-report`
  - `ci-report-release-gate`
