### PR TITLE
test(auth): add webhook authenticity and replay fixtures (#289)

### DIFF
--- a/docs/runbooks/oracle-redrive.md
+++ b/docs/runbooks/oracle-redrive.md
@@ -8,6 +8,13 @@ Gateway-boundary handoff: when failures indicate routing/auth propagation/correl
 Automation-governance source of truth:
 - `docs/runbooks/programmability-governance.md`
 
+Webhook authenticity and replay regression fixtures:
+- `oracle/tests/hmac-middleware.test.ts`
+- `oracle/tests/authenticated-routes.test.ts`
+- `treasury/tests/authMiddleware.test.ts`
+- `treasury/tests/replayProtection.test.ts`
+- `treasury/tests/serviceAuthRoutes.test.ts`
+
 ## Ownership And Intervention Rules
 - `Operator`:
   - Runs health/diagnostic checks.

--- a/oracle/tests/authenticated-routes.test.ts
+++ b/oracle/tests/authenticated-routes.test.ts
@@ -1,0 +1,210 @@
+import express, { Request, Response } from 'express';
+import { AddressInfo } from 'net';
+import { Server } from 'http';
+import { createRouter } from '../src/api/routes';
+import { generateRequestHash } from '../src/utils/crypto';
+import { consumeHmacNonce } from '../src/database/queries';
+
+jest.mock('../src/config', () => ({
+  config: {
+    apiKey: 'test-api-key',
+    hmacSecret: 'test-hmac-secret',
+    hmacNonceTtlSeconds: 600,
+  },
+}));
+
+jest.mock('../src/database/queries', () => ({
+  consumeHmacNonce: jest.fn(),
+}));
+
+function createSignedHeaders(body: Record<string, unknown>, overrides?: {
+  timestamp?: string;
+  signature?: string;
+  nonce?: string;
+  authorization?: string;
+}) {
+  const timestamp = overrides?.timestamp ?? Date.now().toString();
+  const authorization = overrides?.authorization ?? 'Bearer test-api-key';
+  const bodyText = JSON.stringify(body);
+  const signature =
+    overrides?.signature ?? generateRequestHash(timestamp, bodyText, 'test-hmac-secret');
+
+  const headers: Record<string, string> = {
+    authorization,
+    'content-type': 'application/json',
+    'x-timestamp': timestamp,
+    'x-signature': signature,
+  };
+
+  if (overrides?.nonce !== undefined) {
+    headers['x-nonce'] = overrides.nonce;
+  }
+
+  return headers;
+}
+
+describe('oracle authenticated routes', () => {
+  const mockConsumeHmacNonce = consumeHmacNonce as jest.MockedFunction<typeof consumeHmacNonce>;
+  let server: Server;
+  let baseUrl: string;
+  const controller = {
+    releaseStage1: async (req: Request, res: Response) => {
+      res.status(200).json({
+        success: true,
+        route: 'release-stage1',
+        requestHash: req.hmacSignature,
+        nonce: req.hmacNonce,
+      });
+    },
+    confirmArrival: async (_req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    },
+    finalizeTrade: async (_req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    },
+    redriveTrigger: async (_req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    },
+    approveTrigger: async (_req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    },
+    rejectTrigger: async (_req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/oracle', createRouter(controller as never));
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  test('valid signed request reaches protected release route once', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = { tradeId: 'trade-1', requestId: 'req-1' };
+
+    const response = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-route-nonce' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        route: 'release-stage1',
+        nonce: 'oracle-route-nonce',
+        requestHash: expect.any(String),
+      }),
+    );
+    expect(mockConsumeHmacNonce).toHaveBeenCalledWith('test-api-key', 'oracle-route-nonce', 600);
+  });
+
+  test('replayed signed request is rejected before controller runs', async () => {
+    mockConsumeHmacNonce.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const payload = { tradeId: 'trade-2', requestId: 'req-2' };
+    const headers = createSignedHeaders(payload, { nonce: 'oracle-replay-nonce' });
+
+    const firstResponse = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    const secondResponse = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(401);
+    await expect(secondResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'Unauthorized',
+        message: 'Replay detected for nonce',
+      }),
+    );
+  });
+
+  test('invalid signature is rejected at the route boundary', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = { tradeId: 'trade-3', requestId: 'req-3' };
+
+    const response = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, {
+        nonce: 'oracle-invalid-signature',
+        signature: '0'.repeat(64),
+      }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockConsumeHmacNonce).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'Unauthorized',
+        message: 'Invalid HMAC signature',
+      }),
+    );
+  });
+
+  test('stale timestamp is rejected at the route boundary', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = { tradeId: 'trade-4', requestId: 'req-4' };
+
+    const response = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, {
+        nonce: 'oracle-stale',
+        timestamp: String(Date.now() - 6 * 60 * 1000),
+      }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockConsumeHmacNonce).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'Unauthorized',
+        message: expect.stringContaining('Request timestamp too old'),
+      }),
+    );
+  });
+
+  test('nonce persistence failure returns service unavailable', async () => {
+    mockConsumeHmacNonce.mockRejectedValue(new Error('db unavailable'));
+    const payload = { tradeId: 'trade-5', requestId: 'req-5' };
+
+    const response = await fetch(`${baseUrl}/api/oracle/release-stage1`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-db-error' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: 'ServiceUnavailable',
+        message: 'Authentication nonce store unavailable',
+      }),
+    );
+  });
+});

