### PR TITLE
feat(gateway): expose operator capability contract

### DIFF
--- a/docs/api/web3layer-dashboard-gateway.openapi.yml
+++ b/docs/api/web3layer-dashboard-gateway.openapi.yml
@@ -26,6 +26,7 @@ servers:
     description: Production placeholder for future gateway deployment.
 tags:
   - name: System
+  - name: Auth
   - name: Overview
   - name: Operations
   - name: Trades
@@ -80,6 +81,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
+  /auth/capabilities:
+    get:
+      tags: [Auth]
+      summary: Authenticated operator capability snapshot
+      description: |
+        Returns the backend-authoritative route and action capabilities for the current authenticated
+        session so CTSL-Dash can gate operator pages and controls from gateway truth.
+
+        This route authenticates any valid session and does not require `operator:read`. Non-admin
+        sessions therefore receive a successful response with empty gateway roles and all operator
+        capabilities set to `false`.
+
+        Write capabilities are derived from the existing gateway policy:
+        - auth role `admin` maps to `operator:read` and `operator:write`
+        - mutations also require `GATEWAY_ENABLE_MUTATIONS=true`
+        - mutations additionally require the authenticated session to match `GATEWAY_WRITE_ALLOWLIST`
+      operationId: getOperatorCapabilities
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+      responses:
+        '200':
+          description: Backend capability snapshot for the authenticated session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperatorCapabilitiesResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /overview:
     get:
       tags: [Overview]
@@ -1266,6 +1296,85 @@ components:
             sourceRepo:
               type: string
               const: Agroasys.Web3layer
+        timestamp:
+          type: string
+          format: date-time
+    AuthServiceRole:
+      type: string
+      enum: [buyer, supplier, admin, oracle]
+    GatewayRole:
+      type: string
+      enum: [operator:read, operator:write]
+    OperatorCapabilitySubject:
+      type: object
+      required: [userId, walletAddress, authRole, gatewayRoles]
+      properties:
+        userId:
+          type: string
+        walletAddress:
+          type: string
+        authRole:
+          $ref: '#/components/schemas/AuthServiceRole'
+        gatewayRoles:
+          type: array
+          items:
+            $ref: '#/components/schemas/GatewayRole'
+    OperatorRouteCapabilities:
+      type: object
+      required: [overviewRead, operationsRead, tradesRead, governanceRead, complianceRead]
+      properties:
+        overviewRead:
+          type: boolean
+        operationsRead:
+          type: boolean
+        tradesRead:
+          type: boolean
+        governanceRead:
+          type: boolean
+        complianceRead:
+          type: boolean
+    OperatorActionCapabilities:
+      type: object
+      required: [governanceWrite, complianceWrite]
+      properties:
+        governanceWrite:
+          type: boolean
+        complianceWrite:
+          type: boolean
+    OperatorWriteAccess:
+      type: object
+      required: [mutationsConfigured, allowlisted, effective]
+      properties:
+        mutationsConfigured:
+          type: boolean
+          description: True when gateway mutation routes are enabled in config.
+        allowlisted:
+          type: boolean
+          description: True when the authenticated session matches GATEWAY_WRITE_ALLOWLIST.
+        effective:
+          type: boolean
+          description: True only when the session has operator write role, mutations are enabled, and the session is allowlisted.
+    OperatorCapabilitiesSnapshot:
+      type: object
+      required: [subject, routes, actions, writeAccess]
+      properties:
+        subject:
+          $ref: '#/components/schemas/OperatorCapabilitySubject'
+        routes:
+          $ref: '#/components/schemas/OperatorRouteCapabilities'
+        actions:
+          $ref: '#/components/schemas/OperatorActionCapabilities'
+        writeAccess:
+          $ref: '#/components/schemas/OperatorWriteAccess'
+    OperatorCapabilitiesResponse:
+      type: object
+      required: [success, data, timestamp]
+      properties:
+        success:
+          type: boolean
+          const: true
+        data:
+          $ref: '#/components/schemas/OperatorCapabilitiesSnapshot'
         timestamp:
           type: string
           format: date-time

