### PR TITLE
docs(observability): define standard audit envelope (#283)

### DIFF
--- a/docs/incidents/incident-evidence-template.md
+++ b/docs/incidents/incident-evidence-template.md
@@ -15,23 +15,25 @@ Use this template when a responder needs to preserve enough evidence to explain:
 - Gateway mutation incidents or control-plane safety investigations.
 - Treasury payout incidents that require containment, cancellation, or manual recovery.
 
-## Current Correlation Baseline
-Current mandatory log fields come from `docs/observability/logging-schema.md`:
+## Current Audit Envelope Baseline
+Current mandatory audit-envelope fields come from `docs/observability/logging-schema.md`:
 - `tradeId`
 - `actionKey`
 - `requestId`
+- `correlationId`
 - `txHash`
 - `traceId`
-
-Populate the following when the service surface already provides them:
-- `correlationId`
-- `actor`
 - `intent`
 - `outcome`
+
+Populate the following when the service surface already provides them:
+- `actor`
 - `blockNumber` / `extrinsicHash`
 - incident or ticket reference
 
-This template is forward-compatible with later audit-envelope standardization and should not be treated as permission to omit currently available evidence.
+If a service does not emit every field directly, source the missing values from
+the nearest authoritative request ledger, gateway action record, or operator
+evidence packet rather than leaving them implicit.
 
 ## Incident Summary
 
@@ -78,6 +80,7 @@ Populate one row per impacted action or trade.
 ## Closeout Checklist
 - [ ] Severity, owner, and impact recorded.
 - [ ] Affected `tradeId` / `actionKey` / `requestId` values captured where applicable.
+- [ ] `correlationId`, `intent`, and `outcome` captured from the authoritative source where available.
 - [ ] `traceId` and `txHash` or equivalent chain references captured where available.
 - [ ] Containment or rollback decision recorded with timestamp and owner.
 - [ ] Evidence artifacts linked for service logs, chain truth, and indexer or DB truth.

--- a/docs/observability/logging-schema.md
+++ b/docs/observability/logging-schema.md
@@ -1,23 +1,116 @@
 # Logging Schema Baseline
 
-All services should emit JSON logs with these top-level fields:
+All services should emit JSON logs with these baseline top-level fields on every
+record:
 
 - `level`
 - `timestamp`
-- `message`
 - `service`
 - `env`
-- `tradeId`
-- `actionKey`
-- `requestId`
-- `txHash`
-- `traceId`
+- `message` for standard logs, or `action` for explicit audit events
 
-## Correlation field rules
+Use `null` for fields that are not applicable. Do not omit known correlation or
+audit fields just because a specific event does not populate them.
 
-- Include all correlation fields on every log record.
-- Use `null` when a field is not applicable.
-- Never log secrets (private keys, API secrets, full HMAC signatures).
+## Standard Audit Envelope v1
+
+`AuditEnvelopeV1` is the canonical flat-field contract for audit-grade logs,
+operator evidence packets, and incident artifacts.
+
+### Required baseline fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `level` | yes | Log severity. `audit` is permitted for explicit audit records. |
+| `timestamp` | yes | ISO-8601 UTC timestamp for the emitted record. |
+| `service` | yes | Runtime owner of the event (`gateway`, `oracle`, `treasury`, `reconciliation`, etc.). |
+| `env` | yes | Runtime environment label. |
+| `message` | yes for standard logs | Human-readable event summary. |
+| `action` | yes for explicit audit events when `message` is not the primary event name | Stable audit event/action name. |
+
+Rule:
+- Every audit-grade record MUST contain at least one of `message` or `action`.
+
+### Correlation and request linkage
+
+| Field | Required when available | Meaning |
+| --- | --- | --- |
+| `tradeId` | yes | Protocol trade identifier tied to the business action. |
+| `actionKey` | yes | Stable business-action/idempotency key across retries. |
+| `requestId` | yes | Request-scoped identifier for one concrete API/job execution. |
+| `correlationId` | yes | Stable cross-service correlation ID linking related requests and operator actions. |
+| `traceId` | yes | Transport or ingress trace identifier. |
+
+Rules:
+- Keep `requestId` stable across retries for the same submitted request.
+- Keep `actionKey` stable across retries for the same business intent.
+- `correlationId` should outlive any single retry and link dashboard/gateway,
+  service, and incident artifacts.
+
+### Actor, intent, and outcome fields
+
+| Field | Required when available | Meaning |
+| --- | --- | --- |
+| `actorSessionId` | yes | Auth/session identity for operator or client actor. |
+| `actorUserId` | yes | Human/user principal when known. |
+| `actorWallet` | yes | Wallet address of the acting subject when known. |
+| `actorRole` | yes | Authorization role that allowed the action. |
+| `intent` | yes | Stable operator/business intent such as `create_trade`, `pause_claims`, `compliance_deny`, `reconcile_run`. |
+| `outcome` | yes | Stable result such as `requested`, `queued`, `succeeded`, `rejected`, `blocked`, `failed`, `degraded`, or `stale`. |
+
+Rules:
+- For mutating or operator-reviewed paths, `intent` and `outcome` should be
+  explicit rather than inferred from free-form text.
+- If no authenticated actor exists, set actor fields to `null`.
+
+### Chain and execution references
+
+| Field | Required when available | Meaning |
+| --- | --- | --- |
+| `txHash` | yes | On-chain transaction hash for state-changing EVM actions. |
+| `blockNumber` | yes | Block number for the finalized transaction/event when known. |
+| `chainId` | yes | Numeric chain identifier. |
+| `networkName` | yes | Human-readable network label used by operators/runbooks. |
+
+### Failure classification fields
+
+| Field | Required when available | Meaning |
+| --- | --- | --- |
+| `errorCode` | yes | Stable machine-readable classification for client/business/infra failures. |
+| `error` | yes | Normalized error summary safe for logs. |
+
+### Sensitive-data rule
+
+AuditEnvelopeV1 never permits raw secrets or full sensitive materials in logs.
+At minimum, never log:
+
+- private keys
+- seed phrases
+- API secrets
+- bearer tokens
+- full HMAC secrets or full signed canonical strings
+- raw banking details
+
+Data-classification enforcement is governed separately by the data-classification
+policy and release-gate guardrail work.
+
+## Service adoption status
+
+`AuditEnvelopeV1` is the canonical contract, but current service implementations
+do not all emit every field yet. The matrix below is the current repo truth and
+must be used during incident review instead of assuming full adoption.
+
+| Service | Current emitted baseline | Current gap against `AuditEnvelopeV1` |
+| --- | --- | --- |
+| `gateway` | `level`, `timestamp`, `message`, `service`, `env`, `requestId`, `correlationId`, `userId`, `walletAddress`, `gatewayRoles`, `route`, `method`, `statusCode`, `durationMs` via `gateway/src/logging/logger.ts` | No single shared runtime envelope yet for `tradeId`, `actionKey`, `intent`, `outcome`, or canonical actor field names; audit ledgers carry richer metadata than generic logs. |
+| `oracle` | `level`, `timestamp`, `message` or `action`, `service`, `env`, `tradeId`, `actionKey`, `requestId`, `txHash`, `traceId` via `oracle/src/utils/logger.ts` | No first-class `correlationId`; no canonical actor fields; `intent` and `outcome` remain event-specific. |
+| `treasury` | `level`, `timestamp`, `message`, `service`, `env`, `tradeId`, `actionKey`, `requestId`, `txHash`, `traceId` via `treasury/src/utils/logger.ts` | No `correlationId`, actor fields, explicit `intent`, explicit `outcome`, or chain metadata beyond `txHash`. |
+| `reconciliation` | `level`, `timestamp`, `message`, `service`, `env`, `tradeId`, `actionKey`, `requestId`, `txHash`, `chainId`, `networkName`, `traceId` via `reconciliation/src/utils/logger.ts` | No `correlationId`, actor fields, explicit `intent`, or explicit `outcome`. |
+
+Operational rule:
+- When a service does not yet emit a field directly, operators must source it
+  from the nearest authoritative ledger, request record, or incident artifact
+  rather than inventing it in post-processing.
 
 ## Metric counter names
 
@@ -33,9 +126,13 @@ The following counters are emitted through service logs as `metric` events:
 
 Terminal failures must include enough context for support triage:
 
+- `service`
+- `env`
+- `requestId`
+- `correlationId` when available
 - `tradeId` when available
 - `actionKey` when available
-- `requestId` when available
+- `traceId` when available
 - `txHash` when available
-- normalized `error` message
-- `service` and `env`
+- normalized `errorCode` and `error`
+- `outcome=failed` or `outcome=degraded`

--- a/docs/runbooks/api-gateway-boundary.md
+++ b/docs/runbooks/api-gateway-boundary.md
@@ -30,17 +30,25 @@ Rules that apply to gateway-mediated traffic:
 - For internal retries/replays, regenerate service signatures per request; do not replay stale signed headers.
 
 ## Correlation IDs + request IDs (exact fields, generation, logging expectations)
-Correlation fields must align with `docs/observability/logging-schema.md`:
+Gateway-orchestrated traffic must align with `AuditEnvelopeV1` in
+`docs/observability/logging-schema.md`.
+
+Minimum fields for boundary investigations:
 - `tradeId`
 - `actionKey`
 - `requestId`
-- `txHash`
+- `correlationId`
 - `traceId`
+- `intent`
+- `outcome`
+- `txHash` when a chain action occurs
 
 Operational rules:
 - Mutating oracle calls must include `requestId` in request body (already required by oracle API contract).
 - If ingress receives no request correlation header, generate one at ingress and attach to downstream logs as `traceId`.
+- For dashboard or operator-initiated actions, generate or preserve a stable `correlationId` that survives retries and later incident review.
 - Keep `requestId` stable across retry attempts for the same client intent; use `actionKey`/idempotency logic in downstream services to prevent duplication.
+- Populate `intent` and `outcome` explicitly in gateway-owned ledgers and incident artifacts even when downstream services still emit only the correlation baseline.
 
 ## Timeouts and retries (default ceilings; per-service overrides; retry budget)
 Current deterministic behavior in-repo:
@@ -80,13 +88,21 @@ Use this classification for deterministic handoff:
 
 ## Observability requirements (log fields, metrics, traces)
 Minimum log requirements:
-- Include correlation fields from `docs/observability/logging-schema.md`.
+- Include the `AuditEnvelopeV1` baseline from `docs/observability/logging-schema.md`.
 - Redact auth/signature secrets from logs and artifacts.
 
 Required operational evidence for gateway-boundary incidents:
 - health/readiness outputs for affected services
-- correlated logs using `tradeId`, `actionKey`, `requestId`, `txHash`, `traceId`
+- correlated logs using `tradeId`, `actionKey`, `requestId`, `correlationId`, `traceId`, and `txHash`
 - release-gate reports when incident overlaps staging validation
+
+Current adoption note:
+- `gateway` generic request logs already emit `requestId` and `correlationId`, but
+  several downstream services still expose only the correlation baseline
+  (`tradeId`, `actionKey`, `requestId`, `txHash`, `traceId`).
+- During incidents, source missing `intent`, `outcome`, and actor fields from
+  gateway ledgers or operator evidence packets rather than inferring them from
+  free-form logs.
 
 Metric references (existing schema baseline):
 - `auth_failures_total`

--- a/docs/runbooks/dashboard-api-gateway-boundary.md
+++ b/docs/runbooks/dashboard-api-gateway-boundary.md
@@ -124,12 +124,13 @@ Every gateway action must be verifiable through one or more of:
 ### Governance verification examples
 - Pause / claims pause:
   - verify gateway action status
+  - verify audit `intent` / `outcome`
   - verify transaction hash
   - verify `Paused`, `ClaimsPaused`, or `ClaimsUnpaused` event
 - Governance mutation execution model:
   - gateway persists action as `QUEUED`
   - executor process runs `npm run -w gateway execute:governance-action -- <actionId>`
-  - verify resulting action transition, audit entries, and tx hash
+  - verify resulting action transition, audit entries, explicit `outcome`, and tx hash
 - Oracle recovery:
   - verify `OracleDisabledEmergency`, `OracleUpdateProposed`, `OracleUpdateApproved`, `OracleUpdated`
   - verify `oracleAddress` and `oracleActive` read model
@@ -143,7 +144,7 @@ Every gateway action must be verifiable through one or more of:
 
 ### Compliance verification examples
 - Decision create:
-  - verify append-only decision record with provider reference, reason code, evidence links, and actor metadata
+  - verify append-only decision record with provider reference, reason code, evidence links, actor metadata, and explicit `outcome`
 - Block oracle progression:
   - verify trade block state in gateway read model
   - verify that subsequent oracle progression requests are rejected or held by orchestration policy
@@ -151,20 +152,31 @@ Every gateway action must be verifiable through one or more of:
   - verify cleared block state and linked reason/evidence
 
 ## Required audit fields for every mutation
-The gateway must persist, at minimum:
-- actor session id
-- actor wallet / subject
-- actor role
-- request id
-- correlation id
-- idempotency key
-- reason
-- evidence links
-- ticket reference
-- created at
-- requested by
-- approved by, if applicable
-- resulting tx hash / block number, if applicable
+The gateway must persist every mutation in a form that can populate
+`AuditEnvelopeV1` from `docs/observability/logging-schema.md`.
+
+Minimum persisted fields:
+- `requestId`
+- `correlationId`
+- `actionKey` or equivalent gateway action identifier
+- `actorSessionId`
+- `actorWallet`
+- `actorRole`
+- `intent`
+- `outcome`
+- `reason`
+- `evidenceLinks`
+- `ticketRef`
+- `createdAt`
+- `requestedBy`
+- `approvedBy`, if applicable
+- resulting `txHash` / `blockNumber`, if applicable
+
+Gateway-specific note:
+- The current gateway runtime already persists actor and audit metadata in its
+  ledgers, but generic request logs still use local field names such as
+  `userId`, `walletAddress`, and `gatewayRoles`.
+- Treat the ledger records as the stronger audit truth when field names diverge.
 
 ## Resolved design choices
 - The gateway is the canonical owner of dashboard-facing ledgers:

--- a/docs/runbooks/operator-audit-evidence-template.md
+++ b/docs/runbooks/operator-audit-evidence-template.md
@@ -10,22 +10,24 @@ Use this template when an operator needs an audit-ready package for:
 - treasury payout reviews and exception handling
 
 ## Evidence Field Rules
-Current mandatory correlation fields come from `docs/observability/logging-schema.md`:
+Current mandatory audit-envelope fields come from `docs/observability/logging-schema.md`:
 - `tradeId`
 - `actionKey`
 - `requestId`
+- `correlationId`
 - `txHash`
 - `traceId`
-
-Additional fields should be populated when available from the service boundary:
-- `correlationId`
-- `actor`
 - `intent`
 - `outcome`
+
+Additional fields should be populated when available from the service boundary:
+- `actor`
 - `blockNumber` or `extrinsicHash`
 - approval or ticket reference
 
 If a field is not available for the workflow, record `N/A` instead of leaving it blank.
+If the runtime logger does not emit a field directly, source it from the nearest
+authoritative gateway ledger, request record, or operator evidence source.
 
 ## Audit Packet Header
 
@@ -62,8 +64,8 @@ If a field is not available for the workflow, record `N/A` instead of leaving it
 | `<name>` | `<approved / rejected / requires follow-up>` | `<timestamp>` | `<notes>` |
 
 ## Closeout Checklist
-- [ ] Core correlation fields captured from current logging baseline.
-- [ ] `actor`, `intent`, and `outcome` populated when the service boundary exposes them.
+- [ ] Core `AuditEnvelopeV1` fields captured from current logging or ledger baseline.
+- [ ] `actor`, `intent`, and `outcome` populated from the authoritative service or ledger source.
 - [ ] On-chain or extrinsic reference attached where a state-changing action occurred.
 - [ ] Approval or escalation references attached.
 - [ ] Links to service logs and supporting artifacts included.

--- a/docs/runbooks/reconciliation.md
+++ b/docs/runbooks/reconciliation.md
@@ -69,6 +69,24 @@ Severity mapping is deterministic by code path:
 - `HIGH`: status mismatch
 - `MEDIUM`: arrival timestamp mismatch
 
+## Audit envelope expectations
+Reconciliation evidence must align with `AuditEnvelopeV1` in
+`docs/observability/logging-schema.md`.
+
+Current runtime truth:
+- `reconciliation/src/utils/logger.ts` already emits `tradeId`, `actionKey`,
+  `requestId`, `txHash`, `chainId`, `networkName`, and `traceId`.
+- Reconciliation does not yet emit first-class `correlationId`, actor fields,
+  `intent`, or `outcome` on every log line.
+
+Operator rule:
+- When reconciliation output is used for incident or treasury follow-up, attach
+  missing `correlationId`, actor context, `intent`, and `outcome` from the
+  nearest authoritative request ledger, gateway action, or operator evidence
+  packet.
+- Do not infer a terminal result from free-form text alone; record an explicit
+  `outcome` in the incident or operator evidence artifact.
+
 ## Treasury Sweep Reconciliation Invariants
 
 When pull-over-push treasury sweep is enabled, use these deterministic checks:
@@ -176,6 +194,8 @@ CI artifact name:
 ## First 15 Minutes Checklist
 - Execute `docs/incidents/first-15-minutes-checklist.md`.
 - Capture reconciliation logs and identify affected `tradeId`/`requestId` pairs.
+- Capture `correlationId`, `intent`, and `outcome` from the upstream gateway or
+  operator evidence source when the reconciliation logger does not emit them directly.
 - Confirm whether failure source is RPC, indexer GraphQL, or DB.
 - Start `docs/incidents/incident-evidence-template.md` for any mismatch that requires containment or operator escalation.
 - Use `docs/runbooks/operator-audit-evidence-template.md` when reconciliation output drives an operator approval or treasury follow-up.


### PR DESCRIPTION
## Summary
- define a canonical `AuditEnvelopeV1` contract
- align gateway and reconciliation runbooks to the same audit field set
- add adoption notes to keep gaps explicit

## Linked Issue
Closes #283

## Validation
- `bash scripts/tests/api-gateway-boundary-guard.sh`
