### PR TITLE
test(sdk): validate Web3Auth-compatible signer flow (#232)

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -55,6 +55,7 @@ All modules extend a shared **Client** base class, which handles provider initia
 
 ```
 import { BuyerSDK } from '@agroasys/sdk';
+import type { BuyerLockPayload } from '@agroasys/sdk';
 
 const config = {
   rpc: '',
@@ -65,7 +66,17 @@ const config = {
 
 const buyerSDK = new BuyerSDK(config);
 
-const result = await buyerSDK.createTrade(tradeParams, buyerSigner);
+const payload: BuyerLockPayload = {
+  supplier: '',
+  totalAmount: 0n,
+  logisticsAmount: 0n,
+  platformFeesAmount: 0n,
+  supplierFirstTranche: 0n,
+  supplierSecondTranche: 0n,
+  ricardianHash: ''
+};
+
+const result = await buyerSDK.createTrade(payload, buyerSigner);
 ```
 
 ### Recommended: external Agroasys-managed signer
@@ -80,12 +91,10 @@ That keeps:
 Example:
 
 ```ts
-import { BuyerLockPayload, BuyerSDK } from "@agroasys/sdk";
-import { ethers } from "ethers";
+import { BuyerLockPayload, BuyerSDK, createSignerFromEip1193Provider } from "@agroasys/sdk";
 
 const buyerSDK = new BuyerSDK(config);
-const provider = new ethers.BrowserProvider(agroasysManagedProvider);
-const buyerSigner = await provider.getSigner();
+const buyerSigner = await createSignerFromEip1193Provider(agroasysManagedProvider);
 const payload: BuyerLockPayload = {
   supplier: "0xSupplierAddress...",
   totalAmount: 141_500_000n,
@@ -104,6 +113,27 @@ Canonical buyer lock payload contract:
 - `TradeParameters` remains available as a backward-compatible alias.
 - Source of truth: `docs/runbooks/buyer-lock-payload.md`
 
+### Embedded-wallet / Web3Auth compatibility contract
+
+The recommended embedded-wallet path is an injected EIP-1193 provider that the
+SDK converts into an ethers signer via `createSignerFromEip1193Provider(...)`.
+
+Minimum provider capabilities required by the buyer flow:
+
+- `request({ method: "eth_chainId" })` for network verification
+- `request({ method: "eth_accounts" })` or `eth_requestAccounts` for signer resolution
+- `request({ method: "personal_sign" })` for the canonical trade signature
+- standard transaction submission support such as `eth_sendTransaction` for real approve/createTrade execution in production runtimes
+
+Deterministic compatibility harness:
+
+```bash
+npm run -w sdk test -- --runTestsByPath tests/web3AuthSignerCompatibility.test.ts
+```
+
+The harness proves that an EIP-1193/embedded-wallet signer can pass through the
+SDK lock flow, trigger allowance handling, produce the canonical signature, and
+submit the lock call through the current `BuyerSDK` assumptions.
 ### Legacy demo helper: Web3Auth wallet provider
 
 ```ts

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,6 +12,8 @@ export { RicardianClient } from './modules/ricardianClient';
 // service-to-service auth helper
 export { createServiceAuthHeaders, buildServiceAuthCanonicalString, signServiceAuthCanonicalString } from './modules/serviceAuth';
 export { createManagedRpcProvider } from './rpc/failoverProvider';
+export { createSignerFromEip1193Provider } from './wallet/eip1193';
+export type { Eip1193ProviderLike, Eip1193RequestArguments } from './wallet/eip1193';
 
 // types
 export * from './types/trade';

--- a/sdk/src/wallet/eip1193.ts
+++ b/sdk/src/wallet/eip1193.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ethers } from 'ethers';
+
+export type Eip1193RequestArguments = {
+  method: string;
+  params?: readonly unknown[] | Record<string, unknown>;
+};
+
+export type Eip1193ProviderLike = {
+  request(args: Eip1193RequestArguments): Promise<unknown>;
+};
+
+/**
+ * Build an ethers signer from an injected EIP-1193 provider such as a
+ * Web3Auth/embedded-wallet bridge.
+ *
+ * The provider must expose a `request(...)` method compatible with
+ * `ethers.BrowserProvider`. In production this means the provider must support
+ * standard chain/account access, message signing, and transaction submission
+ * methods for the flows the SDK will execute.
+ */
+export async function createSignerFromEip1193Provider(
+  provider: Eip1193ProviderLike
+): Promise<ethers.JsonRpcSigner> {
+  if (!provider || typeof provider.request !== 'function') {
+    throw new Error('EIP-1193 provider must expose a request(...) function');
+  }
+
+  const browserProvider = new ethers.BrowserProvider(provider);
+  return browserProvider.getSigner();
+}