--- a/treasury/tests/serviceAuthRoutes.test.ts
+++ b/treasury/tests/serviceAuthRoutes.test.ts
@@ -1,0 +1,225 @@
+import crypto from 'crypto';
+import express, { Request, Response } from 'express';
+import { AddressInfo } from 'net';
+import { Server } from 'http';
+import { createRouter } from '../src/api/routes';
+import {
+  buildServiceAuthCanonicalString,
+  createServiceAuthMiddleware,
+  signServiceAuthCanonicalString,
+} from '../src/auth/serviceAuth';
+
+function createSignedRequestParts(options?: {
+  method?: string;
+  path?: string;
+  query?: string;
+  body?: Buffer;
+  apiKey?: string;
+  timestamp?: string;
+  nonce?: string;
+  secret?: string;
+  signatureOverride?: string;
+}) {
+  const method = options?.method ?? 'POST';
+  const path = options?.path ?? '/api/treasury/v1/ingest';
+  const query = options?.query ?? '';
+  const body = options?.body ?? Buffer.from(JSON.stringify({ entryId: 'entry-1' }));
+  const timestamp = options?.timestamp ?? '1700000000';
+  const nonce = options?.nonce ?? 'nonce-1';
+  const apiKey = options?.apiKey ?? 'svc-a';
+  const secret = options?.secret ?? 'secret-a';
+  const bodySha256 = crypto.createHash('sha256').update(body).digest('hex');
+  const canonical = buildServiceAuthCanonicalString({
+    method,
+    path,
+    query,
+    bodySha256,
+    timestamp,
+    nonce,
+  });
+  const signature = options?.signatureOverride ?? signServiceAuthCanonicalString(secret, canonical);
+
+  return {
+    body,
+    bodyText: body.toString('utf8'),
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'x-agroasys-timestamp': timestamp,
+      'x-agroasys-nonce': nonce,
+      'x-agroasys-signature': signature,
+    },
+  };
+}
+
+describe('treasury service-authenticated routes', () => {
+  let server: Server;
+  let baseUrl: string;
+  let consumeNonce: jest.MockedFunction<(apiKey: string, nonce: string, ttlSeconds: number) => Promise<boolean>>;
+
+  const lookupApiKey = (apiKey: string) => {
+    if (apiKey === 'svc-a') {
+      return { id: 'svc-a', secret: 'secret-a', active: true };
+    }
+
+    return undefined;
+  };
+
+  beforeEach(async () => {
+    consumeNonce = jest.fn().mockResolvedValue(true);
+    const authMiddleware = createServiceAuthMiddleware({
+      enabled: true,
+      maxSkewSeconds: 300,
+      nonceTtlSeconds: 600,
+      lookupApiKey,
+      consumeNonce,
+      nowSeconds: () => 1700000000,
+    });
+
+    const controller = {
+      ingest: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, route: 'ingest' });
+      },
+      listEntries: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+      appendState: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { updated: true } });
+      },
+      exportEntries: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+    };
+
+    const app = express();
+    app.use(
+      express.json({
+        verify: (req, _res, buffer) => {
+          (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buffer);
+        },
+      }),
+    );
+    app.use('/api/treasury/v1', createRouter(controller as never, { authMiddleware }));
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  test('valid signed ingest request reaches the route once', async () => {
+    const signed = createSignedRequestParts({ nonce: 'treasury-route-nonce' });
+
+    const response = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        route: 'ingest',
+      }),
+    );
+    expect(consumeNonce).toHaveBeenCalledWith('svc-a', 'treasury-route-nonce', 600);
+  });
+
+  test('replayed ingest request is rejected before controller runs', async () => {
+    consumeNonce.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const signed = createSignedRequestParts({ nonce: 'treasury-replay' });
+
+    const firstResponse = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    const secondResponse = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(401);
+    await expect(secondResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        code: 'AUTH_NONCE_REPLAY',
+        error: 'Replay detected for nonce',
+      }),
+    );
+  });
+
+  test('invalid signature is rejected at the route boundary', async () => {
+    const signed = createSignedRequestParts({
+      nonce: 'treasury-invalid-signature',
+      signatureOverride: 'f'.repeat(64),
+    });
+
+    const response = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    expect(response.status).toBe(401);
+    expect(consumeNonce).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        code: 'AUTH_INVALID_SIGNATURE',
+        error: 'Invalid signature',
+      }),
+    );
+  });
+
+  test('stale timestamp is rejected at the route boundary', async () => {
+    const signed = createSignedRequestParts({
+      nonce: 'treasury-stale',
+      timestamp: '1699999600',
+    });
+
+    const response = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    expect(response.status).toBe(401);
+    expect(consumeNonce).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        code: 'AUTH_TIMESTAMP_SKEW',
+        error: 'Timestamp outside allowed skew window',
+      }),
+    );
+  });
+
+  test('nonce persistence failure returns auth unavailable', async () => {
+    consumeNonce.mockRejectedValue(new Error('redis unavailable'));
+    const signed = createSignedRequestParts({ nonce: 'treasury-db-error' });
+
+    const response = await fetch(`${baseUrl}/api/treasury/v1/ingest`, {
+      method: 'POST',
+      headers: signed.headers,
+      body: signed.bodyText,
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        code: 'AUTH_UNAVAILABLE',
+        error: 'Authentication service unavailable',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add route-boundary authenticity and replay fixtures for oracle HMAC routes
- add route-boundary authenticity and replay fixtures for treasury service-auth routes
- link the regression fixture inventory from the oracle redrive runbook

## Linked Issue
Closes #289

## Validation
- `npm -C oracle run lint`
- `npm -C treasury run lint`
- `npm -C oracle test -- --runTestsByPath tests/hmac-middleware.test.ts tests/authenticated-routes.test.ts`
- `npm -C treasury test -- --runTestsByPath tests/authMiddleware.test.ts tests/replayProtection.test.ts tests/serviceAuthRoutes.test.ts`
- `npm -C oracle run build`
- `npm -C treasury run build`
