### PR TITLE
docs(compliance): define off-chain attestation reference contract (#285)

### DIFF
--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -1508,7 +1508,8 @@ paths:
 
         The gateway owns the append-only compliance decision ledger in its Postgres database. Provider
         integrations remain out of scope; this endpoint records the authoritative control-plane decision
-        used by the dashboard and gateway orchestration path.
+        used by the dashboard and gateway orchestration path. Off-chain attestation reference semantics
+        used by later read surfaces are defined separately in `#/components/schemas/AttestationReference`.
       operationId: createComplianceDecision
       parameters:
         - $ref: '#/components/parameters/XRequestId'
@@ -4228,6 +4229,83 @@ components:
           type: string
         audit:
           $ref: '#/components/schemas/MutationAuditInput'
+    AttestationStatus:
+      type: string
+      enum: [active, revoked, expired, unknown]
+      description: |
+        Canonical reference-state values for externally issued attestations.
+        Verification freshness and outage handling are defined by the compliance
+        runbooks and are intentionally separate from this schema-only status contract.
+    AttestationIssuerRef:
+      type: object
+      required: [id, kind]
+      properties:
+        id:
+          type: string
+          description: Stable identifier for the issuer or integrating system.
+        kind:
+          type: string
+          enum: [provider, service, operator, partner]
+          description: Issuer class for the attestation boundary.
+        displayName:
+          type: string
+          nullable: true
+          description: Optional operator-facing label for the issuer.
+    AttestationSubjectRef:
+      type: object
+      required: [type, reference]
+      properties:
+        type:
+          type: string
+          description: Scoped subject class such as `business`, `wallet`, `trade`, or `shipment`.
+        reference:
+          type: string
+          description: Stable bounded subject reference. Must not contain raw PII or full provider dossiers.
+    AttestationReference:
+      type: object
+      description: |
+        Canonical off-chain attestation reference contract for operator surfaces.
+        This schema intentionally carries only reference metadata and not the raw
+        attestation payload.
+      required:
+        - attestationId
+        - attestationType
+        - status
+        - issuer
+        - subjectRef
+        - issuedAt
+        - providerRef
+        - evidenceRef
+      properties:
+        attestationId:
+          type: string
+          description: Stable identifier for the attestation in the issuing or integrating system.
+        attestationType:
+          type: string
+          description: Bounded attestation category such as `kyb`, `kyt`, `sanctions_clearance`, or `inspection`.
+        status:
+          $ref: '#/components/schemas/AttestationStatus'
+        issuer:
+          $ref: '#/components/schemas/AttestationIssuerRef'
+        subjectRef:
+          $ref: '#/components/schemas/AttestationSubjectRef'
+        issuedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        providerRef:
+          type: string
+          description: Provider or issuer lookup reference used for revalidation.
+        evidenceRef:
+          type: string
+          description: Immutable evidence bundle or document reference linked to the attestation.
+        referenceHash:
+          type: string
+          nullable: true
+          description: Optional digest of the external attestation statement or evidence bundle.
     ComplianceDecisionType:
       type: string
       enum: [KYB, KYT, SANCTIONS]

--- a/docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md
+++ b/docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md
@@ -30,6 +30,38 @@ Policy authority:
   - Compliance Lead: Aston
   - Incident Commander: Aston
 
+## Off-chain attestation reference contract
+This runbook is the canonical repository source for the off-chain attestation
+reference contract described by ADR-0143.
+
+Attestation references are permitted only as minimal metadata pointers. They do
+not authorize placing full provider payloads or identity dossiers inside Cotsel
+logs, runbooks, or on-chain state.
+
+Minimum attestation reference fields:
+- `attestationId`: stable identifier for the attestation record in the issuing or integrating system.
+- `attestationType`: category such as `kyb`, `kyt`, `sanctions_clearance`, `inspection`, or another bounded operator-approved type.
+- `status`: last issuer- or integrator-reported state for the attestation reference.
+- `issuer`: who issued the attestation, including stable issuer ID and issuer kind.
+- `subjectRef`: stable reference to the checked subject or settlement object; this must be a pointer, not a raw dossier.
+- `issuedAt`: timestamp when the attestation was issued or captured.
+- `expiresAt`: optional expiry timestamp when the attestation stops being valid for fresh verification.
+- `providerRef`: issuer or provider lookup reference used to re-fetch or re-verify the attestation.
+- `evidenceRef`: immutable evidence bundle or document reference linked to the attestation.
+- `referenceHash`: optional digest of the external attestation statement or evidence bundle when hash linkage is available.
+
+Reference semantics:
+- `issuer.id` is the stable system or operator identifier that owns the attestation decision.
+- `issuer.kind` distinguishes `provider`, `service`, `operator`, or `partner` issuance paths.
+- `subjectRef.reference` must remain bounded and non-sensitive; use provider-scoped IDs, document refs, or trade-linked refs instead of raw PII.
+- `providerRef` is for revalidation lookup, not for displaying raw provider payloads.
+- `evidenceRef` points to the supporting evidence artifact and may resolve to a ticket, document hash bundle, or operator evidence packet.
+- `referenceHash` is additive and should be used when the integrator can bind the attestation to a deterministic external statement.
+
+Contract mirror:
+- OpenAPI component: `#/components/schemas/AttestationReference`
+- ADR boundary: `docs/adr/adr-0143-privacy-attestation-composability.md`
+
 ## Decision contract (allow/deny semantics)
 
 ### Input contract for every compliance decision
@@ -171,3 +203,4 @@ Pilot role mapping:
 - `docs/runbooks/api-gateway-boundary.md`
 - `docs/observability/logging-schema.md`
 - `docs/runbooks/production-readiness-checklist.md`
+- `docs/adr/adr-0143-privacy-attestation-composability.md`


### PR DESCRIPTION
## Summary
- define the canonical off-chain attestation reference schema
- align the compliance boundary runbook and gateway OpenAPI contract
- make issuer, subject, expiry, evidence, and status semantics explicit

## Linked Issue
Closes #285

## Validation
- `npm run -w gateway test -- --runInBand tests/openapiSpec.test.ts tests/compliance.contract.test.ts`