--- a/gateway/src/core/operatorCapabilities.ts
+++ b/gateway/src/core/operatorCapabilities.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { AuthServiceRole } from './authSessionClient';
+import type { GatewayConfig } from '../config/env';
+import { type GatewayPrincipal, type GatewayRole, matchesAllowlist } from '../middleware/auth';
+
+export interface OperatorRouteCapabilities {
+  overviewRead: boolean;
+  operationsRead: boolean;
+  tradesRead: boolean;
+  governanceRead: boolean;
+  complianceRead: boolean;
+}
+
+export interface OperatorActionCapabilities {
+  governanceWrite: boolean;
+  complianceWrite: boolean;
+}
+
+export interface OperatorWriteAccess {
+  mutationsConfigured: boolean;
+  allowlisted: boolean;
+  effective: boolean;
+}
+
+export interface OperatorCapabilitySubject {
+  userId: string;
+  walletAddress: string;
+  authRole: AuthServiceRole;
+  gatewayRoles: GatewayRole[];
+}
+
+export interface OperatorCapabilitySnapshot {
+  subject: OperatorCapabilitySubject;
+  routes: OperatorRouteCapabilities;
+  actions: OperatorActionCapabilities;
+  writeAccess: OperatorWriteAccess;
+}
+
+export function buildOperatorCapabilitySnapshot(
+  principal: GatewayPrincipal,
+  config: GatewayConfig,
+): OperatorCapabilitySnapshot {
+  const canReadOperatorRoutes = principal.gatewayRoles.includes('operator:read');
+  const allowlisted = matchesAllowlist(principal.session, config.writeAllowlist);
+  const canWriteOperatorActions = principal.gatewayRoles.includes('operator:write')
+    && config.enableMutations
+    && allowlisted;
+
+  return {
+    subject: {
+      userId: principal.session.userId,
+      walletAddress: principal.session.walletAddress,
+      authRole: principal.session.role,
+      gatewayRoles: principal.gatewayRoles,
+    },
+    routes: {
+      overviewRead: canReadOperatorRoutes,
+      operationsRead: canReadOperatorRoutes,
+      tradesRead: canReadOperatorRoutes,
+      governanceRead: canReadOperatorRoutes,
+      complianceRead: canReadOperatorRoutes,
+    },
+    actions: {
+      governanceWrite: canWriteOperatorActions,
+      complianceWrite: canWriteOperatorActions,
+    },
+    writeAccess: {
+      mutationsConfigured: config.enableMutations,
+      allowlisted,
+      effective: canWriteOperatorActions,
+    },
+  };
+}

--- a/gateway/src/middleware/auth.ts
+++ b/gateway/src/middleware/auth.ts
@@ -34,7 +34,7 @@ function mapGatewayRoles(session: AuthSession): GatewayRole[] {
   return [];
 }
 
