### PR TITLE
docs(indexer): record chain-event parity retirement (#275)

### DIFF
--- a/docs/runbooks/chain-event-parity-retirement.md
+++ b/docs/runbooks/chain-event-parity-retirement.md
@@ -1,0 +1,70 @@
+# Chain Event Parity And Legacy Ingest Retirement
+
+## Purpose and scope
+Document the authoritative replacement for the legacy `platform.v1/supabase/functions/chain-events/index.ts` webhook ingest and define when that Supabase path can be retired safely.
+
+This runbook covers:
+- legacy webhook responsibilities
+- the current Cotsel component that replaces each responsibility
+- responsibilities intentionally retired rather than reimplemented
+- the operator verification steps required before declaring the legacy ingest obsolete
+
+## Legacy ingest summary
+The legacy Supabase function accepted webhook payloads from an indexer, verified an HMAC signature, suppressed duplicates using `chain_events_log`, and projected protocol events into application tables such as `orders`, `settlements`, `escrow`, `payments`, `disputes`, and `notifications`.
+
+Legacy events handled there included:
+- `TradeCreated`
+- `TradeSigned`
+- `TradeLocked`
+- `DeliveryConfirmed`
+- `FundsReleased`
+- `TradeDisputed`
+
+That function mixed two concerns:
+- authoritative protocol-event intake
+- application-side projections and notifications for the old platform database
+
+## Authoritative replacement matrix
+| Legacy responsibility | Legacy implementation | Current authoritative replacement | Evidence path |
+| --- | --- | --- | --- |
+| Receive chain events from an upstream webhook | Supabase edge function POST handler | `indexer/src/main.ts` reads finalized chain events directly from the processor; no webhook transport is required for protocol truth | `indexer/README.md`, `indexer/src/main.ts` |
+| Verify event authenticity in transit | HMAC on `x-webhook-signature` | Not needed for protocol ingest because Cotsel indexer reads the chain directly. Service-to-service HMAC remains only for explicit HTTP mutation/read boundaries such as treasury/oracle, not for authoritative chain ingest | `oracle/tests/authenticated-routes.test.ts`, `treasury/tests/serviceAuthRoutes.test.ts` |
+| Suppress duplicate event application | `chain_events_log` duplicate lookup by event type/hash/index | Deterministic event entity IDs and append-only indexer persistence; downstream consumers read from the indexed store rather than replaying webhook bodies | `indexer/src/model/generated/tradeEvent.model.ts`, `indexer/src/model/generated/systemEvent.model.ts` |
+| Maintain canonical trade state | Supabase updates to `orders` and `settlements` | `Trade` plus `TradeEvent` records in the indexer, with gateway trade reads exposing the operator-facing projection | `indexer/src/model/generated/trade.model.ts`, `gateway/src/core/tradeReadService.ts`, `docs/api/cotsel-dashboard-gateway.openapi.yml` |
+| Maintain event timeline for audits | `chain_events_log` rows | Indexed trade/system events plus gateway trade timeline rendering | `gateway/src/core/tradeReadService.ts`, `GET /trades/{tradeId}` in `docs/api/cotsel-dashboard-gateway.openapi.yml` |
+| Track lifecycle freshness and operator summary | Implicit via webhook processing timestamps | `OverviewSnapshot` in the indexer plus gateway overview/operations summaries | `indexer/src/model/generated/overviewSnapshot.model.ts`, `gateway/src/core/overviewService.ts`, `GET /operations/summary` |
+| Detect truth-source conflicts | Ad hoc platform-side investigation | Reconciliation compares indexed state to on-chain state and persists deterministic drifts and reports | `reconciliation/src/indexer/client.ts`, `reconciliation/src/core/reconciler.ts`, `docs/runbooks/reconciliation.md` |
+| Treasury release / fee accounting | Payment and settlement side effects in Supabase tables | Treasury ingests treasury-relevant indexed events and exposes append-only accounting views; reconciliation consumes the resulting evidence | `treasury/README.md`, `treasury/src/core/ingestion.ts`, `docs/runbooks/reconciliation.md` |
+| Notifications on drift or settlement anomalies | Supabase notifications inserts | Notifications are no longer a chain-ingest side effect. Cotsel sends operator notifications from current services such as reconciliation, using protocol-authoritative data as input | `notifications/README.md`, `reconciliation/src/core/reconciler.ts` |
+
+## Responsibilities intentionally retired
+The following legacy behaviors are not authoritative protocol-ingest responsibilities in Cotsel and are intentionally retired rather than recreated in the indexer:
+- mutating platform.v1 `orders`, `settlements`, `escrow`, and `payments` tables
+- storing orphaned application events when a Ricardian/order row is missing in a separate product database
+- emitting product-facing notifications directly from the ingest function
+
+Interpretation:
+- Cotsel now owns protocol truth, event history, treasury accounting inputs, reconciliation, and operator read surfaces
+- application-specific projections must consume Cotsel read models instead of expecting a chain-event webhook to mutate their private tables
+
+## Retirement checklist
+Retire the legacy Supabase `chain-events` function only when all of the following are true:
+1. Operators can retrieve canonical trade lifecycle and timeline data from the indexer or gateway trade read endpoints.
+2. Treasury accounting consumers use `treasury/` exports or reconciliation artifacts, not Supabase `payments` side effects.
+3. Drift review uses reconciliation outputs (`reconcile_runs`, `reconcile_drifts`, report JSON), not manual comparison against legacy shadow-ledger rows.
+4. No release gate, operator runbook, or dashboard flow still depends on `platform.v1` `orders`/`settlements`/`escrow` status columns as the primary truth source.
+5. Any remaining product notification flows are triggered from current Cotsel services or have been deliberately decommissioned.
+
+## Operator verification procedure
+Before marking the legacy ingest retired:
+1. Query a representative trade from the gateway `GET /trades/{tradeId}` surface and confirm lifecycle timeline + tx references are present.
+2. Confirm indexer freshness via the overview snapshot and record `lastProcessedBlock` / `lastIndexedAt`.
+3. Run `npm run -w reconciliation reconcile:report -- --run-key=<runKey> --out reports/reconciliation/latest.json` and archive the report.
+4. Confirm treasury entries for a released trade are present via `GET /api/treasury/v1/entries` or treasury export.
+5. Record the retirement evidence bundle in the incident/operator audit template if this change is coupled to an environment cutover.
+
+## References
+- `docs/runbooks/reconciliation.md`
+- `docs/api/cotsel-dashboard-gateway.openapi.yml`
+- `docs/runbooks/operator-audit-evidence-template.md`
+- `docs/incidents/incident-evidence-template.md`

--- a/docs/runbooks/reconciliation.md
+++ b/docs/runbooks/reconciliation.md
@@ -8,6 +8,9 @@ If a mismatch may be caused by routing/auth propagation/correlation breakdown be
 Automation-governance source of truth:
 - `docs/runbooks/programmability-governance.md`
 
+Legacy chain-event ingest retirement source of truth:
+- `docs/runbooks/chain-event-parity-retirement.md`
+
 ## Preconditions
 - Postgres is reachable.
 - Reconciliation env vars are set (`RPC_URL`, `INDEXER_GRAPHQL_URL`, addresses).

--- a/scripts/tests/chain-event-parity-retirement-guard.sh
+++ b/scripts/tests/chain-event-parity-retirement-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RUNBOOK="docs/runbooks/chain-event-parity-retirement.md"
+LINK_DOC="docs/runbooks/reconciliation.md"
+required_headings=(
+  "## Purpose and scope"
+  "## Legacy ingest summary"
+  "## Authoritative replacement matrix"
+  "## Responsibilities intentionally retired"
+  "## Retirement checklist"
+  "## Operator verification procedure"
+)
+required_refs=(
+  "indexer/src/main.ts"
+  "reconciliation/src/indexer/client.ts"
+  "gateway/src/core/tradeReadService.ts"
+  "treasury/src/core/ingestion.ts"
+)
+
+fail=0
+
+if [[ ! -f "$RUNBOOK" ]]; then
+  echo "[FAIL] Missing chain-event parity runbook: ${RUNBOOK}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "$heading" "$RUNBOOK"; then
+    echo "[FAIL] Missing required heading in ${RUNBOOK}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+for ref in "${required_refs[@]}"; do
+  if ! grep -Fq "$ref" "$RUNBOOK"; then
+    echo "[FAIL] Missing required replacement reference in ${RUNBOOK}: ${ref}" >&2
+    fail=1
+  fi
+done
+
+if [[ ! -f "$LINK_DOC" ]]; then
+  echo "[FAIL] Missing reconciliation runbook: ${LINK_DOC}" >&2
+  fail=1
+elif ! grep -Fq "docs/runbooks/chain-event-parity-retirement.md" "$LINK_DOC"; then
+  echo "[FAIL] Missing chain-event parity link in ${LINK_DOC}" >&2
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "Chain-event parity retirement guard: pass"
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- document the authoritative replacement for legacy Supabase chain-event ingest
- add a parity matrix mapping each legacy responsibility to current Cotsel truth
- define the retirement checklist and operator verification procedure

## Linked Issue
Closes #275

## Validation
- `bash scripts/tests/chain-event-parity-retirement-guard.sh`