--- a/sdk/src/wallet/wallet-provider.ts
+++ b/sdk/src/wallet/wallet-provider.ts
@@ -8,6 +8,7 @@
  */
 import { Web3Auth, WEB3AUTH_NETWORK } from '@web3auth/modal';
 import { ethers } from 'ethers';
+import { createSignerFromEip1193Provider } from './eip1193';
 
 type Web3AuthNetwork = (typeof WEB3AUTH_NETWORK)[keyof typeof WEB3AUTH_NETWORK];
 
@@ -57,8 +58,7 @@ class Web3AuthWrapper {
       throw new Error('Web3Auth provider not initialized');
     }
 
-    const provider = new ethers.BrowserProvider(this.web3auth.provider);
-    this.signer = await provider.getSigner();
+    this.signer = await createSignerFromEip1193Provider(this.web3auth.provider);
 
     return this.signer;
   }

--- a/sdk/tests/web3AuthSignerCompatibility.test.ts
+++ b/sdk/tests/web3AuthSignerCompatibility.test.ts
@@ -1,0 +1,165 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { BuyerSDK } from '../src/modules/buyerSDK';
+import { createSignerFromEip1193Provider } from '../src/wallet/eip1193';
+import { Interface } from 'ethers';
+
+const UNIT_CONFIG = {
+  rpc: 'http://127.0.0.1:8545',
+  chainId: 31337,
+  escrowAddress: '0x1000000000000000000000000000000000000001',
+  usdcAddress: '0x2000000000000000000000000000000000000002',
+};
+
+const TRADE_LOCKED_INTERFACE = new Interface([
+  'event TradeLocked(uint256 indexed tradeId,address indexed buyer,address indexed supplier,uint256 totalAmount,uint256 logisticsAmount,uint256 platformFeesAmount,uint256 supplierFirstTranche,uint256 supplierSecondTranche,bytes32 ricardianHash)',
+]);
+
+const CANONICAL_PAYLOAD = {
+  supplier: '0x1111111111111111111111111111111111111111',
+  totalAmount: 1_000_000n,
+  logisticsAmount: 100_000n,
+  platformFeesAmount: 50_000n,
+  supplierFirstTranche: 400_000n,
+  supplierSecondTranche: 450_000n,
+  ricardianHash: `0x${'a'.repeat(64)}`,
+};
+
+class FakeEip1193Provider {
+  readonly address = '0x2222222222222222222222222222222222222222';
+  readonly calls: Array<{ method: string; params?: readonly unknown[] | Record<string, unknown> }> = [];
+  private readonly signature = `0x${'1'.repeat(130)}`;
+
+  async request(args: { method: string; params?: readonly unknown[] | Record<string, unknown> }): Promise<unknown> {
+    this.calls.push(args);
+
+    switch (args.method) {
+      case 'eth_chainId':
+        return '0x7a69';
+      case 'eth_accounts':
+      case 'eth_requestAccounts':
+        return [this.address];
+      case 'personal_sign':
+        return this.signature;
+      default:
+        throw new Error(`Unhandled EIP-1193 method in test fixture: ${args.method}`);
+    }
+  }
+}
+
+function encodeTradeLockedLog(tradeId: bigint) {
+  return TRADE_LOCKED_INTERFACE.encodeEventLog(
+    TRADE_LOCKED_INTERFACE.getEvent('TradeLocked')!,
+    [
+      tradeId,
+      '0x2222222222222222222222222222222222222222',
+      CANONICAL_PAYLOAD.supplier,
+      CANONICAL_PAYLOAD.totalAmount,
+      CANONICAL_PAYLOAD.logisticsAmount,
+      CANONICAL_PAYLOAD.platformFeesAmount,
+      CANONICAL_PAYLOAD.supplierFirstTranche,
+      CANONICAL_PAYLOAD.supplierSecondTranche,
+      CANONICAL_PAYLOAD.ricardianHash,
+    ],
+  );
+}
+
+describe('Web3Auth-compatible signer validation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('createSignerFromEip1193Provider signs through personal_sign', async () => {
+    const provider = new FakeEip1193Provider();
+    const signer = await createSignerFromEip1193Provider(provider);
+
+    const address = await signer.getAddress();
+    const signature = await signer.signMessage(new TextEncoder().encode('cotsel-web3auth-check'));
+    const methods = provider.calls.map((call) => call.method);
+    const personalSignCall = provider.calls.find((call) => call.method === 'personal_sign');
+
+    expect(address).toBe(provider.address);
+    expect(signature).toBe(`0x${'1'.repeat(130)}`);
+    expect(methods.filter((method) => method === 'eth_chainId')).toHaveLength(1);
+    expect(methods.filter((method) => method === 'eth_accounts')).toHaveLength(2);
+    expect(methods.at(-1)).toBe('personal_sign');
+    expect(personalSignCall?.params).toEqual([expect.any(String), provider.address]);
+  });
+
+  test('BuyerSDK.createTrade accepts an EIP-1193 signer, auto-approves, and submits the lock flow', async () => {
+    const provider = new FakeEip1193Provider();
+    const buyerSigner = await createSignerFromEip1193Provider(provider);
+    const buyerSdk = new BuyerSDK(UNIT_CONFIG);
+
+    const encodedLog = encodeTradeLockedLog(42n);
+    const createTrade = jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: `0x${'2'.repeat(64)}`,
+        blockNumber: 456,
+        logs: [
+          {
+            address: UNIT_CONFIG.escrowAddress,
+            topics: encodedLog.topics,
+            data: encodedLog.data,
+          },
+        ],
+      }),
+    });
+
+    const connect = jest.fn().mockImplementation((signer) => {
+      expect(signer).toBe(buyerSigner);
+      return { createTrade };
+    });
+
+    (buyerSdk as any).contract = {
+      connect,
+      interface: TRADE_LOCKED_INTERFACE,
+    };
+
+    jest.spyOn(buyerSdk, 'getUSDCAllowance').mockResolvedValue(0n);
+    const approveUsdcSpy = jest.spyOn(buyerSdk, 'approveUSDC').mockResolvedValue({
+      txHash: `0x${'3'.repeat(64)}`,
+      blockNumber: 123,
+    });
+    jest.spyOn(buyerSdk, 'getBuyerNonce').mockResolvedValue(7n);
+    jest.spyOn(buyerSdk, 'getTreasuryAddress').mockResolvedValue(
+      '0x3000000000000000000000000000000000000003',
+    );
+
+    const result = await buyerSdk.createTrade(CANONICAL_PAYLOAD, buyerSigner);
+    const methods = provider.calls.map((call) => call.method);
+    const personalSignCall = provider.calls.find((call) => call.method === 'personal_sign');
+
+    expect(approveUsdcSpy).toHaveBeenCalledWith(CANONICAL_PAYLOAD.totalAmount, buyerSigner);
+    expect(connect).toHaveBeenCalledWith(buyerSigner);
+    expect(createTrade).toHaveBeenCalledTimes(1);
+    expect(createTrade).toHaveBeenCalledWith(
+      CANONICAL_PAYLOAD.supplier,
+      CANONICAL_PAYLOAD.totalAmount,
+      CANONICAL_PAYLOAD.logisticsAmount,
+      CANONICAL_PAYLOAD.platformFeesAmount,
+      CANONICAL_PAYLOAD.supplierFirstTranche,
+      CANONICAL_PAYLOAD.supplierSecondTranche,
+      CANONICAL_PAYLOAD.ricardianHash,
+      7n,
+      expect.any(Number),
+      `0x${'1'.repeat(130)}`,
+    );
+    expect(result).toEqual({
+      txHash: `0x${'2'.repeat(64)}`,
+      blockNumber: 456,
+      tradeId: '42',
+    });
+    expect(methods.filter((method) => method === 'eth_chainId')).toHaveLength(2);
+    expect(methods.filter((method) => method === 'eth_accounts')).toHaveLength(2);
+    expect(methods).toContain('personal_sign');
+    expect(personalSignCall?.params).toEqual([expect.any(String), provider.address]);
+  });
+
+  test('createSignerFromEip1193Provider rejects providers without request support', async () => {
+    await expect(
+      createSignerFromEip1193Provider({} as any),
+    ).rejects.toThrow('EIP-1193 provider must expose a request(...) function');
+  });
+});


### PR DESCRIPTION
## Summary
- add an EIP-1193 signer helper for embedded-wallet style providers
- validate address resolution, signing, approval flow, and lock submission through the buyer SDK
- document the provider compatibility contract for Web3Auth-style integrations

## Stack
- base branch: `batch/issue-231-buyer-lock-payload`

## Linked Issue
Closes #232

## Validation
- `npm run -w sdk lint`
- `npm run -w sdk test -- --runTestsByPath tests/web3AuthSignerCompatibility.test.ts tests/buyerSDK.test.ts tests/buyerLockPayloadContract.test.ts`
- `npm run -w sdk build`