-function matchesAllowlist(session: AuthSession, allowlist: string[]): boolean {
+export function matchesAllowlist(session: AuthSession, allowlist: string[]): boolean {
   if (allowlist.length === 0) {
     return false;
   }

--- a/gateway/src/routes/capabilities.ts
+++ b/gateway/src/routes/capabilities.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Router } from 'express';
+import type { GatewayConfig } from '../config/env';
+import type { AuthSessionClient } from '../core/authSessionClient';
+import { buildOperatorCapabilitySnapshot } from '../core/operatorCapabilities';
+import { GatewayError } from '../errors';
+import { createAuthenticationMiddleware } from '../middleware/auth';
+import { successResponse } from '../responses';
+
+export interface CapabilitiesRouterOptions {
+  authSessionClient: AuthSessionClient;
+  config: GatewayConfig;
+}
+
+export function createCapabilitiesRouter(options: CapabilitiesRouterOptions): Router {
+  const router = Router();
+  const authenticate = createAuthenticationMiddleware(options.authSessionClient, options.config);
+
+  router.use(authenticate);
+
+  router.get('/auth/capabilities', async (req, res, next) => {
+    try {
+      if (!req.gatewayPrincipal) {
+        throw new GatewayError(401, 'AUTH_REQUIRED', 'Authentication is required');
+      }
+
+      const snapshot = buildOperatorCapabilitySnapshot(req.gatewayPrincipal, options.config);
+      res.status(200).json(successResponse(snapshot));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -26,6 +26,7 @@ import { OperationsSummaryService } from './core/operationsSummaryService';
 import { OverviewService } from './core/overviewService';
 import { checkIndexerHealth } from './core/indexerHealthProbe';
 import { Logger } from './logging/logger';
+import { createCapabilitiesRouter } from './routes/capabilities';
 import { createComplianceRouter } from './routes/compliance';
 import { createGovernanceRouter } from './routes/governance';
 import { createGovernanceMutationRouter } from './routes/governanceMutations';
@@ -239,6 +240,10 @@ async function bootstrap(): Promise<void> {
   await runMigrations(pool);
 
   const extraRouter = Router();
+  extraRouter.use(createCapabilitiesRouter({
+    authSessionClient,
+    config,
+  }));
   extraRouter.use(createComplianceRouter({
     authSessionClient,
     config,

--- a/gateway/tests/capabilitiesRoutes.contract.test.ts
+++ b/gateway/tests/capabilitiesRoutes.contract.test.ts
@@ -1,0 +1,192 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Server } from 'http';
+import { Router } from 'express';
+import { createApp } from '../src/app';
+import type { GatewayConfig } from '../src/config/env';
+import { loadOpenApiSpec } from '../src/openapi/spec';
+import { createSchemaValidator, hasOperation } from '../src/openapi/contract';
+import { createCapabilitiesRouter } from '../src/routes/capabilities';
+import type { AuthSessionClient, AuthServiceRole } from '../src/core/authSessionClient';
+
+const baseConfig: GatewayConfig = {
+  port: 3600,
+  dbHost: 'localhost',
+  dbPort: 5432,
+  dbName: 'agroasys_gateway',
+  dbUser: 'postgres',
+  dbPassword: 'postgres',
+  authBaseUrl: 'http://127.0.0.1:3005',
+  authRequestTimeoutMs: 5000,
+  indexerGraphqlUrl: 'http://127.0.0.1:4350/graphql',
+  indexerRequestTimeoutMs: 5000,
+  rpcUrl: 'http://127.0.0.1:8545',
+  rpcFallbackUrls: [],
+  rpcReadTimeoutMs: 8000,
+  chainId: 31337,
+  escrowAddress: '0x0000000000000000000000000000000000000000',
+  enableMutations: true,
+  writeAllowlist: ['uid-admin'],
+  governanceQueueTtlSeconds: 86400,
+  settlementIngressEnabled: false,
+  settlementServiceAuthApiKeysJson: '[]',
+  settlementServiceAuthMaxSkewSeconds: 300,
+  settlementServiceAuthNonceTtlSeconds: 600,
+  settlementCallbackEnabled: false,
+  settlementCallbackRequestTimeoutMs: 5000,
+  settlementCallbackPollIntervalMs: 5000,
+  settlementCallbackMaxAttempts: 8,
+  settlementCallbackInitialBackoffMs: 2000,
+  settlementCallbackMaxBackoffMs: 60000,
+  commitSha: 'abc1234',
+  buildTime: '2026-03-14T00:00:00.000Z',
+  nodeEnv: 'test',
+};
+
+async function startServer(
+  role: AuthServiceRole | null,
+  config: GatewayConfig = baseConfig,
+) {
+  const authSessionClient: AuthSessionClient = {
+    resolveSession: jest.fn().mockImplementation(async () => {
+      if (role === null) {
+        return null;
+      }
+
+      return {
+        userId: `uid-${role}`,
+        walletAddress: '0x00000000000000000000000000000000000000aa',
+        role,
+        issuedAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+      };
+    }),
+    checkReadiness: jest.fn(),
+  };
+
+  const router = Router();
+  router.use(createCapabilitiesRouter({ authSessionClient, config }));
+
+  const app = createApp(config, {
+    version: '0.1.0',
+    commitSha: config.commitSha,
+    buildTime: config.buildTime,
+    readinessCheck: async () => [{ name: 'postgres', status: 'ok' }],
+    extraRouter: router,
+  });
+
+  const server = await new Promise<Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve server address');
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}/api/dashboard-gateway/v1`,
+  };
+}
+
+describe('gateway capabilities route contract', () => {
+  const spec = loadOpenApiSpec();
+  const validateCapabilities = createSchemaValidator(spec, '#/components/schemas/OperatorCapabilitiesResponse');
+
+  test('OpenAPI spec exposes capabilities endpoint', () => {
+    expect(hasOperation(spec, 'get', '/auth/capabilities')).toBe(true);
+  });
+
+  test('GET /auth/capabilities returns schema-valid admin capability snapshot', async () => {
+    const { server, baseUrl } = await startServer('admin');
+
+    try {
+      const response = await fetch(`${baseUrl}/auth/capabilities`, {
+        headers: { Authorization: 'Bearer sess-admin', 'x-request-id': 'req-capabilities' },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('x-request-id')).toBe('req-capabilities');
+      expect(validateCapabilities(payload)).toBe(true);
+      expect(payload.data.subject.authRole).toBe('admin');
+      expect(payload.data.subject.gatewayRoles).toEqual(['operator:read', 'operator:write']);
+      expect(payload.data.routes.overviewRead).toBe(true);
+      expect(payload.data.routes.governanceRead).toBe(true);
+      expect(payload.data.actions.governanceWrite).toBe(true);
+      expect(payload.data.actions.complianceWrite).toBe(true);
+      expect(payload.data.writeAccess).toEqual({
+        mutationsConfigured: true,
+        allowlisted: true,
+        effective: true,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('GET /auth/capabilities returns explicit no-operator snapshot for buyer sessions', async () => {
+    const { server, baseUrl } = await startServer('buyer');
+
+    try {
+      const response = await fetch(`${baseUrl}/auth/capabilities`, {
+        headers: { Authorization: 'Bearer sess-buyer' },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(validateCapabilities(payload)).toBe(true);
+      expect(payload.data.subject.authRole).toBe('buyer');
+      expect(payload.data.subject.gatewayRoles).toEqual([]);
+      expect(payload.data.routes.operationsRead).toBe(false);
+      expect(payload.data.actions.governanceWrite).toBe(false);
+      expect(payload.data.actions.complianceWrite).toBe(false);
+      expect(payload.data.writeAccess).toEqual({
+        mutationsConfigured: true,
+        allowlisted: false,
+        effective: false,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('GET /auth/capabilities exposes allowlist state when mutations are disabled', async () => {
+    const { server, baseUrl } = await startServer('admin', {
+      ...baseConfig,
+      enableMutations: false,
+    });
+
+    try {
+      const response = await fetch(`${baseUrl}/auth/capabilities`, {
+        headers: { Authorization: 'Bearer sess-admin' },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(validateCapabilities(payload)).toBe(true);
+      expect(payload.data.actions.governanceWrite).toBe(false);
+      expect(payload.data.actions.complianceWrite).toBe(false);
+      expect(payload.data.writeAccess).toEqual({
+        mutationsConfigured: false,
+        allowlisted: true,
+        effective: false,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('GET /auth/capabilities enforces authentication', async () => {
+    const { server, baseUrl } = await startServer(null);
+
+    try {
+      const response = await fetch(`${baseUrl}/auth/capabilities`);
+      expect(response.status).toBe(401);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Introduces an authenticated gateway capability snapshot route to enable accurate route and action gating within the dashboard.

Key Changes:

- Added an authenticated capability snapshot route to the gateway.
- Documented the new authentication capability contract within the OpenAPI specification.
- Implemented comprehensive contract tests to verify expected behaviors across specific roles and states (Admin, Non-operator, and Mutation-disabled).

## Testing
The following verifications were executed successfully from the gateway directory:

- Linting:
`npm run lint`

- Targeted Contract & Middleware Tests:

`npm test -- --runTestsByPath tests/capabilitiesRoutes.contract.test.ts tests/authMiddleware.test.ts tests/openapiSpec.test.ts`

- Full Test Suite:

`npm test`

Closes #248