### PR TITLE
docs(ops): define production signer custody boundary (#235)

### DIFF
--- a/docs/runbooks/dashboard-gateway-operations.md
+++ b/docs/runbooks/dashboard-gateway-operations.md
@@ -66,10 +66,14 @@ Executor-only env:
 - `GATEWAY_EXECUTOR_PRIVATE_KEY`
 - `GATEWAY_EXECUTOR_TIMEOUT_MS`
 
+Signer custody source of truth:
+- `docs/runbooks/gateway-governance-signer-custody.md`
+
 Safety rules:
 - If `GATEWAY_ENABLE_MUTATIONS=false`, all gateway mutation routes must reject writes.
 - If `GATEWAY_WRITE_ALLOWLIST` is empty, mutations must reject writes even when enabled.
 - The gateway process must never hold the governance signer key; only the separate executor process may do so.
+- `GATEWAY_EXECUTOR_PRIVATE_KEY` is an approved local/staging bootstrap path only, not a steady-state production custody model.
 - Approved write operators for later enablement are Aston and `czpyioe`, but `GATEWAY_WRITE_ALLOWLIST`
   must contain the exact local auth principal IDs used by the auth service. Do not guess identifiers.
 
@@ -189,6 +193,11 @@ npm run -w gateway execute:governance-action -- <actionId>
 10. Executor updates the action record and audit log atomically.
 11. Operator verifies tx hash, status, and chain event.
 
+Signer-custody requirements before step 8:
+- confirm the executor signer address matches the approved admin address for the queued action
+- confirm the signer source satisfies `docs/runbooks/gateway-governance-signer-custody.md`
+- record the approval or incident reference before starting the executor session
+
 ## Rollback procedure
 If gateway behavior regresses after deploy:
 1. Set `GATEWAY_ENABLE_MUTATIONS=false`.
@@ -219,3 +228,4 @@ curl -fsS -H "Authorization: Bearer <session>" \
 - `docs/runbooks/dashboard-api-gateway-boundary.md`
 - `docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md`
 - `docs/runbooks/api-gateway-boundary.md`
+- `docs/runbooks/gateway-governance-signer-custody.md`

--- a/docs/runbooks/emergency-disable-unpause.md
+++ b/docs/runbooks/emergency-disable-unpause.md
@@ -6,6 +6,9 @@ Operational playbook for emergency stop and controlled recovery path.
 Automation-governance source of truth:
 - `docs/runbooks/programmability-governance.md`
 
+Signer custody source of truth:
+- `docs/runbooks/gateway-governance-signer-custody.md`
+
 ## Preconditions
 - Incident severity confirmed (security or correctness risk).
 - Admin quorum availability confirmed.
@@ -14,6 +17,7 @@ Automation-governance source of truth:
 ## Commands
 - Contract interactions must be executed through approved admin tooling and governance flow.
 - Do not execute ad-hoc scripts outside approved signer path.
+- Emergency disable may use a break-glass signer session only under the custody and evidence rules in `docs/runbooks/gateway-governance-signer-custody.md`.
 
 ## Expected outputs
 - Emergency disable action emits audit events.
@@ -32,6 +36,7 @@ Automation-governance source of truth:
 1. Keep protocol paused if verification is incomplete.
 2. Re-run reconciliation to verify state consistency before unpause.
 3. Resume only after governance approvals are finalized.
+4. Rotate or revoke any temporary break-glass signer session before reopening normal execution.
 
 ## Escalation criteria
 - Suspected key compromise.

--- a/docs/runbooks/gateway-governance-signer-custody.md
+++ b/docs/runbooks/gateway-governance-signer-custody.md
@@ -1,0 +1,118 @@
+# Gateway Governance Signer Custody
+
+## Purpose and scope
+Define the approved signer-custody boundary for gateway-governed protocol actions and the operator procedures required before any governance executor action is run.
+
+This runbook applies to:
+- `gateway/src/executor/adminSdkGovernanceChainExecutor.ts`
+- `npm run -w gateway execute:governance-action -- <actionId>`
+- emergency disable and controlled unpause actions
+- treasury payout receiver governance changes
+- oracle governance changes
+
+This runbook does not change protocol quorum rules. It defines how the executor signer is sourced, approved, rotated, and used safely.
+
+Automation-governance source of truth:
+- `docs/runbooks/programmability-governance.md`
+
+## Current code boundary
+Current executor code loads a raw `GATEWAY_EXECUTOR_PRIVATE_KEY` and instantiates an `ethers.Wallet` directly inside `adminSdkGovernanceChainExecutor.ts`.
+
+Interpretation:
+- local development and deterministic staging validation may use `GATEWAY_EXECUTOR_PRIVATE_KEY`
+- production readiness must not rely on a long-lived raw environment private key managed like a convenience secret
+- the gateway API process must never hold the signer key; only the isolated executor invocation may access signer material
+
+Until a managed signer adapter exists in code, production approval is limited to environments where the raw private key is injected from a managed custody system for a bounded execution window and never persisted in source control, images, CI logs, or long-lived shell history.
+
+## Approved custody models
+### Local and CI validation
+- Ephemeral test key allowed.
+- Key scope is non-production only.
+- Key may be environment injected for the duration of the test run.
+
+### Staging and pilot validation
+- `GATEWAY_EXECUTOR_PRIVATE_KEY` is allowed only for isolated staging or pilot environments with named operator ownership.
+- Key must be distinct from local/dev keys and rotated on any operator change or suspected exposure.
+- Access must be limited to the executor host/session used for the approved validation window.
+
+### Production
+- Approved custody boundary is managed signing only: HSM, KMS-backed signing, or an equivalent delegated signer service with auditable request history.
+- The executor host may trigger a signing request, but production operators must not manually copy or reuse a raw private key across sessions.
+- Raw key export is not an approved steady-state production model.
+- Any temporary exception requires written approval from the Incident Commander plus Security/Platform owner, a start and end time, and same-day rotation after use.
+
+## Approval and execution procedure
+Before running `execute:governance-action`, operators must record:
+- `actionId`
+- `intentKey`
+- expected contract method
+- target admin signer address
+- linked incident/change record
+- approver identities and time of approval
+
+Required approvals:
+- normal governance execution: Service Owner plus one peer reviewer
+- emergency disable path: Incident Commander plus Service Owner
+- recovery or unpause path: protocol quorum evidence plus Incident Commander approval to resume
+
+Execution steps:
+1. Verify the queued action details from the gateway API and confirm the signer address expected by the queued action.
+2. Verify the signer source matches the approved custody model for the environment.
+3. Start a bounded executor session with only the env vars required for that action.
+4. Run `npm run -w gateway execute:governance-action -- <actionId>`.
+5. Capture resulting `txHash`, `blockNumber`, `requestId`, and audit log row.
+6. End the session and remove any temporary secret material from the shell/session context.
+
+## Rotation and revocation
+Rotate the signer immediately when any of the following occurs:
+- operator change or offboarding
+- suspected secret exposure
+- emergency exception used a raw exported key
+- signer address no longer matches the approved admin/quorum mapping
+
+Rotation minimums:
+1. Provision the new signer in the managed custody system.
+2. Record the new signer address and approval record.
+3. Validate the signer in non-production first.
+4. Update environment injection on the executor host only.
+5. Revoke the previous signer and archive the rotation evidence.
+
+Required evidence:
+- old signer address
+- new signer address
+- approving operators
+- validation timestamp
+- rollback plan if the new signer fails
+
+## Break-glass and emergency disable
+Break-glass use is limited to containment actions such as `pause`, `pauseClaims`, or `disableOracleEmergency`.
+
+Rules:
+- use the narrowest action that safely contains the incident
+- record the incident URL before execution if at all possible
+- do not use a break-glass signer session to perform recovery or unpause actions
+- after break-glass use, rotate the signer or revoke the exception before reopening normal execution
+
+For emergency actions, also follow:
+- `docs/runbooks/emergency-disable-unpause.md`
+- `docs/incidents/first-15-minutes-checklist.md`
+
+## Evidence and audit minimums
+Every signer-backed governance execution must leave:
+- gateway `actionId`
+- `requestId` and `correlationId`
+- signer address used
+- operator identity
+- approval record or incident record
+- `txHash` and `blockNumber`
+- post-execution verification note
+
+Store the operator packet in:
+- `docs/runbooks/operator-audit-evidence-template.md`
+- `docs/incidents/incident-evidence-template.md` when incident-driven
+
+## References
+- `docs/runbooks/dashboard-gateway-operations.md`
+- `docs/runbooks/emergency-disable-unpause.md`
+- `docs/runbooks/production-readiness-checklist.md`

--- a/docs/runbooks/production-readiness-checklist.md
+++ b/docs/runbooks/production-readiness-checklist.md
@@ -36,6 +36,8 @@ Purpose:
 - Private key access is role-limited and logged.
 - Emergency rotation procedure is documented and tested in non-production first.
 - Shared test/dev keys are never reused for production environments.
+- Gateway governance signer custody is defined in `docs/runbooks/gateway-governance-signer-custody.md`.
+- Production governance execution must use managed signer custody; raw `GATEWAY_EXECUTOR_PRIVATE_KEY` env injection is staging-only unless a time-boxed exception is approved and rotated immediately after use.
 
 ## 2) Gas and Fee Expectations
 
@@ -113,5 +115,6 @@ Purpose:
   - `docs/runbooks/staging-e2e-release-gate.md`
   - `docs/runbooks/staging-e2e-real-release-gate.md`
   - `docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md`
+  - `docs/runbooks/gateway-governance-signer-custody.md`
   - `docs/runbooks/oracle-redrive.md`
   - `docs/incidents/first-15-minutes-checklist.md`

--- a/scripts/tests/gateway-signer-custody-guard.sh
+++ b/scripts/tests/gateway-signer-custody-guard.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RUNBOOK="docs/runbooks/gateway-governance-signer-custody.md"
+LINK_DOCS=(
+  "docs/runbooks/dashboard-gateway-operations.md"
+  "docs/runbooks/production-readiness-checklist.md"
+  "docs/runbooks/emergency-disable-unpause.md"
+)
+required_headings=(
+  "## Purpose and scope"
+  "## Current code boundary"
+  "## Approved custody models"
+  "## Approval and execution procedure"
+  "## Rotation and revocation"
+  "## Break-glass and emergency disable"
+  "## Evidence and audit minimums"
+)
+
+fail=0
+
+if [[ ! -f "$RUNBOOK" ]]; then
+  echo "[FAIL] Missing signer custody runbook: ${RUNBOOK}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "$heading" "$RUNBOOK"; then
+    echo "[FAIL] Missing required heading in ${RUNBOOK}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+for doc in "${LINK_DOCS[@]}"; do
+  if [[ ! -f "$doc" ]]; then
+    echo "[FAIL] Missing linked doc: ${doc}" >&2
+    fail=1
+    continue
+  fi
+
+  if ! grep -Fq "docs/runbooks/gateway-governance-signer-custody.md" "$doc"; then
+    echo "[FAIL] Missing signer custody runbook link in ${doc}" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "Gateway signer custody guard: pass"
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- define the gateway governance signer custody boundary and production approval model
- add explicit staging vs production custody rules, rotation, and break-glass handling
- add a deterministic guard so the signer-custody contract stays linked from ops docs

## Linked Issue
Closes #235

## Validation
- `bash scripts/tests/gateway-signer-custody-guard.sh`
- `bash scripts/tests/programmability-governance-guard.sh`
