### PR TITLE
ci(dependabot): ignore chai semver-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,9 @@ updates:
       - dependency-name: "solidity-coverage"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "chai"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-runtime:
         patterns:


### PR DESCRIPTION
## Summary
- Add a Dependabot ignore rule for `chai` semver-major updates.
- Prevent reopening of known-breaking Chai 6 major bump PRs against current Hardhat matcher stack.
- Keep minor/patch updates for `chai` available.

## Why
- PR #205 showed that upgrading `chai` from 4.x to 6.x breaks contract test matcher compatibility (`emit` / `revertedWith`) and fails `ci/contracts` + release-gate.
- This is a controlled risk-reduction step until a planned Chai-major migration is executed.

## Scope
- `.github/dependabot.yml` only.
- No runtime, protocol, or on-chain behavior changes.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot.yml: OK'"`

## Rollback
- Revert this commit to re-enable major `chai` Dependabot PRs.
