### PR TITLE
fix(gateway): make overview freshness authoritative (#250)

### DIFF
--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -404,6 +404,12 @@ paths:
         and `posture` is `null` when the chain RPC feed is unavailable. The endpoint always returns
         HTTP 200 so the dashboard can render a partial view with degraded-feed indicators rather
         than a blank screen.
+
+        Authoritative trade freshness comes from the indexer snapshot watermark, not from the
+        gateway request timestamp. For the trades feed:
+        - `feedFreshness.trades.queriedAt` is when the gateway asked the indexer for this snapshot
+        - `feedFreshness.trades.freshAt` mirrors the indexer `lastIndexedAt` watermark
+        - `feedFreshness.trades.lastProcessedBlock` identifies the last indexed block for the snapshot
       operationId: getOverview
       parameters:
         - $ref: '#/components/parameters/XRequestId'
@@ -1956,14 +1962,13 @@ components:
             - type: string
               format: date-time
             - type: 'null'
-          deprecated: true
-          description: "Deprecated: use freshAt instead. ISO timestamp of when the gateway successfully queried this feed for the current snapshot; null when the feed is unavailable. Kept for backward compatibility with existing consumers."
+          description: ISO timestamp of when the gateway successfully queried this feed for the current snapshot; null when the feed is unavailable.
         freshAt:
           anyOf:
             - type: string
               format: date-time
             - type: 'null'
-          description: ISO timestamp of when the gateway successfully queried this feed for the current snapshot; null when the feed is unavailable.
+          description: Source-authoritative freshness timestamp for this feed; null when the feed is unavailable.
         available:
           type: boolean
           description: False when the feed returned an error or timed out for this request.
@@ -1971,8 +1976,14 @@ components:
       allOf:
         - $ref: '#/components/schemas/OverviewFeedStatus'
         - type: object
-          required: [lastProcessedBlock, lastTradeEventAt]
+          required: [lastIndexedAt, lastProcessedBlock, lastTradeEventAt]
           properties:
+            lastIndexedAt:
+              anyOf:
+                - type: string
+                  format: date-time
+                - type: 'null'
+              description: Indexer watermark timestamp for the most recently processed block; mirrors `freshAt` when available.
             lastProcessedBlock:
               anyOf:
                 - type: string

--- a/docs/runbooks/dashboard-api-gateway-boundary.md
+++ b/docs/runbooks/dashboard-api-gateway-boundary.md
@@ -36,6 +36,7 @@ Operations read surface:
 - `GET /operations/summary` provides service health and incident summary for operator operations pages.
 - Response states are explicit and deterministic: `healthy`, `degraded`, `unavailable`, `stale`.
 - Every service status and incident summary snapshot includes source and freshness timestamps.
+- `GET /overview` trade freshness must come from indexer watermarks (`lastIndexedAt`, `lastProcessedBlock`), not gateway request time.
 
 Current connected-validation constraint:
 - Cotsel-Dash may run connected mode only against explicit local/docker gateway and auth-service URLs until real remote staging coordinates are recorded.

--- a/gateway/src/core/overviewService.ts
+++ b/gateway/src/core/overviewService.ts
@@ -25,6 +25,7 @@ export interface OverviewFeedStatus {
 }
 
 export interface OverviewTradeFeedStatus extends OverviewFeedStatus {
+  lastIndexedAt: string | null;
   lastProcessedBlock: string | null;
   lastTradeEventAt: string | null;
 }
@@ -92,6 +93,48 @@ const overviewSnapshotQuery = `
   }
 `;
 
+function parseNonNegativeInteger(raw: number, field: string): number {
+  if (!Number.isSafeInteger(raw) || raw < 0) {
+    throw new GatewayError(502, 'UPSTREAM_UNAVAILABLE', `Indexer returned invalid ${field}`, {
+      field,
+      value: raw,
+    });
+  }
+
+  return raw;
+}
+
+function parseIsoTimestamp(raw: string, field: string): string {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new GatewayError(502, 'UPSTREAM_UNAVAILABLE', `Indexer returned invalid ${field}`, {
+      field,
+      value: raw,
+    });
+  }
+
+  return parsed.toISOString();
+}
+
+function parseOptionalIsoTimestamp(raw: string | null, field: string): string | null {
+  if (raw === null) {
+    return null;
+  }
+
+  return parseIsoTimestamp(raw, field);
+}
+
+function parseBlockNumber(raw: string, field: string): string {
+  if (!/^\d+$/.test(raw)) {
+    throw new GatewayError(502, 'UPSTREAM_UNAVAILABLE', `Indexer returned invalid ${field}`, {
+      field,
+      value: raw,
+    });
+  }
+
+  return raw;
+}
+
 export class OverviewService implements OverviewReader {
   constructor(
     private readonly indexerGraphqlUrl: string,
@@ -138,6 +181,25 @@ export class OverviewService implements OverviewReader {
       : null;
 
     const blockedTrades = complianceAvailable ? complianceResult.value : 0;
+    const tradesFeedFreshness: OverviewTradeFeedStatus = snapshotAvailable && indexerSnapshot
+      ? {
+          source: 'indexer_graphql',
+          queriedAt: now,
+          freshAt: indexerSnapshot.lastIndexedAt,
+          available: true,
+          lastIndexedAt: indexerSnapshot.lastIndexedAt,
+          lastProcessedBlock: indexerSnapshot.lastProcessedBlock,
+          lastTradeEventAt: indexerSnapshot.lastTradeEventAt,
+        }
+      : {
+          source: 'indexer_graphql',
+          queriedAt: null,
+          freshAt: null,
+          available: false,
+          lastIndexedAt: null,
+          lastProcessedBlock: null,
+          lastTradeEventAt: null,
+        };
 
     return {
       kpis: {
@@ -146,14 +208,7 @@ export class OverviewService implements OverviewReader {
       },
       posture,
       feedFreshness: {
-        trades: {
-          source: 'indexer_graphql',
-          queriedAt: snapshotAvailable ? now : null,
-          freshAt: snapshotAvailable ? now : null,
-          available: snapshotAvailable,
-          lastProcessedBlock: indexerSnapshot?.lastProcessedBlock ?? null,
-          lastTradeEventAt: indexerSnapshot?.lastTradeEventAt ?? null,
-        },
+        trades: tradesFeedFreshness,
         governance: { source: 'chain_rpc', queriedAt: governanceAvailable ? now : null, freshAt: governanceAvailable ? now : null, available: governanceAvailable },
         compliance: { source: 'gateway_ledger', queriedAt: complianceAvailable ? now : null, freshAt: complianceAvailable ? now : null, available: complianceAvailable },
       },
@@ -193,7 +248,18 @@ export class OverviewService implements OverviewReader {
         throw new GatewayError(502, 'UPSTREAM_UNAVAILABLE', 'Indexer returned no overview snapshot');
       }
 
-      return snapshot;
+      return {
+        totalTrades: parseNonNegativeInteger(snapshot.totalTrades, 'overviewSnapshot.totalTrades'),
+        lockedTrades: parseNonNegativeInteger(snapshot.lockedTrades, 'overviewSnapshot.lockedTrades'),
+        stage1Trades: parseNonNegativeInteger(snapshot.stage1Trades, 'overviewSnapshot.stage1Trades'),
+        stage2Trades: parseNonNegativeInteger(snapshot.stage2Trades, 'overviewSnapshot.stage2Trades'),
+        completedTrades: parseNonNegativeInteger(snapshot.completedTrades, 'overviewSnapshot.completedTrades'),
+        disputedTrades: parseNonNegativeInteger(snapshot.disputedTrades, 'overviewSnapshot.disputedTrades'),
+        cancelledTrades: parseNonNegativeInteger(snapshot.cancelledTrades, 'overviewSnapshot.cancelledTrades'),
+        lastProcessedBlock: parseBlockNumber(snapshot.lastProcessedBlock, 'overviewSnapshot.lastProcessedBlock'),
+        lastIndexedAt: parseIsoTimestamp(snapshot.lastIndexedAt, 'overviewSnapshot.lastIndexedAt'),
+        lastTradeEventAt: parseOptionalIsoTimestamp(snapshot.lastTradeEventAt, 'overviewSnapshot.lastTradeEventAt'),
+      };
     } catch (error) {
       if (error instanceof GatewayError) {
         throw error;

--- a/gateway/tests/overviewRoutes.contract.test.ts
+++ b/gateway/tests/overviewRoutes.contract.test.ts
@@ -59,7 +59,7 @@ const overviewFixture: OverviewSnapshot = {
     oracleActive: true,
   },
   feedFreshness: {
-    trades: { source: 'indexer_graphql', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true, lastProcessedBlock: '42000', lastTradeEventAt: '2026-03-08T12:00:00.000Z' },
+    trades: { source: 'indexer_graphql', queriedAt: '2026-03-09T00:00:05.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true, lastIndexedAt: '2026-03-09T00:00:00.000Z', lastProcessedBlock: '42000', lastTradeEventAt: '2026-03-08T12:00:00.000Z' },
     governance: { source: 'chain_rpc', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true },
     compliance: { source: 'gateway_ledger', queriedAt: '2026-03-09T00:00:00.000Z', freshAt: '2026-03-09T00:00:00.000Z', available: true },
   },
@@ -75,7 +75,7 @@ const degradedFixture: OverviewSnapshot = {
   },
   posture: null,
   feedFreshness: {
-    trades: { source: 'indexer_graphql', queriedAt: null, freshAt: null, available: false, lastProcessedBlock: null, lastTradeEventAt: null },
+    trades: { source: 'indexer_graphql', queriedAt: null, freshAt: null, available: false, lastIndexedAt: null, lastProcessedBlock: null, lastTradeEventAt: null },
     governance: { source: 'chain_rpc', queriedAt: null, freshAt: null, available: false },
     compliance: { source: 'gateway_ledger', queriedAt: null, freshAt: null, available: false },
   },
@@ -155,6 +155,9 @@ describe('gateway overview route contract', () => {
       expect(payload.data.posture.paused).toBe(false);
       expect(payload.data.posture.oracleActive).toBe(true);
       expect(payload.data.feedFreshness.trades.available).toBe(true);
+      expect(payload.data.feedFreshness.trades.freshAt).toBe('2026-03-09T00:00:00.000Z');
+      expect(payload.data.feedFreshness.trades.queriedAt).toBe('2026-03-09T00:00:05.000Z');
+      expect(payload.data.feedFreshness.trades.lastIndexedAt).toBe('2026-03-09T00:00:00.000Z');
       expect(payload.data.feedFreshness.governance.source).toBe('chain_rpc');
     } finally {
       server.close();

--- a/gateway/tests/overviewService.test.ts
+++ b/gateway/tests/overviewService.test.ts
@@ -8,11 +8,13 @@ describe('overview service', () => {
   const originalFetch = global.fetch;
 
   afterEach(() => {
+    jest.useRealTimers();
     global.fetch = originalFetch;
     jest.restoreAllMocks();
   });
 
-  test('maps overview snapshot from indexer to trade KPIs', async () => {
+  test('maps overview snapshot from indexer to trade KPIs and preserves indexer watermarks', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-03-09T00:01:00.000Z'));
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -58,6 +60,9 @@ describe('overview service', () => {
     expect(snapshot.kpis.trades.byStatus.completed).toBe(2);
     expect(snapshot.kpis.trades.byStatus.disputed).toBe(1);
     expect(snapshot.kpis.trades.byStatus.cancelled).toBe(1);
+    expect(snapshot.feedFreshness.trades.queriedAt).toBe('2026-03-09T00:01:00.000Z');
+    expect(snapshot.feedFreshness.trades.freshAt).toBe('2026-03-09T00:00:00.000Z');
+    expect(snapshot.feedFreshness.trades.lastIndexedAt).toBe('2026-03-09T00:00:00.000Z');
     expect(snapshot.feedFreshness.trades.lastProcessedBlock).toBe('42000');
     expect(snapshot.feedFreshness.trades.lastTradeEventAt).toBe('2026-03-08T12:00:00.000Z');
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -90,6 +95,7 @@ describe('overview service', () => {
       queriedAt: null,
       freshAt: null,
       available: false,
+      lastIndexedAt: null,
       lastProcessedBlock: null,
       lastTradeEventAt: null,
     });
@@ -104,6 +110,60 @@ describe('overview service', () => {
       queriedAt: null,
       freshAt: null,
       available: false,
+    });
+  });
+
+  test('rejects invalid indexer watermark timestamps instead of fabricating overview freshness', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          overviewSnapshotById: {
+            totalTrades: 1,
+            lockedTrades: 1,
+            stage1Trades: 0,
+            stage2Trades: 0,
+            completedTrades: 0,
+            disputedTrades: 0,
+            cancelledTrades: 0,
+            lastProcessedBlock: '42001',
+            lastIndexedAt: 'not-a-date',
+            lastTradeEventAt: null,
+          },
+        },
+      }),
+    } as Response);
+
+    const governanceStatusService = {
+      getGovernanceStatus: jest.fn().mockResolvedValue({
+        paused: false,
+        claimsPaused: false,
+        oracleActive: true,
+      }),
+      checkReadiness: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = new OverviewService(
+      'http://127.0.0.1:4350/graphql',
+      5000,
+      governanceStatusService,
+      createInMemoryComplianceStore([]),
+    );
+
+    const snapshot = await service.getOverview();
+
+    expect(snapshot.kpis.trades).toEqual({
+      total: 0,
+      byStatus: { locked: 0, stage_1: 0, stage_2: 0, completed: 0, disputed: 0, cancelled: 0 },
+    });
+    expect(snapshot.feedFreshness.trades).toEqual({
+      source: 'indexer_graphql',
+      queriedAt: null,
+      freshAt: null,
+      available: false,
+      lastIndexedAt: null,
+      lastProcessedBlock: null,
+      lastTradeEventAt: null,
     });
   });
 });


### PR DESCRIPTION
## Summary
- derive overview trade freshness from the indexer watermark rather than gateway query time
- expose `lastIndexedAt` alongside `lastProcessedBlock` and `lastTradeEventAt`
- tighten overview tests and OpenAPI docs around authoritative freshness semantics

## Linked Issue
Closes #250

## Validation
- `npm run -w gateway lint`
- `npm run -w gateway test -- --runInBand tests/overviewService.test.ts tests/overviewRoutes.contract.test.ts tests/openapiSpec.test.ts`
- `npm run -w gateway build`
- `npm run -w indexer test`
