### PR TITLE
fix(gateway): scope approval intents to signer wallets

### DIFF
--- a/gateway/src/core/governanceMutationService.ts
+++ b/gateway/src/core/governanceMutationService.ts
@@ -169,6 +169,7 @@ export class GovernanceMutationService {
       targetAddress: input.targetAddress ?? null,
       tradeId: input.tradeId ?? null,
       chainId: this.config.chainId,
+      approverWallet: input.principal.session.walletAddress,
     });
     const actionId = randomUUID();
 

--- a/gateway/src/core/governanceStore.ts
+++ b/gateway/src/core/governanceStore.ts
@@ -36,6 +36,12 @@ export const GOVERNANCE_OPEN_INTENT_STATUSES: readonly GovernanceActionStatus[] 
   'approved',
 ] as const;
 
+export const GOVERNANCE_APPROVAL_CONTRACT_METHODS = [
+  'approveUnpause',
+  'approveTreasuryPayoutAddressUpdate',
+  'approveOracleUpdate',
+] as const;
+
 export interface EvidenceLink {
   kind: 'runbook' | 'incident' | 'ticket' | 'tx' | 'event' | 'document' | 'log' | 'dashboard' | 'other';
   uri: string;
@@ -144,6 +150,10 @@ function normalizeIntentFragment(value: string | number | null | undefined): str
   return String(value).trim().toLowerCase();
 }
 
