### PR TITLE
fix(scripts): make PolkaVM bytecode size report authoritative (#212)

### DIFF
--- a/docs/runbooks/polkavm-deploy-verification.md
+++ b/docs/runbooks/polkavm-deploy-verification.md
@@ -62,6 +62,7 @@ npm run -w contracts compile
 Bytecode size report script:
 
 ```bash
+# requires a compiled artifact at contracts/artifacts/... or an explicit --artifact override
 node scripts/polkavm-bytecode-size.mjs
 ```
 
@@ -69,6 +70,12 @@ Deterministic JSON output for CI or local verification:
 
 ```bash
 node scripts/polkavm-bytecode-size.mjs --json
+```
+
+Fixture or alternate artifact override:
+
+```bash
+node scripts/polkavm-bytecode-size.mjs --json --artifact path/to/AgroasysEscrow.json
 ```
 
 Interpretation:

--- a/scripts/polkavm-bytecode-size.mjs
+++ b/scripts/polkavm-bytecode-size.mjs
@@ -19,9 +19,36 @@ const DEPLOY_ARGS = {
 };
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const artifactPath = path.join(root, "contracts/artifacts/src/AgroasysEscrow.sol/AgroasysEscrow.json");
+const defaultArtifactPath = path.join(root, "contracts/artifacts/src/AgroasysEscrow.sol/AgroasysEscrow.json");
+const args = process.argv.slice(2);
 
-const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+function parseArtifactPath(argv) {
+  const flagIndex = argv.indexOf("--artifact");
+  if (flagIndex === -1) {
+    return defaultArtifactPath;
+  }
+
+  const rawPath = argv[flagIndex + 1];
+  if (!rawPath || rawPath.startsWith("--")) {
+    throw new Error("Missing value for --artifact");
+  }
+
+  return path.resolve(root, rawPath);
+}
+
+function loadArtifact(artifactPath) {
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(
+      `Artifact not found at ${artifactPath}. ` +
+      "Run 'npm run -w contracts compile:polkavm' first or pass --artifact <path>."
+    );
+  }
+
+  return JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+}
+
+const artifactPath = parseArtifactPath(args);
+const artifact = loadArtifact(artifactPath);
 const fmt = artifact._format ?? "unknown";
 const EVM_CAP = 49152;
 
@@ -80,7 +107,7 @@ const report = {
   exceedsByBytes,
 };
 
-if (process.argv.includes("--json")) {
+if (args.includes("--json")) {
   console.log(JSON.stringify(report, null, 2));
   process.exit(0);
 }

--- a/scripts/tests/fixtures/polkavm-bytecode-size-artifact.json
+++ b/scripts/tests/fixtures/polkavm-bytecode-size-artifact.json
@@ -1,0 +1,20 @@
+{
+  "_format": "hh-resolc-artifact-1",
+  "contractName": "AgroasysEscrow",
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        { "name": "usdcAddress", "type": "address" },
+        { "name": "oracleAddress", "type": "address" },
+        { "name": "treasuryAddress", "type": "address" },
+        { "name": "admins", "type": "address[]" },
+        { "name": "requiredApprovals", "type": "uint256" }
+      ]
+    }
+  ],
+  "bytecode": "0x60006000556001600055",
+  "deployedBytecode": {
+    "object": "0x6001600055"
+  }
+}

--- a/scripts/tests/polkavm-bytecode-size.test.mjs
+++ b/scripts/tests/polkavm-bytecode-size.test.mjs
@@ -7,8 +7,15 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const scriptPath = path.join(repoRoot, "scripts", "polkavm-bytecode-size.mjs");
+const fixtureArtifactPath = path.join(
+  repoRoot,
+  "scripts",
+  "tests",
+  "fixtures",
+  "polkavm-bytecode-size-artifact.json",
+);
 
-const stdout = execFileSync(process.execPath, [scriptPath, "--json"], {
+const stdout = execFileSync(process.execPath, [scriptPath, "--json", "--artifact", fixtureArtifactPath], {
   cwd: repoRoot,
   encoding: "utf8",
 });
@@ -16,6 +23,7 @@ const stdout = execFileSync(process.execPath, [scriptPath, "--json"], {
 const report = JSON.parse(stdout);
 
 assert.equal(typeof report.format, "string");
+assert.equal(report.artifactPath, path.relative(repoRoot, fixtureArtifactPath));
 assert.equal(typeof report.runtimeBytecodeBytes, "number");
 assert.equal(typeof report.initcodeBytes, "number");
 assert.equal(typeof report.encodedArgsBytes, "number");


### PR DESCRIPTION
## Summary
- separate runtime bytecode from deploy payload reporting
- compare the EIP-3860 cap against full deploy payload size
- add deterministic `--json` output plus a fixture-backed `--artifact` regression test
- document the compiled-artifact prerequisite and explicit `--artifact` override

## Linked Issue
Closes #212

## Validation
- `node scripts/tests/polkavm-bytecode-size.test.mjs`
- `node scripts/polkavm-bytecode-size.mjs --json --artifact scripts/tests/fixtures/polkavm-bytecode-size-artifact.json`
