### PR TITLE
ops(gateway): add local dashboard session smoke

### DIFF
--- a/scripts/dashboard-operator-session.mjs
+++ b/scripts/dashboard-operator-session.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { Wallet } from "ethers";
+import {
+  assertExpectedSession,
+  DEFAULT_SESSION_OUTPUT_FILE,
+  DEFAULT_TIMEOUT_MS,
+  maskSessionId,
+  normalizeTimeoutMs,
+  writeSessionArtifact,
+} from "./lib/dashboard-operator-session.mjs";
 
 const DEFAULT_AUTH_BASE_URL = "http://127.0.0.1:3005/api/auth/v1";
-const DEFAULT_TIMEOUT_MS = 8000;
 
 function fail(message) {
   console.error(`ERROR: ${message}`);
@@ -41,7 +48,7 @@ function buildUrl(baseUrl, pathname, query = {}) {
 
 async function fetchJson(url, options = {}) {
   const controller = new AbortController();
-  const timeoutMs = Number(optionalEnv("DASHBOARD_SMOKE_REQUEST_TIMEOUT_MS", String(DEFAULT_TIMEOUT_MS)));
+  const timeoutMs = normalizeTimeoutMs(optionalEnv("DASHBOARD_SMOKE_REQUEST_TIMEOUT_MS", String(DEFAULT_TIMEOUT_MS)));
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
@@ -72,6 +79,7 @@ async function fetchJson(url, options = {}) {
 
 async function main() {
   const authBaseUrl = optionalEnv("DASHBOARD_SMOKE_AUTH_BASE_URL", DEFAULT_AUTH_BASE_URL);
+  const outputPath = optionalEnv("DASHBOARD_SMOKE_SESSION_OUTPUT_FILE", DEFAULT_SESSION_OUTPUT_FILE);
   const privateKey = requiredEnv("DASHBOARD_SMOKE_PRIVATE_KEY");
   const role = optionalEnv("DASHBOARD_SMOKE_ROLE", "admin");
   const orgId = optionalEnv("DASHBOARD_SMOKE_ORG_ID", "");
@@ -109,16 +117,30 @@ async function main() {
     },
   });
   const session = sessionEnvelope?.data;
-  if (!session?.walletAddress || !session?.role) {
-    fail(`auth session payload missing required fields: ${JSON.stringify(sessionEnvelope)}`);
+  try {
+    assertExpectedSession({ session, walletAddress, role });
+  } catch (error) {
+    fail(`${error instanceof Error ? error.message : String(error)}: ${JSON.stringify(sessionEnvelope)}`);
   }
+
+  writeSessionArtifact({
+    outputPath,
+    artifact: {
+      authBaseUrl,
+      walletAddress,
+      sessionId: login.sessionId,
+      expiresAt: login.expiresAt,
+      session,
+    },
+  });
 
   process.stdout.write(
     `${JSON.stringify(
       {
         authBaseUrl,
         walletAddress,
-        sessionId: login.sessionId,
+        sessionFile: outputPath,
+        sessionIdPreview: maskSessionId(login.sessionId),
         expiresAt: login.expiresAt,
         session,
       },

--- a/scripts/lib/dashboard-operator-session.mjs
+++ b/scripts/lib/dashboard-operator-session.mjs
@@ -1,0 +1,47 @@
+import { chmodSync, writeFileSync } from "node:fs";
+
+export const DEFAULT_TIMEOUT_MS = 8000;
+export const DEFAULT_SESSION_OUTPUT_FILE = "/tmp/ctsp-dashboard-session.json";
+
+export function normalizeTimeoutMs(rawValue, fallback = DEFAULT_TIMEOUT_MS) {
+  const numericValue = Number(rawValue);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return fallback;
+  }
+
+  return Math.trunc(numericValue);
+}
+
+export function assertExpectedSession({ session, walletAddress, role }) {
+  if (!session?.walletAddress || !session?.role) {
+    throw new Error("auth session payload missing required fields");
+  }
+
+  if (session.walletAddress.toLowerCase() !== walletAddress.toLowerCase()) {
+    throw new Error(`auth session wallet mismatch: expected ${walletAddress}, received ${session.walletAddress}`);
+  }
+
+  if (session.role !== role) {
+    throw new Error(`auth session role mismatch: expected ${role}, received ${session.role}`);
+  }
+}
+
+export function maskSessionId(sessionId) {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return "missing";
+  }
+
+  if (sessionId.length <= 12) {
+    return sessionId;
+  }
+
+  return `${sessionId.slice(0, 8)}...${sessionId.slice(-4)}`;
+}
+
+export function writeSessionArtifact({ outputPath, artifact }) {
+  writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(outputPath, 0o600);
+}

--- a/scripts/tests/dashboard-operator-session.test.mjs
+++ b/scripts/tests/dashboard-operator-session.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertExpectedSession,
+  DEFAULT_TIMEOUT_MS,
+  maskSessionId,
+  normalizeTimeoutMs,
+} from "../lib/dashboard-operator-session.mjs";
+
+test("normalizeTimeoutMs falls back for invalid timeout values", () => {
+  assert.equal(normalizeTimeoutMs(undefined, DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+  assert.equal(normalizeTimeoutMs("0", DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+  assert.equal(normalizeTimeoutMs("-1", DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+  assert.equal(normalizeTimeoutMs("NaN", DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+  assert.equal(normalizeTimeoutMs("1500", DEFAULT_TIMEOUT_MS), 1500);
+});
+
+test("assertExpectedSession requires the requested wallet and role", () => {
+  assert.doesNotThrow(() => {
+    assertExpectedSession({
+      walletAddress: "0x21f8a65897e4863811b7759F8EaE84650F8E031F",
+      role: "admin",
+      session: {
+        walletAddress: "0x21f8a65897e4863811b7759f8eae84650f8e031f",
+        role: "admin",
+      },
+    });
+  });
+
+  assert.throws(
+    () =>
+      assertExpectedSession({
+        walletAddress: "0x21f8a65897e4863811b7759F8EaE84650F8E031F",
+        role: "admin",
+        session: {
+          walletAddress: "0x0000000000000000000000000000000000000001",
+          role: "admin",
+        },
+      }),
+    /wallet mismatch/,
+  );
+
+  assert.throws(
+    () =>
+      assertExpectedSession({
+        walletAddress: "0x21f8a65897e4863811b7759F8EaE84650F8E031F",
+        role: "admin",
+        session: {
+          walletAddress: "0x21f8a65897e4863811b7759f8eae84650f8e031f",
+          role: "buyer",
+        },
+      }),
+    /role mismatch/,
+  );
+});
+
+test("maskSessionId redacts long bearer tokens", () => {
+  assert.equal(maskSessionId(""), "missing");
+  assert.equal(maskSessionId("shorttoken"), "shorttoken");
+  assert.equal(maskSessionId("c8911aac37ebe24cd433f73eeddec0a5afb5427bb19db0b3a746e8ef943c0252"), "c8911aac...0252");
+});


### PR DESCRIPTION
Refs #123

## Summary
- add a repeatable auth challenge/login/session smoke script for local dashboard connected validation
- keep the smoke scoped to local/docker auth sessions only
- provide a simple JSON session artifact that Cotsel-Dash can consume for connected read validation

## Validation
- `node -v` -> `v20.20.0`
- `node scripts/dashboard-operator-session.mjs` with a generated local dev key against local auth service ✅

## Why Safe
- no gateway endpoint or protocol logic changed
- no signer/executor behavior changed
- script is local validation tooling only

## Rollback
- revert this PR as a single unit
