### PR TITLE
docs(compliance): define attestation verification and outage stance (#286)

### DIFF
--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -4277,7 +4277,8 @@ components:
       description: |
         Canonical off-chain attestation reference contract for operator surfaces.
         This schema intentionally carries only reference metadata and not the raw
-        attestation payload.
+        attestation payload. Verification freshness and outage interpretation are
+        defined operationally in `docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md`.
       required:
         - attestationId
         - attestationType

--- a/docs/incidents/first-15-minutes-checklist.md
+++ b/docs/incidents/first-15-minutes-checklist.md
@@ -21,8 +21,8 @@ scripts/docker-services.sh logs local-dev ricardian
 5. Run release-gate diagnostics for the impacted profile:
    - `docs/runbooks/staging-e2e-release-gate.md`
    - `docs/runbooks/staging-e2e-real-release-gate.md`
-6. Confirm whether issue is chain connectivity, indexer drift, auth failures, or data-layer fault.
-7. Start `docs/incidents/incident-evidence-template.md` and record affected trade IDs, action keys, request IDs, trace IDs, and tx hashes.
+6. Confirm whether issue is chain connectivity, indexer drift, auth failures, attestation/compliance-provider outage, or data-layer fault.
+7. Start `docs/incidents/incident-evidence-template.md` and record affected trade IDs, action keys, request IDs, trace IDs, tx hashes, and attestation issuer/provider references when applicable.
 8. Decide containment path (pause/disable/or continue with monitoring) and record the owner and timestamp in the template.
 9. Link operator-reviewed evidence packets from `docs/runbooks/operator-audit-evidence-template.md` when recovery actions require approval or audit follow-up.
 10. Notify stakeholders with current blast radius and next update time.

--- a/docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md
+++ b/docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md
@@ -62,6 +62,59 @@ Contract mirror:
 - OpenAPI component: `#/components/schemas/AttestationReference`
 - ADR boundary: `docs/adr/adr-0143-privacy-attestation-composability.md`
 
+## Attestation verification, freshness, and outage stance
+Attestation references are not trusted just because they exist. They must be
+evaluated against issuer trust, expiry, freshness, and current issuer
+availability.
+
+Verification rules:
+- Trust only attestation issuers that are explicitly approved for the pilot or
+  integration boundary. An unknown `issuer.id` or unsupported `issuer.kind`
+  must be treated as untrusted.
+- `providerRef` or equivalent issuer lookup evidence must exist before an
+  attestation is treated as operator-usable.
+- `evidenceRef` must point to the evidence artifact that justified the current
+  attestation state.
+
+Freshness rules:
+- `expiresAt` is a hard stop. Once past, the attestation is `expired` and not
+  sufficient for new trade-gating decisions.
+- If the current operator surface cannot prove when the issuer state was last
+  revalidated, the attestation must be treated as `stale`.
+- Gateway query time is never an acceptable substitute for issuer verification
+  time. A UI refresh does not make an attestation fresh.
+
+Operator decision rules:
+
+| Condition | Operator interpretation | Execution stance |
+| --- | --- | --- |
+| issuer trusted, not expired, latest verification available | usable | May support normal operator review and settlement gating. |
+| `expiresAt` in the past | expired | Treat as deny/block until re-issued or re-verified. |
+| latest verification missing or older than approved freshness window | stale | Treat as deny/block until issuer revalidation succeeds. |
+| issuer unknown or not approved | untrusted | Treat as deny/block; escalate integration or policy review. |
+| issuer/provider unavailable | unavailable | Treat as deny/block for new trade decisions; preserve last-known metadata only as degraded evidence. |
+
+Outage stance:
+- New trade-gating paths remain fail-closed during attestation-provider outage,
+  stale verification, or unknown issuer state.
+- Read-only operator surfaces may show the last known attestation reference, but
+  they must mark it as degraded or unavailable and must not imply successful
+  current verification.
+- Emergency override follows the same approval and evidence rules as the rest of
+  this compliance boundary; an outage alone does not authorize silent fail-open
+  behavior.
+
+Operator evidence minimum during attestation incidents:
+- `attestationId`
+- `issuer.id`
+- `subjectRef.reference`
+- `providerRef`
+- `evidenceRef`
+- last known verification timestamp, if available
+- expiry timestamp, if available
+- affected `tradeId` / `correlationId`
+- outage start time and current degraded reason
+
 ## Decision contract (allow/deny semantics)
 
 ### Input contract for every compliance decision
@@ -201,6 +254,7 @@ Pilot role mapping:
 - `docs/incidents/first-15-minutes-checklist.md`
 - `docs/runbooks/staging-e2e-real-release-gate.md`
 - `docs/runbooks/api-gateway-boundary.md`
+- `docs/runbooks/dashboard-gateway-operations.md`
 - `docs/observability/logging-schema.md`
 - `docs/runbooks/production-readiness-checklist.md`
 - `docs/adr/adr-0143-privacy-attestation-composability.md`

--- a/docs/runbooks/dashboard-gateway-operations.md
+++ b/docs/runbooks/dashboard-gateway-operations.md
@@ -166,6 +166,31 @@ Reason:
 - downstream services already own their idempotency and retry policies
 - the gateway must fail deterministically rather than amplify mutations
 
+## Attestation verification and outage stance
+For compliance and future attestation read surfaces, the gateway must preserve
+the issuer’s attestation reference metadata without turning query time into fake
+verification truth.
+
+Operational rules:
+- The gateway may expose last-known attestation reference metadata, but it must
+  not imply successful current verification when issuer/provider checks are
+  unavailable.
+- Missing, stale, expired, or untrusted attestation state remains fail-closed
+  for new trade-gating decisions.
+- Read-only operator pages must distinguish:
+  - last-known reference metadata
+  - last successful verification time
+  - current degraded or unavailable state
+- During outage, operators must capture issuer ID, subject reference, provider
+  reference, evidence reference, expiry, and affected `tradeId`/`correlationId`
+  values in the incident or audit evidence packet.
+
+Escalation:
+- Follow the compliance outage thresholds in
+  `docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md`.
+- Do not re-enable writes or approve overrides on the assumption that a manual
+  dashboard refresh constitutes fresh verification.
+
 ## Governance queue and executor procedure
 Mutation requests do not execute governance transactions inline.
 


### PR DESCRIPTION
Replacement for #317 after its stacked base branch was merged and deleted. This PR carries the rebased #286 attestation verification, freshness, trust, and outage stance updates directly against `main`.