### PR TITLE
fix(ci): accept strict tx-backed deploy verification

### DIFF
--- a/scripts/lib/polkavm-deploy-verify-smoke.mjs
+++ b/scripts/lib/polkavm-deploy-verify-smoke.mjs
@@ -1,8 +1,25 @@
+import { getCreateAddress } from "ethers";
+
 function normalizeHex(value) {
   if (typeof value !== "string" || value.length === 0) {
     return "";
   }
   return value.toLowerCase();
+}
+
+function deriveCreateContractAddress(tx) {
+  if (!tx || typeof tx.from !== "string" || tx.from.length === 0 || tx.nonce == null) {
+    return null;
+  }
+
+  try {
+    return getCreateAddress({
+      from: tx.from,
+      nonce: tx.nonce,
+    });
+  } catch {
+    return null;
+  }
 }
 
 export function evaluateDeployVerificationSmoke({
@@ -22,12 +39,22 @@ export function evaluateDeployVerificationSmoke({
 }) {
   const txHashMatch = normalizeHex(tx?.hash) === normalizeHex(txHash);
   const txCreatesContract = !!tx && tx.to === null;
+  const derivedContractAddress = deriveCreateContractAddress(tx);
+  const derivedContractAddressMatch =
+    normalizeHex(derivedContractAddress) === normalizeHex(contractAddress);
   const rawReceiptFound = !!receipt;
   const rawReceiptSuccess = normalizeHex(receipt?.status) === "0x1";
   const rawReceiptContractAddressMatch =
     normalizeHex(receipt?.contractAddress) === normalizeHex(contractAddress);
   const receiptTransactionHashMatch =
     normalizeHex(receipt?.transactionHash) === normalizeHex(txHash);
+  const txFallbackUsed =
+    !!tx &&
+    txHashMatch &&
+    txCreatesContract &&
+    derivedContractAddressMatch &&
+    onChainCodeNonEmpty &&
+    bytecodeHashMatch;
 
   const receiptFallbackUsed =
     !tx &&
@@ -46,12 +73,17 @@ export function evaluateDeployVerificationSmoke({
     chainIdMatchesExpected:
       expectedChainId == null || normalizeHex(chainId) === normalizeHex(expectedChainId),
     txFound: !!tx,
-    receiptFound: rawReceiptFound || receiptFallbackUsed,
+    receiptFound: rawReceiptFound || receiptFallbackUsed || txFallbackUsed,
     txHashMatch,
-    receiptTransactionHashMatch: rawReceiptFound ? receiptTransactionHashMatch : receiptFallbackUsed,
-    receiptSuccess: rawReceiptFound ? rawReceiptSuccess : receiptFallbackUsed,
-    receiptContractAddressMatch: rawReceiptFound ? rawReceiptContractAddressMatch : receiptFallbackUsed,
+    receiptTransactionHashMatch: rawReceiptFound
+      ? receiptTransactionHashMatch
+      : receiptFallbackUsed || txFallbackUsed,
+    receiptSuccess: rawReceiptFound ? rawReceiptSuccess : receiptFallbackUsed || txFallbackUsed,
+    receiptContractAddressMatch: rawReceiptFound
+      ? rawReceiptContractAddressMatch
+      : receiptFallbackUsed || txFallbackUsed,
     txCreatesContract,
+    txDerivedContractAddressMatch: rawReceiptFound ? true : derivedContractAddressMatch,
     onChainCodeNonEmpty,
     bytecodeHashMatch,
     deployerMatchesExpected:
@@ -74,7 +106,11 @@ export function evaluateDeployVerificationSmoke({
       success: rawReceiptSuccess,
       contractAddressMatch: rawReceiptContractAddressMatch,
       transactionHashMatch: receiptTransactionHashMatch,
-      fallbackUsed: receiptFallbackUsed,
+      fallbackUsed: receiptFallbackUsed || txFallbackUsed,
+      receiptFallbackUsed,
+      txFallbackUsed,
+      txDerivedContractAddress: derivedContractAddress,
+      txDerivedContractAddressMatch: derivedContractAddressMatch,
     },
   };
 }

--- a/scripts/tests/polkavm-deploy-verify-smoke.test.mjs
+++ b/scripts/tests/polkavm-deploy-verify-smoke.test.mjs
@@ -60,6 +60,79 @@ test("passes with strict receipt-backed fallback when transaction lookup is unav
   assert.equal(result.checks.txFound, false);
   assert.equal(result.checks.receiptTransactionHashMatch, true);
   assert.equal(result.receiptDiagnostics.fallbackUsed, true);
+  assert.equal(result.receiptDiagnostics.receiptFallbackUsed, true);
+  assert.equal(result.receiptDiagnostics.txFallbackUsed, false);
+});
+
+test("passes with strict transaction-backed fallback when receipt lookup is unavailable", () => {
+  const result = evaluateDeployVerificationSmoke({
+    runtimeTarget: "paseo-asset-hub-revive",
+    rpcClientVersion: "eth-rpc/test",
+    rpcClientVersionError: null,
+    chainId: "0x190f1b41",
+    expectedChainId: "0x190f1b41",
+    tx: {
+      hash: "0xaaa111",
+      to: null,
+      from: "0x1111111111111111111111111111111111111111",
+      nonce: "0x5",
+    },
+    txHash: "0xaaa111",
+    receipt: null,
+    contractAddress: "0xa0BCB2140DcE5CF8DD708C6C2174248B8E4279c0",
+    onChainCodeNonEmpty: true,
+    bytecodeHashMatch: true,
+    deployer: "0x1111111111111111111111111111111111111111",
+    expectedDeployer: "0x1111111111111111111111111111111111111111",
+  });
+
+  assert.equal(result.pass, true);
+  assert.deepEqual(result.failedChecks, []);
+  assert.deepEqual(result.waivedChecks, []);
+  assert.equal(result.checks.txFound, true);
+  assert.equal(result.checks.txHashMatch, true);
+  assert.equal(result.checks.txCreatesContract, true);
+  assert.equal(result.checks.txDerivedContractAddressMatch, true);
+  assert.equal(result.checks.receiptFound, true);
+  assert.equal(result.checks.receiptSuccess, true);
+  assert.equal(result.receiptDiagnostics.fallbackUsed, true);
+  assert.equal(result.receiptDiagnostics.receiptFallbackUsed, false);
+  assert.equal(result.receiptDiagnostics.txFallbackUsed, true);
+});
+
+test("fails when transaction lookup is present but does not derive the expected contract address", () => {
+  const result = evaluateDeployVerificationSmoke({
+    runtimeTarget: "paseo-asset-hub-revive",
+    rpcClientVersion: "eth-rpc/test",
+    rpcClientVersionError: null,
+    chainId: "0x190f1b41",
+    expectedChainId: "0x190f1b41",
+    tx: {
+      hash: "0xbbb222",
+      to: null,
+      from: "0x1111111111111111111111111111111111111111",
+      nonce: "0x5",
+    },
+    txHash: "0xbbb222",
+    receipt: null,
+    contractAddress: "0x2222222222222222222222222222222222222222",
+    onChainCodeNonEmpty: true,
+    bytecodeHashMatch: true,
+    deployer: "0x1111111111111111111111111111111111111111",
+    expectedDeployer: "0x1111111111111111111111111111111111111111",
+  });
+
+  assert.equal(result.pass, false);
+  assert.deepEqual(result.waivedChecks, []);
+  assert.deepEqual(result.failedChecks, [
+    "receiptFound",
+    "receiptTransactionHashMatch",
+    "receiptSuccess",
+    "receiptContractAddressMatch",
+    "txDerivedContractAddressMatch",
+  ]);
+  assert.equal(result.receiptDiagnostics.fallbackUsed, false);
+  assert.equal(result.receiptDiagnostics.txFallbackUsed, false);
 });
 
 test("fails when receipt lookup is present but does not prove the requested transaction", () => {


### PR DESCRIPTION
## Summary
- add a strict transaction-backed fallback when receipt lookup is unavailable but transaction lookup still proves the CREATE deployment
- keep the existing receipt-backed fallback intact
- add regression tests for the tx-backed success and mismatch paths

## Acceptance Mapping
| Requirement | Files | Evidence |
| --- | --- | --- |
| Main release-gate should not fail when RPC omits the receipt but transaction lookup still proves the deployment | `scripts/lib/polkavm-deploy-verify-smoke.mjs` | `node --test scripts/tests/polkavm-deploy-verify-smoke.test.mjs` |
| Fallback must stay strict and reject mismatched derived contract addresses | `scripts/tests/polkavm-deploy-verify-smoke.test.mjs` | failing-path test added for derived-address mismatch |
| Existing receipt-backed fallback must remain valid | `scripts/tests/polkavm-deploy-verify-smoke.test.mjs` | existing receipt fallback test still passes |

## Validation
- `node -v` -> `v20.20.0`
- `node --test scripts/tests/polkavm-deploy-verify-smoke.test.mjs`
- `npm run lint --workspaces --if-present`
- `npm run test --workspaces --if-present`
- `git diff --check`

## Why Safe
- no gateway runtime or contract logic changed
- no endpoint or schema changes
- fallback is only used when the tx itself proves the CREATE address and on-chain bytecode still matches the artifact
- receipt-backed verification remains unchanged

## Rollback
- revert this PR as a single unit