+export function isApprovalGovernanceContractMethod(contractMethod: string): boolean {
+  return (GOVERNANCE_APPROVAL_CONTRACT_METHODS as readonly string[]).includes(contractMethod);
+}
+
 export function buildGovernanceIntentKey(input: {
   category: GovernanceActionCategory;
   contractMethod: string;
@@ -151,6 +161,7 @@ export function buildGovernanceIntentKey(input: {
   targetAddress?: string | null;
   tradeId?: string | null;
   chainId?: string | number | null;
+  approverWallet?: string | null;
 }): string {
   return [
     'v1',
@@ -160,6 +171,11 @@ export function buildGovernanceIntentKey(input: {
     normalizeIntentFragment(input.targetAddress),
     normalizeIntentFragment(input.tradeId),
     normalizeIntentFragment(input.chainId),
+    normalizeIntentFragment(
+      isApprovalGovernanceContractMethod(input.contractMethod)
+        ? input.approverWallet ?? null
+        : null,
+    ),
   ].join('|');
 }
 
@@ -192,6 +208,7 @@ function mapRow(row: GovernanceActionRow): GovernanceActionRecord {
       targetAddress: row.targetAddress,
       tradeId: row.tradeId,
       chainId: row.chainId,
+      approverWallet: row.actorWallet,
     }),
     proposalId: numericOrNull(row.proposalId),
     category: row.category,

--- a/gateway/src/executor/governanceExecutor.ts
+++ b/gateway/src/executor/governanceExecutor.ts
@@ -9,6 +9,7 @@ import {
   GovernanceActionRecord,
   GovernanceActionStatus,
   GovernanceActionStore,
+  isApprovalGovernanceContractMethod,
   isExpiredRequestedGovernanceAction,
 } from '../core/governanceStore';
 import {
@@ -58,6 +59,10 @@ function fallbackPostExecutionStatus(action: GovernanceActionRecord): Governance
 
 function isTimeoutError(error: unknown): boolean {
   return error instanceof GatewayError && error.details?.cause === 'timeout';
+}
+
+function normalizeWalletAddress(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
 }
 
 async function resolveProposalStatus(
@@ -167,6 +172,42 @@ export class GovernanceExecutorService {
         );
       } catch (error) {
         return this.persistFailure(existing, requestId, correlationId, executorWallet, error);
+      }
+
+      if (isApprovalGovernanceContractMethod(existing.contractMethod)) {
+        const expectedApproverWallet = normalizeWalletAddress(existing.audit.actorWallet);
+        const actualExecutorWallet = normalizeWalletAddress(executorWallet);
+
+        if (!expectedApproverWallet) {
+          throw new GatewayError(500, 'INTERNAL_ERROR', 'Queued approval action is missing the approver wallet');
+        }
+
+        if (expectedApproverWallet !== actualExecutorWallet) {
+          await this.auditLogStore.append({
+            eventType: 'governance.action.execution.rejected',
+            route: '/internal/executor/governance-actions/:actionId',
+            method: 'EXECUTE',
+            requestId,
+            correlationId: correlationId ?? null,
+            actorWalletAddress: executorWallet,
+            actorRole: 'executor',
+            status: existing.status,
+            metadata: {
+              actionId,
+              contractMethod: existing.contractMethod,
+              expectedApproverWallet,
+              executorWallet,
+              reasonCode: 'EXECUTOR_SIGNER_MISMATCH',
+            },
+          });
+
+          throw new GatewayError(409, 'CONFLICT', 'Executor signer does not match the queued approval approver wallet', {
+            actionId,
+            contractMethod: existing.contractMethod,
+            expectedApproverWallet,
+            executorWallet,
+          });
+        }
       }
 
       await this.auditLogStore.append({

--- a/gateway/tests/governanceExecutor.test.ts
+++ b/gateway/tests/governanceExecutor.test.ts
@@ -202,6 +202,10 @@ describe('GovernanceExecutorService', () => {
         category: 'oracle_update',
         contractMethod: 'approveOracleUpdate',
         targetAddress: '0x0000000000000000000000000000000000000044',
+        audit: {
+          ...buildAction().audit,
+          actorWallet: '0x0000000000000000000000000000000000000e11',
+        },
       }),
     ]);
     const reader = createReader({
@@ -228,6 +232,64 @@ describe('GovernanceExecutorService', () => {
 
     expect(result.status).toBe('approved');
     expect(result.txHash).toBe('0xabc123');
+  });
+
+  test('rejects approval execution when executor signer does not match the queued approver wallet', async () => {
+    const store = createInMemoryGovernanceActionStore([
+      buildAction({
+        actionId: 'action-approve-oracle-mismatch',
+        proposalId: 7,
+        category: 'oracle_update',
+        contractMethod: 'approveOracleUpdate',
+        targetAddress: '0x0000000000000000000000000000000000000044',
+        intentKey: buildGovernanceIntentKey({
+          category: 'oracle_update',
+          contractMethod: 'approveOracleUpdate',
+          proposalId: 7,
+          targetAddress: '0x0000000000000000000000000000000000000044',
+          chainId: '31337',
+          approverWallet: '0x00000000000000000000000000000000000000aa',
+        }),
+      }),
+    ]);
+    const auditLogStore = createInMemoryAuditLogStore();
+    const executor = createExecutor({
+      getSignerAddress: jest.fn(async () => '0x00000000000000000000000000000000000000ff'),
+    });
+    const service = new GovernanceExecutorService(
+      store,
+      createPassthroughGovernanceWriteStore(store, auditLogStore),
+      auditLogStore,
+      createReader(),
+      createInMemoryGovernanceExecutionLock(),
+      executor,
+    );
+
+    await expect(service.executeAction('action-approve-oracle-mismatch', 'executor-req-mismatch'))
+      .rejects
+      .toMatchObject({
+        statusCode: 409,
+        code: 'CONFLICT',
+        details: expect.objectContaining({
+          actionId: 'action-approve-oracle-mismatch',
+          expectedApproverWallet: '0x00000000000000000000000000000000000000aa',
+          executorWallet: '0x00000000000000000000000000000000000000ff',
+        }),
+      });
+
+    expect(executor.execute).not.toHaveBeenCalled();
+    const stored = await store.get('action-approve-oracle-mismatch');
+    expect(stored?.status).toBe('requested');
+    expect(stored?.txHash).toBeNull();
+    expect(auditLogStore.entries).toHaveLength(1);
+    expect(auditLogStore.entries[0]).toMatchObject({
+      eventType: 'governance.action.execution.rejected',
+      status: 'requested',
+      metadata: expect.objectContaining({
+        actionId: 'action-approve-oracle-mismatch',
+        reasonCode: 'EXECUTOR_SIGNER_MISMATCH',
+      }),
+    });
   });
 
   test('marks failed actions and appends a failure audit log when execution fails', async () => {
@@ -428,6 +490,10 @@ describe('GovernanceExecutorService', () => {
         proposalId: 7,
         category: 'oracle_update',
         contractMethod: 'approveOracleUpdate',
+        audit: {
+          ...buildAction().audit,
+          actorWallet: '0x0000000000000000000000000000000000000e11',
+        },
       }),
     ]);
     const auditLogStore = createInMemoryAuditLogStore();

--- a/gateway/tests/governanceMutations.contract.test.ts
+++ b/gateway/tests/governanceMutations.contract.test.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import { createApp } from '../src/app';
 import type { GatewayConfig } from '../src/config/env';
 import type { AuthSessionClient } from '../src/core/authSessionClient';
+import type { AuthSession } from '../src/core/authSessionClient';
 import { createInMemoryAuditLogStore } from '../src/core/auditLogStore';
 import {
   createInMemoryGovernanceActionStore,
@@ -101,6 +102,7 @@ interface StartServerOptions {
   sessionRole?: 'admin' | 'buyer' | null;
   enableMutations?: boolean;
   writeAllowlist?: string[];
+  sessionFixtures?: Record<string, AuthSession | null>;
   configureReader?: (reader: jest.Mocked<GovernanceMutationPreflightReader>) => void;
 }
 
@@ -124,20 +126,53 @@ async function startServer(options: StartServerOptions = {}) {
   };
   options.configureReader?.(governanceReader);
 
+  const defaultSessionFixtures: Record<string, AuthSession> = {
+    'sess-admin': {
+      userId: 'uid-admin',
+      walletAddress: '0x00000000000000000000000000000000000000aa',
+      role: 'admin',
+      email: 'admin@agroasys.io',
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    },
+    'sess-admin-2': {
+      userId: 'uid-admin-2',
+      walletAddress: '0x00000000000000000000000000000000000000ac',
+      role: 'admin',
+      email: 'admin2@agroasys.io',
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    },
+    'sess-buyer': {
+      userId: 'uid-buyer',
+      walletAddress: '0x00000000000000000000000000000000000000bb',
+      role: 'buyer',
+      email: 'buyer@agroasys.io',
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    },
+  };
+
   const authSessionClient: AuthSessionClient = {
-    resolveSession: jest.fn().mockImplementation(async () => {
+    resolveSession: jest.fn().mockImplementation(async (token: string) => {
       if (options.sessionRole === null) {
         return null;
       }
 
-      const role = options.sessionRole ?? 'admin';
+      if (options.sessionRole) {
+        const fixture = options.sessionRole === 'admin'
+          ? defaultSessionFixtures['sess-admin']
+          : defaultSessionFixtures['sess-buyer'];
+        return { ...fixture, issuedAt: Date.now(), expiresAt: Date.now() + 60_000 };
+      }
+
+      const fixture = options.sessionFixtures?.[token] ?? defaultSessionFixtures[token];
+      if (!fixture) {
+        return null;
+      }
+
       return {
-        userId: role === 'admin' ? 'uid-admin' : 'uid-buyer',
-        walletAddress: role === 'admin'
-          ? '0x00000000000000000000000000000000000000aa'
-          : '0x00000000000000000000000000000000000000bb',
-        role,
-        email: role === 'admin' ? 'admin@agroasys.io' : 'buyer@agroasys.io',
+        ...fixture,
         issuedAt: Date.now(),
         expiresAt: Date.now() + 60_000,
       };
@@ -539,6 +574,66 @@ describe('gateway governance mutation routes contract', () => {
       expect(auditLogStore.entries.map((entry) => entry.eventType)).toEqual([
         'governance.action.queued',
         'governance.action.duplicate_reused',
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('approval actions keep separate queued intents for different admin wallets', async () => {
+    const { server, baseUrl, governanceActionStore, auditLogStore } = await startServer({
+      writeAllowlist: ['uid-admin', 'uid-admin-2'],
+      configureReader(reader) {
+        reader.getOracleProposalState.mockResolvedValue(buildProposalState({
+          proposalId: 7,
+          approvalCount: 1,
+          expired: false,
+          cancelled: false,
+          executed: false,
+        }));
+        reader.hasApprovedOracleProposal.mockResolvedValue(false);
+      },
+    });
+
+    try {
+      const body = JSON.stringify(buildAuditBody());
+
+      const first = await fetch(`${baseUrl}/governance/oracle/proposals/7/approve`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sess-admin',
+          'content-type': 'application/json',
+          'Idempotency-Key': 'idem-approve-oracle-1',
+        },
+        body,
+      });
+      const firstPayload = await first.json();
+
+      const second = await fetch(`${baseUrl}/governance/oracle/proposals/7/approve`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sess-admin-2',
+          'content-type': 'application/json',
+          'Idempotency-Key': 'idem-approve-oracle-2',
+        },
+        body,
+      });
+      const secondPayload = await second.json();
+
+      expect(first.status).toBe(202);
+      expect(second.status).toBe(202);
+      expect(firstPayload.data.actionId).not.toBe(secondPayload.data.actionId);
+      expect(firstPayload.data.intentKey).not.toBe(secondPayload.data.intentKey);
+
+      const stored = await governanceActionStore.list({ limit: 10 });
+      expect(stored.items).toHaveLength(2);
+      expect(stored.items.map((action) => action.audit.actorWallet)).toEqual(expect.arrayContaining([
+        '0x00000000000000000000000000000000000000aa',
+        '0x00000000000000000000000000000000000000ac',
+      ]));
+      expect(auditLogStore.entries.map((entry) => entry.eventType)).toEqual([
+        'governance.action.queued',
+        'governance.action.queued',
       ]);
     } finally {
       server.close();


### PR DESCRIPTION
## Summary
- scope approval-action intent dedupe to the intended approver wallet instead of collapsing all approvals for the same proposal
- enforce executor signer/wallet matching for queued approval actions
- add regression coverage for multi-admin approval queueing and signer mismatch rejection

## Why
The queue dedupe added in #223 was correct for single-intent governance actions, but too coarse for approval actions when quorum is greater than one. Multiple distinct approvers for the same proposal could collapse into one open queued action.

## Safety
- no new endpoints
- no protocol/on-chain logic changes
- signer model remains unchanged (`GATEWAY_EXECUTOR_PRIVATE_KEY`)
- change is limited to approval-intent derivation and executor validation

## Validation
- Node 20
- `npm --prefix gateway run lint`
- `npm --prefix gateway test -- --runTestsByPath tests/governanceMutations.contract.test.ts tests/governanceExecutor.test.ts`
- `npm run lint --workspaces --if-present`
- `npm run test --workspaces --if-present`
- `npm run -w gateway build`

## Rollback
Revert this PR to restore the previous approval-intent behavior.