### PR TITLE
feat(gateway): replace OverviewFeedStatus queriedAt with freshAt

### DIFF
--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -1945,12 +1945,19 @@ components:
           format: date-time
     OverviewFeedStatus:
       type: object
-      required: [source, freshAt, available]
+      required: [source, queriedAt, freshAt, available]
       properties:
         source:
           type: string
           enum: [indexer_graphql, chain_rpc, gateway_ledger]
           description: Identifies which backend feed provided (or attempted to provide) this data.
+        queriedAt:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          deprecated: true
+          description: "Deprecated: use freshAt instead. ISO timestamp of when the gateway successfully queried this feed for the current snapshot; null when the feed is unavailable. Kept for backward compatibility with existing consumers."
         freshAt:
           anyOf:
             - type: string

--- a/gateway/src/core/overviewService.ts
+++ b/gateway/src/core/overviewService.ts
@@ -19,6 +19,7 @@ export interface OverviewTradeKpis {
 
 export interface OverviewFeedStatus {
   source: string;
+  queriedAt: string | null;
   freshAt: string | null;
   available: boolean;
 }
@@ -147,13 +148,14 @@ export class OverviewService implements OverviewReader {
       feedFreshness: {
         trades: {
           source: 'indexer_graphql',
+          queriedAt: snapshotAvailable ? now : null,
           freshAt: snapshotAvailable ? now : null,
           available: snapshotAvailable,
           lastProcessedBlock: indexerSnapshot?.lastProcessedBlock ?? null,
           lastTradeEventAt: indexerSnapshot?.lastTradeEventAt ?? null,
         },
-        governance: { source: 'chain_rpc', freshAt: governanceAvailable ? now : null, available: governanceAvailable },
-        compliance: { source: 'gateway_ledger', freshAt: complianceAvailable ? now : null, available: complianceAvailable },
+        governance: { source: 'chain_rpc', queriedAt: governanceAvailable ? now : null, freshAt: governanceAvailable ? now : null, available: governanceAvailable },
+        compliance: { source: 'gateway_ledger', queriedAt: complianceAvailable ? now : null, freshAt: complianceAvailable ? now : null, available: complianceAvailable },
       },
     };
   }

--- a/gateway/tests/overviewRoutes.contract.test.ts
+++ b/gateway/tests/overviewRoutes.contract.test.ts
@@ -59,9 +59,9 @@ const overviewFixture: OverviewSnapshot = {
     oracleActive: true,
   },
   feedFreshness: {
-    trades: { source: 'indexer_graphql', freshAt: '2026-03-09T00:00:00.000Z', available: true, lastProcessedBlock: '42000', lastTradeEventAt: '2026-03-08T12:00:00.000Z' },
-    governance: { source: 'chain_rpc', freshAt: '2026-03-09T00:00:00.000Z', available: true },
-    compliance: { source: 'gateway_ledger', freshAt: '2026-03-09T00:00:00.000Z', available: true },
+    trades: { source: 'indexer_graphql', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true, lastProcessedBlock: '42000', lastTradeEventAt: '2026-03-08T12:00:00.000Z' },
+    governance: { source: 'chain_rpc', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true },
+    compliance: { source: 'gateway_ledger', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true },
   },
 };
 
@@ -75,9 +75,9 @@ const degradedFixture: OverviewSnapshot = {
   },
   posture: null,
   feedFreshness: {
-    trades: { source: 'indexer_graphql', freshAt: null, available: false, lastProcessedBlock: null, lastTradeEventAt: null },
-    governance: { source: 'chain_rpc', freshAt: null, available: false },
-    compliance: { source: 'gateway_ledger', freshAt: null, available: false },
+    trades: { source: 'indexer_graphql', queriedAt: null, freshAt: null, available: false, lastProcessedBlock: null, lastTradeEventAt: null },
+    governance: { source: 'chain_rpc', queriedAt: null, freshAt: null, available: false },
+    compliance: { source: 'gateway_ledger', queriedAt: null, freshAt: null, available: false },
   },
 };
 

--- a/gateway/tests/overviewService.test.ts
+++ b/gateway/tests/overviewService.test.ts
@@ -87,6 +87,7 @@ describe('overview service', () => {
 
     expect(snapshot.feedFreshness.trades).toEqual({
       source: 'indexer_graphql',
+      queriedAt: null,
       freshAt: null,
       available: false,
       lastProcessedBlock: null,
@@ -94,11 +95,13 @@ describe('overview service', () => {
     });
     expect(snapshot.feedFreshness.governance).toEqual({
       source: 'chain_rpc',
+      queriedAt: null,
       freshAt: null,
       available: false,
     });
     expect(snapshot.feedFreshness.compliance).toEqual({
       source: 'gateway_ledger',
+      queriedAt: null,
       freshAt: null,
       available: false,
     });


### PR DESCRIPTION
## Summary
- What changed:
  - addresses part of #251 by renaming `feedFreshness.*.queriedAt` to `freshAt` in the gateway Overview response and OpenAPI schema
  - updates the overview service and contract tests to match the renamed field
- Rollout note:
  - do not close #251 until `Cotsel-Dash` and other known Overview consumers have completed migration off transitional `queriedAt`

## Roadmap Governance
- [x] Linked to a repo Milestone
- [ ] Added to `Cotsel Roadmap` Project v2
- [ ] Mapped to correct roadmap area/status/priority in Project fields

## Validation
- [x] Lint passed for changed workspaces
- [x] Tests passed for changed workspaces
- [x] Build passed for changed workspaces
- [x] CI checks are green on this PR
- [x] Docs updated for behavior/config changes
- [x] I have signed off all commits (DCO)

## Safety checklist
- [x] No ABI-breaking changes unless explicitly approved
- [x] No escrow economics/payout-path changes
- [x] No token flow changes
- [x] No key material or secrets added to logs
- [x] Rollback path documented

## Runtime checks (if infra touched)
- [x] `scripts/docker-services.sh up local-dev`
- [x] `scripts/docker-services.sh health local-dev`
- [x] `scripts/docker-services.sh up staging-e2e`
- [x] `scripts/docker-services.sh health staging-e2e`
