### PR TITLE
feat(ops): complete base mainnet launch governance and retirement

### DIFF
--- a/.github/workflows/historical-archive-maintenance.yml
+++ b/.github/workflows/historical-archive-maintenance.yml
@@ -1,0 +1,332 @@
+name: Historical Archive Maintenance
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  historical-governance-archive:
+    name: historical/governance-archive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run historical governance archive checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set +e
+          mkdir -p ci-reports
+          report="ci-reports/historical-governance-archive.txt"
+          fail=0
+
+          run_check() {
+            local label="$1"
+            shift
+            echo "[$label] command: $*" | tee -a "$report"
+            if "$@" 2>&1 | tee -a "$report"; then
+              echo "[$label] PASS" | tee -a "$report"
+            else
+              echo "[$label] FAIL" | tee -a "$report"
+              fail=1
+            fi
+            echo "" >> "$report"
+          }
+
+          run_check architecture-roadmap-consistency node scripts/architecture-roadmap-consistency-check.mjs --repo "${{ github.repository }}" --out ci-reports/arch-roadmap-consistency.json
+          run_check architecture-roadmap-sync-regression scripts/tests/architecture-roadmap-sync.test.sh
+          run_check architecture-roadmap-consistency-regression scripts/tests/architecture-roadmap-consistency-check.test.sh
+
+          if [[ "$fail" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Upload historical governance archive report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: historical-governance-archive
+          path: |
+            ci-reports/historical-governance-archive.txt
+            ci-reports/arch-roadmap-consistency.json
+
+  historical-asset-fee-path:
+    name: historical/asset-fee-path
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare profile env files
+        run: |
+          cp .env.example .env
+          cp .env.local.example .env.local
+          cp .env.staging-e2e-real.example .env.staging-e2e-real
+
+      - name: Run historical asset fee-path checks
+        shell: bash
+        run: |
+          set +e
+          mkdir -p ci-reports
+          report="ci-reports/historical-asset-fee-path.txt"
+          fail=0
+
+          run_check() {
+            local label="$1"
+            local cmd="$2"
+            echo "[$label] command: $cmd" | tee -a "$report"
+            if bash -lc "$cmd"; then
+              echo "[$label] PASS" | tee -a "$report"
+            else
+              echo "[$label] FAIL" | tee -a "$report"
+              fail=1
+            fi
+            echo "" >> "$report"
+          }
+
+          run_check local-dev "ASSET_FEE_PATH_ASSERT_CONFIG_ONLY=true bash scripts/asset-fee-path-gate.sh local-dev"
+          run_check staging-e2e-real "ASSET_FEE_PATH_ASSERT_CONFIG_ONLY=true bash scripts/asset-fee-path-gate.sh staging-e2e-real"
+          run_check regression-test "bash scripts/tests/asset-fee-path-gate.test.sh"
+
+          if [[ "$fail" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Upload historical asset fee-path report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: historical-asset-fee-path
+          path: |
+            ci-reports/historical-asset-fee-path.txt
+            reports/asset-fee-path
+
+  historical-polkavm-compile:
+    name: historical/polkavm-compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install pinned historical resolc binary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RESOLC_VERSION="1.0.0"
+          RESOLC_COMMIT="b080c1"
+
+          case "$(uname -s)" in
+            Linux)
+              HH_PLATFORM="linux-amd64"
+              RESOLC_NAME="resolc-x86_64-unknown-linux-musl"
+              RESOLC_SHA256="e626ba7a1a0d26828c14713781b0082ececc9a0fbfe984f11f0d93d66bbd7806"
+              ;;
+            Darwin)
+              HH_PLATFORM="macosx-amd64"
+              RESOLC_NAME="resolc-universal-apple-darwin"
+              RESOLC_SHA256="eaee8e64a863101e95e92e68b1e4e936081a97a68bc9dbf308a63f2d0084ce83"
+              ;;
+            *)
+              echo "Unsupported OS for pinned resolc install: $(uname -s)"
+              exit 1
+              ;;
+          esac
+
+          RESOLC_FILE="${RESOLC_NAME}+commit.${RESOLC_COMMIT}"
+          COMPILERS_DIR="$(node -e "require('hardhat/internal/util/global-dir').getCompilersDir().then((d) => process.stdout.write(d))")"
+          PLATFORM_DIR="${COMPILERS_DIR}/${HH_PLATFORM}"
+          TARGET_BIN="${PLATFORM_DIR}/${RESOLC_FILE}"
+
+          mkdir -p "${PLATFORM_DIR}"
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+            "https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/${RESOLC_NAME}" \
+            -o "${TARGET_BIN}"
+          echo "${RESOLC_SHA256}  ${TARGET_BIN}" | shasum -a 256 -c -
+          chmod +x "${TARGET_BIN}"
+
+          cat > "${PLATFORM_DIR}/resolc-list.json" <<EOF
+          {
+            "builds": [
+              {
+                "name": "${RESOLC_NAME}",
+                "path": "${RESOLC_FILE}",
+                "version": "${RESOLC_VERSION}",
+                "build": "${RESOLC_COMMIT}",
+                "longVersion": "${RESOLC_VERSION}+commit.${RESOLC_COMMIT}.llvm-18.1.8",
+                "sha256": "${RESOLC_SHA256}",
+                "platform": "${HH_PLATFORM}"
+              }
+            ],
+            "releases": {
+              "v${RESOLC_VERSION}": "${RESOLC_FILE}"
+            },
+            "latestRelease": "v${RESOLC_VERSION}"
+          }
+          EOF
+
+          "${TARGET_BIN}" --version
+
+      - name: Compile historical PolkaVM contracts
+        run: npm run -w contracts compile:polkavm:historical
+
+      - name: Generate historical PolkaVM compile evidence bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p reports/polkavm-compile
+
+          files_file="reports/polkavm-compile/artifact-files.txt"
+          hashes_file="reports/polkavm-compile/artifact-hashes.txt"
+          bundle_file="reports/polkavm-compile/compile-evidence.json"
+
+          find contracts/artifacts -type f | LC_ALL=C sort > "$files_file"
+
+          if [[ -s "$files_file" ]]; then
+            while IFS= read -r file; do
+              shasum -a 256 "$file"
+            done < "$files_file" > "$hashes_file"
+          else
+            : > "$hashes_file"
+          fi
+
+          artifact_set_hash=$(shasum -a 256 "$hashes_file" | awk '{print $1}')
+          commit_sha=$(git rev-parse HEAD)
+
+          cat > "$bundle_file" <<EOF
+          {
+            "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "commitSha": "${commit_sha}",
+            "artifactFileCount": $(wc -l < "$files_file" | tr -d ' '),
+            "artifactHashesFile": "${hashes_file}",
+            "artifactSetHashSha256": "${artifact_set_hash}"
+          }
+          EOF
+
+      - name: Upload historical PolkaVM compile artifact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: historical-polkavm-compile
+          path: reports/polkavm-compile
+
+  historical-polkavm-deploy-verification:
+    name: historical/polkavm-deploy-verification
+    runs-on: ubuntu-latest
+    needs:
+      - historical-polkavm-compile
+    env:
+      DEPLOY_VERIFY_RPC_URL: "https://services.polkadothub-rpc.com/testnet"
+      DEPLOY_VERIFY_NETWORK_NAME: "polkadotTestnet"
+      DEPLOY_VERIFY_RUNTIME_TARGET: "paseo-asset-hub-revive"
+      DEPLOY_VERIFY_EXPECTED_CHAIN_ID: "0x190f1b41"
+      DEPLOY_VERIFY_ARTIFACT_PATH: "contracts/artifacts/src/MockUSDC.sol/MockUSDC.json"
+      DEPLOY_VERIFY_CONTRACT_ADDRESS: "0xd58fA437C8Ad344a85D6CA99E91700a1E160d87b"
+      DEPLOY_VERIFY_TX_HASH: "0x6ea53035e3f594a40913a56c4257045a9101dbb7309b6721ab81d17d1cef574f"
+      DEPLOY_VERIFY_COMPILER_NAME: "solc"
+      DEPLOY_VERIFY_OUT_DIR: "reports/deploy-verification"
+      DEPLOY_VERIFY_TIMEOUT_MS: '12000'
+      DEPLOY_VERIFY_RETRIES: '3'
+      DEPLOY_VERIFY_BACKOFF_MS: '1000'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install pinned historical resolc binary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RESOLC_VERSION="1.0.0"
+          RESOLC_COMMIT="b080c1"
+          HH_PLATFORM="linux-amd64"
+          RESOLC_NAME="resolc-x86_64-unknown-linux-musl"
+          RESOLC_SHA256="e626ba7a1a0d26828c14713781b0082ececc9a0fbfe984f11f0d93d66bbd7806"
+          RESOLC_FILE="${RESOLC_NAME}+commit.${RESOLC_COMMIT}"
+          COMPILERS_DIR="$(node -e "require('hardhat/internal/util/global-dir').getCompilersDir().then((d) => process.stdout.write(d))")"
+          PLATFORM_DIR="${COMPILERS_DIR}/${HH_PLATFORM}"
+          TARGET_BIN="${PLATFORM_DIR}/${RESOLC_FILE}"
+
+          mkdir -p "${PLATFORM_DIR}"
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+            "https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/${RESOLC_NAME}" \
+            -o "${TARGET_BIN}"
+          echo "${RESOLC_SHA256}  ${TARGET_BIN}" | shasum -a 256 -c -
+          chmod +x "${TARGET_BIN}"
+
+          cat > "${PLATFORM_DIR}/resolc-list.json" <<EOF
+          {
+            "builds": [
+              {
+                "name": "${RESOLC_NAME}",
+                "path": "${RESOLC_FILE}",
+                "version": "${RESOLC_VERSION}",
+                "build": "${RESOLC_COMMIT}",
+                "longVersion": "${RESOLC_VERSION}+commit.${RESOLC_COMMIT}.llvm-18.1.8",
+                "sha256": "${RESOLC_SHA256}",
+                "platform": "${HH_PLATFORM}"
+              }
+            ],
+            "releases": {
+              "v${RESOLC_VERSION}": "${RESOLC_FILE}"
+            },
+            "latestRelease": "v${RESOLC_VERSION}"
+          }
+          EOF
+
+      - name: Generate historical PolkaVM contract artifacts for verification
+        run: npm run -w contracts compile:polkavm:historical
+
+      - name: Run historical deploy verification smoke tests
+        run: node --test scripts/tests/polkavm-deploy-verify-smoke.test.mjs
+
+      - name: Verify historical deployed contract bytecode and deployment evidence
+        run: node scripts/polkavm-deploy-verify.mjs
+
+      - name: Upload historical deploy verification artifact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: historical-polkavm-deploy-verification
+          path: reports/deploy-verification

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -176,6 +176,8 @@ jobs:
           run_check docs-profile-name scripts/tests/docs-profile-name-guard.sh
           run_check api-gateway-boundary scripts/tests/api-gateway-boundary-guard.sh
           run_check programmability-governance scripts/tests/programmability-governance-guard.sh
+          run_check base-mainnet-governance scripts/tests/base-mainnet-governance-guard.sh
+          run_check polkadot-retirement scripts/tests/polkadot-retirement-guard.sh
           run_check data-classification-guard node scripts/tests/data-classification-guard.mjs
           run_check monitoring-baseline-validator node scripts/monitoring-baseline-validate.mjs --runbook docs/runbooks/monitoring-alerting-baseline.md --out ci-reports/monitoring-baseline-validation.json
 
@@ -198,62 +200,6 @@ jobs:
         with:
           name: ci-report-monitoring-baseline
           path: ci-reports/monitoring-baseline-validation.json
-
-  arch-roadmap-consistency:
-    if: ${{ vars.ENABLE_HISTORICAL_ABC_GOVERNANCE == 'true' }}
-    name: ci/arch-roadmap-consistency-historical
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Run historical A/B/C architecture-roadmap consistency guard
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set +e
-          mkdir -p ci-reports
-          node scripts/architecture-roadmap-consistency-check.mjs \
-            --repo "${{ github.repository }}" \
-            --out "ci-reports/arch-roadmap-consistency.json" \
-            > ci-reports/arch-roadmap-consistency.log 2>&1
-          status=$?
-          if [[ "$status" -ne 0 ]]; then
-            node scripts/arch-roadmap-sync.mjs \
-              --repo "${{ github.repository }}" \
-              --out "ci-reports/arch-roadmap-sync.json" \
-              --patch "ci-reports/arch-roadmap-sync.patch" \
-              >> ci-reports/arch-roadmap-consistency.log 2>&1 || true
-            {
-              echo ""
-              echo "Remediation:"
-              echo "  Historical-only A/B/C governance drift was detected."
-              echo "  This check is disabled by default for the active Base migration and should only be enabled for archive maintenance."
-              echo "  GITHUB_TOKEN=\"\$(gh auth token)\" node scripts/arch-roadmap-sync.mjs --repo \"${{ github.repository }}\" --write"
-              echo "  GITHUB_TOKEN=\"\$(gh auth token)\" node scripts/arch-roadmap-sync.mjs --repo \"${{ github.repository }}\" --write --normalize-progress"
-              echo "  GITHUB_TOKEN=\"\$(gh auth token)\" node scripts/arch-roadmap-sync.mjs --repo \"${{ github.repository }}\" --write-gate-issues --apply"
-            } >> ci-reports/arch-roadmap-consistency.log
-          fi
-          cat ci-reports/arch-roadmap-consistency.log
-          exit "$status"
-
-      - name: Upload architecture-roadmap consistency report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: ci-report-arch-roadmap-consistency
-          path: |
-            ci-reports/arch-roadmap-consistency.json
-            ci-reports/arch-roadmap-consistency.log
-            ci-reports/arch-roadmap-sync.json
-            ci-reports/arch-roadmap-sync.patch
 
   env-profile-regression:
     name: ci/env-profile-regression
@@ -289,8 +235,6 @@ jobs:
           run_check docker-services-env-layering scripts/tests/docker-services-env-layering.test.sh
           run_check staging-e2e-real-gate-start-block scripts/tests/staging-e2e-real-gate-start-block.test.sh
           run_check notifications-wiring-health scripts/tests/notifications-wiring-health.test.sh
-          run_check arch-roadmap-consistency scripts/tests/architecture-roadmap-consistency-check.test.sh
-          run_check arch-roadmap-sync scripts/tests/architecture-roadmap-sync.test.sh
 
           if [[ "$fail" -ne 0 ]]; then
             exit 1
@@ -418,58 +362,6 @@ jobs:
           path: reports/reconciliation/staging-e2e-real-report.json
           if-no-files-found: error
 
-  asset-fee-path:
-    if: vars.ENABLE_HISTORICAL_ASSET_FEE_PATH == 'true'
-    name: ci/asset-fee-path-historical
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Prepare profile env files
-        run: |
-          cp .env.example .env
-          cp .env.local.example .env.local
-          cp .env.staging-e2e-real.example .env.staging-e2e-real
-
-      - name: Run historical asset fee-path checks (config-only)
-        shell: bash
-        run: |
-          set +e
-          mkdir -p ci-reports
-          report="ci-reports/asset-fee-path.txt"
-          fail=0
-
-          run_check() {
-            local label="$1"
-            local cmd="$2"
-            echo "[$label] command: $cmd" | tee -a "$report"
-            if bash -lc "$cmd"; then
-              echo "[$label] PASS" | tee -a "$report"
-            else
-              echo "[$label] FAIL" | tee -a "$report"
-              fail=1
-            fi
-            echo "" >> "$report"
-          }
-
-          run_check local-dev "ASSET_FEE_PATH_ASSERT_CONFIG_ONLY=true bash scripts/asset-fee-path-gate.sh local-dev"
-          run_check staging-e2e-real "ASSET_FEE_PATH_ASSERT_CONFIG_ONLY=true bash scripts/asset-fee-path-gate.sh staging-e2e-real"
-          run_check regression-test "bash scripts/tests/asset-fee-path-gate.test.sh"
-
-          if [[ "$fail" -ne 0 ]]; then
-            exit 1
-          fi
-
-      - name: Upload historical asset fee-path report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: ci-report-asset-fee-path-historical
-          path: |
-            ci-reports/asset-fee-path.txt
-            reports/asset-fee-path
-
   contracts:
     name: ci/contracts
     runs-on: ubuntu-latest
@@ -491,195 +383,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install pinned historical resolc binary (deterministic)
-        if: vars.ENABLE_HISTORICAL_POLKAVM_COMPILE_EVIDENCE == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          RESOLC_VERSION="1.0.0"
-          RESOLC_COMMIT="b080c1"
-
-          case "$(uname -s)" in
-            Linux)
-              HH_PLATFORM="linux-amd64"
-              RESOLC_NAME="resolc-x86_64-unknown-linux-musl"
-              RESOLC_SHA256="e626ba7a1a0d26828c14713781b0082ececc9a0fbfe984f11f0d93d66bbd7806"
-              ;;
-            Darwin)
-              HH_PLATFORM="macosx-amd64"
-              RESOLC_NAME="resolc-universal-apple-darwin"
-              RESOLC_SHA256="eaee8e64a863101e95e92e68b1e4e936081a97a68bc9dbf308a63f2d0084ce83"
-              ;;
-            *)
-              echo "Unsupported OS for pinned resolc install: $(uname -s)"
-              exit 1
-              ;;
-          esac
-
-          RESOLC_FILE="${RESOLC_NAME}+commit.${RESOLC_COMMIT}"
-          COMPILERS_DIR="$(node -e "require('hardhat/internal/util/global-dir').getCompilersDir().then((d) => process.stdout.write(d))")"
-          PLATFORM_DIR="${COMPILERS_DIR}/${HH_PLATFORM}"
-          TARGET_BIN="${PLATFORM_DIR}/${RESOLC_FILE}"
-
-          mkdir -p "${PLATFORM_DIR}"
-          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
-            "https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/${RESOLC_NAME}" \
-            -o "${TARGET_BIN}"
-          echo "${RESOLC_SHA256}  ${TARGET_BIN}" | shasum -a 256 -c -
-          chmod +x "${TARGET_BIN}"
-
-          cat > "${PLATFORM_DIR}/resolc-list.json" <<EOF
-          {
-            "builds": [
-              {
-                "name": "${RESOLC_NAME}",
-                "path": "${RESOLC_FILE}",
-                "version": "${RESOLC_VERSION}",
-                "build": "${RESOLC_COMMIT}",
-                "longVersion": "${RESOLC_VERSION}+commit.${RESOLC_COMMIT}.llvm-18.1.8",
-                "sha256": "${RESOLC_SHA256}",
-                "platform": "${HH_PLATFORM}"
-              }
-            ],
-            "releases": {
-              "v${RESOLC_VERSION}": "${RESOLC_FILE}"
-            },
-            "latestRelease": "v${RESOLC_VERSION}"
-          }
-          EOF
-
-          "${TARGET_BIN}" --version
-
-      - name: Compile historical PolkaVM contracts via resolc path
-        if: vars.ENABLE_HISTORICAL_POLKAVM_COMPILE_EVIDENCE == 'true'
-        run: npm run -w contracts compile:polkavm:historical
-
-      - name: Generate historical PolkaVM compile evidence bundle
-        if: always() && vars.ENABLE_HISTORICAL_POLKAVM_COMPILE_EVIDENCE == 'true'
-        shell: bash
-        run: |
-          set +e
-          mkdir -p reports/polkavm-compile
-
-          files_file="reports/polkavm-compile/artifact-files.txt"
-          hashes_file="reports/polkavm-compile/artifact-hashes.txt"
-          bundle_file="reports/polkavm-compile/compile-evidence.json"
-
-          find contracts/artifacts -type f | LC_ALL=C sort > "$files_file"
-
-          if [[ -s "$files_file" ]]; then
-            while IFS= read -r file; do
-              shasum -a 256 "$file"
-            done < "$files_file" > "$hashes_file"
-          else
-            : > "$hashes_file"
-          fi
-
-          artifact_set_hash=$(shasum -a 256 "$hashes_file" | awk '{print $1}')
-          commit_sha=$(git rev-parse HEAD)
-          resolc_version=$(node -p "const fs=require('fs');const path=require('path');const entry=require.resolve('@parity/resolc');const pkg=JSON.parse(fs.readFileSync(path.join(path.dirname(entry),'..','package.json'),'utf8'));pkg.version" 2>/dev/null || echo "unknown")
-
-          solc_version=$(node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const dir = path.join(process.cwd(), 'contracts', 'artifacts', 'build-info');
-          try {
-            const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
-            if (files.length === 0) {
-              process.stdout.write('unknown');
-              process.exit(0);
-            }
-            const buildInfo = JSON.parse(fs.readFileSync(path.join(dir, files[0]), 'utf8'));
-            process.stdout.write(buildInfo.solcVersion || 'unknown');
-          } catch {
-            process.stdout.write('unknown');
-          }
-          NODE
-          )
-
-          solc_long_version=$(node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const dir = path.join(process.cwd(), 'contracts', 'artifacts', 'build-info');
-          try {
-            const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
-            if (files.length === 0) {
-              process.stdout.write('unknown');
-              process.exit(0);
-            }
-            const buildInfo = JSON.parse(fs.readFileSync(path.join(dir, files[0]), 'utf8'));
-            process.stdout.write(buildInfo.solcLongVersion || 'unknown');
-          } catch {
-            process.stdout.write('unknown');
-          }
-          NODE
-          )
-
-          pvm_artifact_count=$(node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const root = path.join(process.cwd(), 'contracts', 'artifacts');
-          let count = 0;
-          function walk(dir) {
-            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-              const full = path.join(dir, entry.name);
-              if (entry.isDirectory()) {
-                walk(full);
-                continue;
-              }
-              if (!entry.name.endsWith('.json') || entry.name.endsWith('.dbg.json')) {
-                continue;
-              }
-              try {
-                const parsed = JSON.parse(fs.readFileSync(full, 'utf8'));
-                if (parsed && parsed._format === 'hh-resolc-artifact-1') {
-                  count += 1;
-                }
-              } catch {}
-            }
-          }
-          try {
-            walk(root);
-            process.stdout.write(String(count));
-          } catch {
-            process.stdout.write('0');
-          }
-          NODE
-          )
-
-          cat > "$bundle_file" <<EOF
-          {
-            "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "commitSha": "${commit_sha}",
-            "resolcVersion": "${resolc_version}",
-            "solcVersion": "${solc_version}",
-            "solcLongVersion": "${solc_long_version}",
-            "artifactFileCount": $(wc -l < "$files_file" | tr -d ' '),
-            "pvmArtifactCount": ${pvm_artifact_count},
-            "artifactHashesFile": "${hashes_file}",
-            "artifactSetHashSha256": "${artifact_set_hash}"
-          }
-          EOF
-
-      - name: Guard historical PolkaVM artifact evidence integrity
-        if: always() && vars.ENABLE_HISTORICAL_POLKAVM_COMPILE_EVIDENCE == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          bundle_file="reports/polkavm-compile/compile-evidence.json"
-          if [[ ! -f "$bundle_file" ]]; then
-            echo "Missing compile evidence bundle: $bundle_file"
-            exit 1
-          fi
-
-          pvm_count="$(jq -r '.pvmArtifactCount // empty' "$bundle_file")"
-          if [[ -z "$pvm_count" || "$pvm_count" == "0" || "$pvm_count" == "null" ]]; then
-            echo "pvmArtifactCount=$pvm_count (expected >0). resolc artifacts missing/overwritten."
-            exit 1
-          fi
-          echo "pvmArtifactCount=$pvm_count"
 
       - name: Run workspace checks
         shell: bash
@@ -711,127 +414,12 @@ jobs:
             exit 1
           fi
 
-      - name: Upload historical PolkaVM compile evidence bundle
-        if: always() && vars.ENABLE_HISTORICAL_POLKAVM_COMPILE_EVIDENCE == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: ci-report-contracts-compile-polkavm-historical
-          path: reports/polkavm-compile
-
       - name: Upload workspace report
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ci-report-${{ env.WORKSPACE }}
           path: ci-reports/${{ env.WORKSPACE }}.txt
-
-  contracts_deploy_verification:
-    if: ${{ (needs.changes.outputs.full_matrix == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.contracts == 'true') && vars.ENABLE_HISTORICAL_POLKADOT_DEPLOY_VERIFICATION == 'true' }}
-    name: ci/contracts-deploy-verification-historical
-    runs-on: ubuntu-latest
-    needs:
-      - changes
-      - contracts
-    env:
-      DEPLOY_VERIFY_RPC_URL: "https://services.polkadothub-rpc.com/testnet"
-      DEPLOY_VERIFY_NETWORK_NAME: "polkadotTestnet"
-      DEPLOY_VERIFY_RUNTIME_TARGET: "paseo-asset-hub-revive"
-      DEPLOY_VERIFY_EXPECTED_CHAIN_ID: "0x190f1b41"
-      DEPLOY_VERIFY_ARTIFACT_PATH: "contracts/artifacts/src/MockUSDC.sol/MockUSDC.json"
-      DEPLOY_VERIFY_CONTRACT_ADDRESS: "0xd58fA437C8Ad344a85D6CA99E91700a1E160d87b"
-      DEPLOY_VERIFY_TX_HASH: "0x6ea53035e3f594a40913a56c4257045a9101dbb7309b6721ab81d17d1cef574f"
-      DEPLOY_VERIFY_COMPILER_NAME: "solc"
-      DEPLOY_VERIFY_OUT_DIR: "reports/deploy-verification"
-      DEPLOY_VERIFY_TIMEOUT_MS: '12000'
-      DEPLOY_VERIFY_RETRIES: '3'
-      DEPLOY_VERIFY_BACKOFF_MS: '1000'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install pinned historical resolc binary (deterministic)
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          RESOLC_VERSION="1.0.0"
-          RESOLC_COMMIT="b080c1"
-
-          case "$(uname -s)" in
-            Linux)
-              HH_PLATFORM="linux-amd64"
-              RESOLC_NAME="resolc-x86_64-unknown-linux-musl"
-              RESOLC_SHA256="e626ba7a1a0d26828c14713781b0082ececc9a0fbfe984f11f0d93d66bbd7806"
-              ;;
-            Darwin)
-              HH_PLATFORM="macosx-amd64"
-              RESOLC_NAME="resolc-universal-apple-darwin"
-              RESOLC_SHA256="eaee8e64a863101e95e92e68b1e4e936081a97a68bc9dbf308a63f2d0084ce83"
-              ;;
-            *)
-              echo "Unsupported OS for pinned resolc install: $(uname -s)"
-              exit 1
-              ;;
-          esac
-
-          RESOLC_FILE="${RESOLC_NAME}+commit.${RESOLC_COMMIT}"
-          COMPILERS_DIR="$(node -e "require('hardhat/internal/util/global-dir').getCompilersDir().then((d) => process.stdout.write(d))")"
-          PLATFORM_DIR="${COMPILERS_DIR}/${HH_PLATFORM}"
-          TARGET_BIN="${PLATFORM_DIR}/${RESOLC_FILE}"
-
-          mkdir -p "${PLATFORM_DIR}"
-          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
-            "https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/${RESOLC_NAME}" \
-            -o "${TARGET_BIN}"
-          echo "${RESOLC_SHA256}  ${TARGET_BIN}" | shasum -a 256 -c -
-          chmod +x "${TARGET_BIN}"
-
-          cat > "${PLATFORM_DIR}/resolc-list.json" <<EOF
-          {
-            "builds": [
-              {
-                "name": "${RESOLC_NAME}",
-                "path": "${RESOLC_FILE}",
-                "version": "${RESOLC_VERSION}",
-                "build": "${RESOLC_COMMIT}",
-                "longVersion": "${RESOLC_VERSION}+commit.${RESOLC_COMMIT}.llvm-18.1.8",
-                "sha256": "${RESOLC_SHA256}",
-                "platform": "${HH_PLATFORM}"
-              }
-            ],
-            "releases": {
-              "v${RESOLC_VERSION}": "${RESOLC_FILE}"
-            },
-            "latestRelease": "v${RESOLC_VERSION}"
-          }
-          EOF
-
-          "${TARGET_BIN}" --version
-
-      - name: Generate historical PolkaVM contract artifacts for verification
-        run: npm run -w contracts compile:polkavm:historical
-
-      - name: Run historical deploy verification smoke tests
-        run: node --test scripts/tests/polkavm-deploy-verify-smoke.test.mjs
-
-      - name: Verify historical deployed contract bytecode and deployment evidence
-        run: node scripts/polkavm-deploy-verify.mjs
-
-      - name: Upload historical deploy verification artifact
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: ci-report-contracts-deploy-verification-historical
-          path: reports/deploy-verification
 
   sdk:
     name: ci/sdk
@@ -1249,12 +837,9 @@ jobs:
     needs:
       - changes
       - docs-profile-guard
-      - arch-roadmap-consistency
       - env-profile-regression
       - staging-e2e-real-gate
-      - asset-fee-path
       - contracts
-      - contracts_deploy_verification
       - sdk
       - oracle
       - indexer
@@ -1272,12 +857,9 @@ jobs:
           declare -A results
           results["ci/changes"]="${{ needs.changes.result }}"
           results["ci/docs-profile-guard"]="${{ needs.docs-profile-guard.result }}"
-          results["ci/arch-roadmap-consistency"]="${{ needs.arch-roadmap-consistency.result }}"
           results["ci/env-profile-regression"]="${{ needs.env-profile-regression.result }}"
           results["ci/staging-e2e-real-gate"]="${{ needs.staging-e2e-real-gate.result }}"
-          results["ci/asset-fee-path-historical"]="${{ needs.asset-fee-path.result }}"
           results["ci/contracts"]="${{ needs.contracts.result }}"
-          results["ci/contracts-deploy-verification-historical"]="${{ needs.contracts_deploy_verification.result }}"
           results["ci/sdk"]="${{ needs.sdk.result }}"
           results["ci/oracle"]="${{ needs.oracle.result }}"
           results["ci/indexer"]="${{ needs.indexer.result }}"

--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -3335,10 +3335,6 @@ components:
         txHash:
           type: string
           description: Canonical EVM transaction hash when available.
-        extrinsicHash:
-          type: string
-          deprecated: true
-          description: Historical-only compatibility input. Base-era submitted and confirmed events must use `txHash`.
         detail:
           type: string
         metadata:

--- a/docs/incidents/first-15-minutes-checklist.md
+++ b/docs/incidents/first-15-minutes-checklist.md
@@ -21,8 +21,15 @@ scripts/docker-services.sh logs local-dev ricardian
 5. Run release-gate diagnostics for the impacted profile:
    - `docs/runbooks/staging-e2e-release-gate.md`
    - `docs/runbooks/staging-e2e-real-release-gate.md`
+   - For Base mainnet launch or rollback windows, also use:
+     - `docs/runbooks/base-mainnet-go-no-go.md`
+     - `docs/runbooks/base-mainnet-cutover-and-rollback.md`
 6. Confirm whether issue is chain connectivity, indexer drift, auth failures, attestation/compliance-provider outage, or data-layer fault.
 7. Start `docs/incidents/incident-evidence-template.md` and record affected trade IDs, action keys, request IDs, trace IDs, tx hashes, and attestation issuer/provider references when applicable.
 8. Decide containment path (pause/disable/or continue with monitoring) and record the owner and timestamp in the template.
 9. Link operator-reviewed evidence packets from `docs/runbooks/operator-audit-evidence-template.md` when recovery actions require approval or audit follow-up.
 10. Notify stakeholders with current blast radius and next update time.
+
+Launch-window rule:
+- Do not improvise historical Polkadot rollback paths during a Base mainnet incident.
+- Historical artifacts remain audit-only and are enumerated in `docs/runbooks/polkadot-retirement-checklist.md`.

--- a/docs/runbooks/architecture-coverage-matrix.md
+++ b/docs/runbooks/architecture-coverage-matrix.md
@@ -7,6 +7,7 @@ Historical-only note:
 - It is not the active v1 migration source of truth.
 - The active Base migration execution source of truth is issue `#339` and milestones `M0` through `M5`.
 - Do not use this matrix to determine current pilot readiness, M4 closure, or M5 go/no-go. Those decisions must be taken from the Base migration issue tree, active Base runbooks, and the actual pilot evidence packet.
+- During M5, this matrix is archive-only evidence. It must not be used as an active weekly operator checklist.
 
 Scope:
 - Source of truth is repository code, merged/open PRs, and roadmap issues.
@@ -28,7 +29,7 @@ Production readiness checklist:
 Row metadata semantics:
 - `Owner`: maintainer group responsible for row freshness/evidence upkeep.
 - `Last Refreshed`: last date the row evidence/status was validated.
-- `Refresh Cadence`: expected review frequency for row maintenance.
+- `Refresh Cadence`: expected review frequency for row maintenance. Use `archive-only` when the row is preserved purely as historical evidence after retirement.
 
 | Component | Milestone Target | Status | % Complete | Roadmap Issue(s) | Evidence | Remaining Gap | Owner | Last Refreshed | Refresh Cadence |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -38,7 +39,7 @@ Row metadata semantics:
 | Indexer pipeline + GraphQL schema correctness | A/B | Done | 100 | #44, #174 | `indexer/src/main.ts` (tx/extrinsic separation), `indexer/schema.graphql` (`txHash`, `extrinsicHash` indexed fields), `indexer/src/model/generated/tradeEvent.model.ts`, `indexer/db/migrations/1771180205323-Data.js`, PR #23, PR #177 | None for issue-#44 and issue-#174 scope | roadmap-maintainers | 2026-02-28 | weekly |
 | Reconciliation drift remediation | A/B | Done | 100 | #45, #53 | `reconciliation/src/core/classifier.ts`, `reconciliation/src/core/reconciler.ts`, `reconciliation/src/core/reconciliationReport.ts`, `reconciliation/src/tests/classifier-address-validation.test.ts`, `reconciliation/src/tests/reconciliation-report.test.ts`, `scripts/staging-e2e-real-gate.sh`, PR #182 | None for issue-#45 and issue-#53 scope | roadmap-maintainers | 2026-03-01 | weekly |
 | SDK typed modules + ABI parity | A | Done | 100 | #46, #50 | `sdk/src/modules/`, `sdk/tests/abiAlignment.test.ts`, `sdk/README.md`, PR #12, PR #15, CI run 22197616358 (`ci/sdk` success) | None for issue-#46 scope (checkout integration tracked in #50) | roadmap-maintainers | 2026-02-28 | weekly |
-| Release gates + profile health determinism | A/B | In Progress | 75 | #47, #55, #71 | `scripts/docker-services.sh`, `scripts/staging-e2e-gate.sh`, `scripts/tests/docker-services-args.test.sh`, PR #28, PR #39, PR #41 (open) | Staging-real gate promotion and full CI enforcement are not complete | roadmap-maintainers | 2026-02-28 | weekly |
+| Release gates + profile health determinism | A/B | Done | 100 | #47, #55, #71 | `scripts/docker-services.sh`, `scripts/staging-e2e-gate.sh`, `scripts/tests/docker-services-args.test.sh`, PR #28, PR #39, PR #41 (open) | None for retired A/B release-gate scope | roadmap-maintainers | 2026-04-01 | archive-only |
 | Core docs + runbooks + developer guidance | A | Done | 100 | #49, #65, #172 | `README.md`, `docs/docker-services.md`, `docs/runbooks/staging-e2e-release-gate.md`, `docs/runbooks/production-readiness-checklist.md`, `docs/runbooks/pull-over-push-claim-flow.md`, `docs/runbooks/treasury-to-fiat-sop.md`, `docs/runbooks/reconciliation.md`, PR #31, PR #34, PR #178 | None for issue-#49, issue-#65, and issue-#172 scope | roadmap-maintainers | 2026-02-28 | weekly |
 | Dashboard + unified checkout + settlement tracker | B | Blocked | 25 | #50, #129 | SDK support exists (`sdk/src/modules/`, `sdk/README.md`), Web3Auth dependency present | No in-repo dashboard surface; cross-repo dependency governance still required for closure | roadmap-maintainers | 2026-02-28 | weekly |
 | Identity service + user profile persistence | B | Done | 100 | #122 | `auth/`, `auth/src/core/sessionService.ts`, `auth/src/database/schema.sql`, `sdk/src/modules/authClient.ts`, PR #197 | None for issue-#122 scope | roadmap-maintainers | 2026-03-01 | weekly |
@@ -46,9 +47,9 @@ Row metadata semantics:
 | Oracle trigger + approval + retry controls | B/C | In Progress | 70 | #51, #56, #61, #124 | `oracle/src/core/trigger-manager.ts`, `oracle/src/worker/confirmation-worker.ts`, `oracle/src/api/routes.ts`, `docs/runbooks/oracle-redrive.md`, PR #14 | Pilot manual-approval mode and complete SOP hardening still open | roadmap-maintainers | 2026-02-28 | weekly |
 | Treasury payout queue + audit traceability | B/C | Blocked | 40 | #52, #67, #126, #127 | `treasury/src/database/schema.sql`, `treasury/src/database/queries.ts`, `treasury/src/core/payout.ts`, PR #22 | Processing/audit workflow requires missing operator UI/workflow integration and bank/fiat boundary finalization | roadmap-maintainers | 2026-02-28 | weekly |
 | Reconciliation reports (on-chain ↔ fiat evidence) | B | Done | 100 | #53 | `reconciliation/src/report-cli.ts`, `reconciliation/src/core/reconciliationReport.ts`, `reconciliation/src/tests/reconciliation-report.test.ts`, `scripts/staging-e2e-real-gate.sh`, `.github/workflows/release-gate.yml` (`ci-report-reconciliation-report`), `docs/runbooks/reconciliation.md`, PR #182 | None for issue-#53 scope | roadmap-maintainers | 2026-03-01 | weekly |
-| AssetHub assets + USDC fee conversion validation | A | In Progress | 60 | #63 | `scripts/asset-fee-path-gate.sh`, `scripts/asset-fee-path-validate.mjs`, `scripts/tests/asset-fee-path-gate.test.sh`, `docs/runbooks/asset-conversion-fee-validation.md`, `.github/workflows/release-gate.yml` (`ci/asset-fee-path`) | Live staging tx reference set for `usdc-preferred` mode still needs operator-supplied tx hashes/evidence | roadmap-maintainers | 2026-02-28 | weekly |
-| PolkaVM deployment verification + smoke checks | A | Done | 100 | #64 | `scripts/polkavm-deploy-verify.mjs`, `.github/workflows/release-gate.yml` (`ci/contracts-deploy-verification`), `docs/runbooks/polkavm-deploy-verification.md`, PR #141 (merged), CI run 22491206400 (`ci/contracts-deploy-verification` success + artifact), CI run 22492497423 (`bytecodeHashMatch=true` with real artifact path in `ci-report-contracts-deploy-verification`) | None for issue-#64 scope | roadmap-maintainers | 2026-02-28 | weekly |
-| Mainnet pilot execution evidence | B | Backlog | 0 | #66 | None in repo yet | No transaction evidence package or pilot proof artifacts | roadmap-maintainers | 2026-02-28 | weekly |
+| AssetHub assets + USDC fee conversion validation | A | Out of Scope | 0 | #63 | `scripts/asset-fee-path-gate.sh`, `scripts/asset-fee-path-validate.mjs`, `scripts/tests/asset-fee-path-gate.test.sh`, `docs/runbooks/asset-conversion-fee-validation.md`, `.github/workflows/historical-archive-maintenance.yml` (`historical-asset-fee-path`) | Historical AssetHub-only validation retained for audit; not active Base v1 truth | roadmap-maintainers | 2026-04-01 | archive-only |
+| PolkaVM deployment verification + smoke checks | A | Out of Scope | 0 | #64 | `scripts/polkavm-deploy-verify.mjs`, `scripts/tests/polkavm-deploy-verify-smoke.test.mjs`, `docs/runbooks/polkavm-deploy-verification.md`, `.github/workflows/historical-archive-maintenance.yml` (`historical-polkavm-deploy-verification`) | Historical PolkaVM evidence retained for audit; not active Base v1 truth | roadmap-maintainers | 2026-04-01 | archive-only |
+| Mainnet pilot execution evidence | B | Out of Scope | 0 | #66 | `docs/runbooks/base-mainnet-go-no-go.md`, `docs/runbooks/base-mainnet-cutover-and-rollback.md`, `docs/runbooks/polkadot-retirement-checklist.md` | Historical pilot evidence package was retired with M5 launch governance closure; no separate proof bundle is active v1 truth | roadmap-maintainers | 2026-04-01 | archive-only |
 | Hybrid split walkthrough + treasury-to-fiat SOP | B | Done | 100 | #67 | `docs/runbooks/hybrid-split-walkthrough.md`, `docs/runbooks/treasury-to-fiat-sop.md`, `README.md` runbook links | None for issue-#67 scope | roadmap-maintainers | 2026-02-28 | weekly |
 | Pilot documentation package (env + legal/KPI/demo templates + user guide) | C | Done | 100 | #57, #58, #59, #60, #68 | `docs/runbooks/pilot-environment-onboarding.md`, `docs/runbooks/staging-e2e-real-release-gate.md`, `docs/runbooks/pilot-kpi-report-template.md`, `docs/runbooks/demo/community-demo-checklist.md`, `docs/runbooks/demo/community-demo-script.md`, `docs/runbooks/non-custodial-pilot-user-guide.md`, `docs/runbooks/legal-evidence-package-template.md` | None for documentation scope deliverables in repo | roadmap-maintainers | 2026-02-28 | weekly |
 | Pilot lessons-learned case study (post-live execution) | Post-C | Out of Scope | 0 | #69 | None in repo yet | Deferred until real pilot execution evidence exists | roadmap-maintainers | 2026-02-28 | weekly |
@@ -84,8 +85,8 @@ Computation method:
   - SDK typed modules + ABI parity
   - Release gates + profile health determinism
   - Core docs + runbooks + developer guidance
-  - AssetHub assets + USDC fee conversion validation
-  - PolkaVM deployment verification + smoke checks
+  - AssetHub assets + USDC fee conversion validation (historical-only)
+  - PolkaVM deployment verification + smoke checks (historical-only)
 - Gate `#71` (Milestone B) maps to:
   - Dashboard + unified checkout + settlement tracker
   - Identity service + user profile persistence

--- a/docs/runbooks/asset-conversion-fee-validation.md
+++ b/docs/runbooks/asset-conversion-fee-validation.md
@@ -1,4 +1,9 @@
-# Asset Conversion Fee Validation
+# Historical Asset Conversion Fee Validation
+
+Historical-only notice:
+- This runbook is retained for pre-Base traceability.
+- It is not an active Base mainnet launch or rollback requirement.
+- Use `.github/workflows/historical-archive-maintenance.yml` only when maintaining historical archive evidence for this path.
 
 ## Purpose
 

--- a/docs/runbooks/base-mainnet-cutover-and-rollback.md
+++ b/docs/runbooks/base-mainnet-cutover-and-rollback.md
@@ -1,0 +1,163 @@
+# Base Mainnet Cutover and Rollback
+
+## Purpose and scope
+Define the canonical operator sequence for Base mainnet cutover, rollback, and containment.
+
+This runbook covers:
+- preconditions before cutover starts
+- ordered cutover steps
+- rollback triggers and ordered rollback steps
+- containment posture when rollback is partial or blocked
+- role-based ownership during the launch window
+
+This runbook does not cover:
+- protocol feature delivery
+- ad hoc deployment commands outside the approved change record
+- historical Polkadot runtime reactivation
+
+## Authoritative references
+- Launch approval record: `docs/runbooks/base-mainnet-go-no-go.md`
+- Production readiness baseline: `docs/runbooks/production-readiness-checklist.md`
+- Staging real validation: `docs/runbooks/staging-e2e-real-release-gate.md`
+- Incident triage baseline: `docs/incidents/first-15-minutes-checklist.md`
+- Emergency disable/unpause controls: `docs/runbooks/emergency-disable-unpause.md`
+- Signer custody controls: `docs/runbooks/gateway-governance-signer-custody.md`
+- Gateway operator boundary: `docs/runbooks/dashboard-gateway-operations.md`
+- Reconciliation evidence generation: `docs/runbooks/reconciliation.md`
+- Polkadot retirement closure: `docs/runbooks/polkadot-retirement-checklist.md`
+
+## Launch-day ownership matrix
+Use roles, not personal names, in the canonical path:
+
+| Responsibility | Owner role |
+| --- | --- |
+| Launch approval authority | `Engineering Lead` |
+| Runtime promotion execution | `Ops Lead` |
+| Treasury and reconciliation verification | `Treasury Owner` |
+| Incident declaration and containment coordination | `Incident Commander` |
+| Provider escalation coordination | `Ops Lead` |
+| Communications update owner | `Incident Commander` |
+
+## Preconditions before cutover begins
+All of the following must be true before step 1 starts:
+- `docs/runbooks/base-mainnet-go-no-go.md` approval record is present and marked `GO`
+- M4 is complete in GitHub state
+- `docs/runbooks/polkadot-retirement-checklist.md` is complete for active CI, API, and runbook surfaces
+- the production change record or external deployment record is attached
+- current escrow address, chain ID `8453`, and Base mainnet USDC address are recorded
+- signer custody review is complete
+- provider primary and fallback posture is recorded
+- rollback owner and communications owner are assigned
+
+## Cutover steps
+Execute these steps in order. If any step fails, stop and evaluate rollback triggers.
+
+1. Freeze the approval packet.
+   - Record the final go/no-go timestamp and launch window ID.
+   - Record the deployment/change record that will perform runtime promotion.
+
+2. Reconfirm current staging-real evidence.
+   - Run:
+     ```bash
+     scripts/validate-env.sh staging-e2e-real
+     scripts/docker-services.sh health staging-e2e-real
+     scripts/staging-e2e-real-gate.sh
+     scripts/notifications-gate.sh staging-e2e-real
+     npm run -w reconciliation reconcile:report -- --run-key=<runKey> --out reports/reconciliation/<file>.json
+     ```
+   - If any required check fails, stop and mark the window `NO-GO`.
+
+3. Verify deployment truth for the launch window.
+   - If mainnet deployment is part of the launch window, execute only the approved repo command path:
+     ```bash
+     npm run -w contracts deploy:base-mainnet
+     npm run -w contracts verify:base-mainnet
+     ```
+   - If production promotion is executed outside this repo, record the external deployment record URL and do not substitute an untracked local command.
+
+4. Execute the approved production change.
+   - Apply the external deployment/change record or the approved repo deployment command path.
+   - Record the start timestamp, operator role, and change reference.
+
+5. Confirm post-cutover runtime identity.
+   - Verify the active runtime is `base-mainnet`.
+   - Verify the active chain ID is `8453`.
+   - Verify the production escrow address matches the reviewed approval record.
+   - Verify the active explorer base and USDC address match repo runtime truth.
+
+6. Verify post-cutover service health and evidence paths.
+   - Capture service health from the production monitoring system referenced in the change record.
+   - Confirm reconciliation and notification evidence generation are active for the production window.
+   - Record the first post-cutover evidence links in the change record.
+
+7. Declare the window stabilized.
+   - `Engineering Lead`, `Ops Lead`, `Treasury Owner`, and `Incident Commander` all confirm no stop condition is present.
+   - Record the stabilization timestamp.
+
+## Rollback triggers
+Rollback is mandatory if any of the following occurs during the launch window:
+- production deployment/change execution deviates from the approved approval packet
+- wrong chain, wrong escrow address, or wrong runtime is detected
+- provider posture collapses and fallback is not healthy
+- signer custody or execution path violates the approved model
+- critical reconciliation drift appears and cannot be classified safely
+- emergency containment is requested by the `Incident Commander`
+
+## Rollback steps
+Execute these steps in order unless the `Incident Commander` invokes immediate containment first.
+
+1. Declare incident control.
+   - Run the process in `docs/incidents/first-15-minutes-checklist.md`.
+   - Record the incident start timestamp and owner roles.
+
+2. Halt additional production promotion activity.
+   - Stop the active change record or external deployment rollout.
+   - Freeze further runtime mutations until containment is understood.
+
+3. Apply the approved rollback entry from the same change-control surface used for cutover.
+   - Revert to the last known-good Base-era production deployment and configuration bundle.
+   - Do not reactivate historical Polkadot runtime paths as a rollback shortcut.
+
+4. Verify containment state.
+   - Follow `docs/runbooks/emergency-disable-unpause.md` if settlement correctness is uncertain.
+   - Confirm unsafe automation is paused or disabled.
+
+5. Revalidate runtime identity and evidence posture.
+   - Verify runtime identity, chain ID, and escrow address after rollback.
+   - Capture updated service health, provider posture, and reconciliation evidence.
+
+6. Decide stabilization or extended incident handling.
+   - If the system is stable, record the rollback completion timestamp.
+   - If not stable, continue under incident management and do not resume launch activity.
+
+## Containment posture when rollback is partial or blocked
+If rollback cannot complete cleanly:
+- `Incident Commander` owns the active incident
+- `Ops Lead` owns runtime containment
+- `Treasury Owner` owns settlement freeze and audit posture
+- `Engineering Lead` owns remediation change review
+
+Containment rules:
+- prefer disable/pause controls over improvised runtime edits
+- preserve audit evidence for all launch and rollback actions
+- do not restore historical Polkadot operational flows
+- keep historical Polkadot artifacts visible only as archived evidence for operator reference
+
+## Historical Polkadot artifacts during rollback
+Historical Polkadot artifacts may remain visible for audit and traceability only:
+- `docs/runbooks/polkavm-deploy-verification.md`
+- `docs/runbooks/asset-conversion-fee-validation.md`
+- `.github/workflows/historical-archive-maintenance.yml`
+- `.github/workflows/roadmap-weighted-progress-sync.yml`
+
+They must not be used as active production rollback paths.
+
+## Communications path
+For every cutover, rollback, or containment event record:
+- window ID
+- change record URL
+- incident record URL when applicable
+- current operator role holders
+- next update timestamp
+
+The `Incident Commander` owns stakeholder updates and escalation timing.

--- a/docs/runbooks/base-mainnet-go-no-go.md
+++ b/docs/runbooks/base-mainnet-go-no-go.md
@@ -1,0 +1,182 @@
+# Base Mainnet Go/No-Go
+
+## Purpose and scope
+Define the authoritative production approval record for Base mainnet launch.
+
+This runbook exists to answer one question clearly:
+- can Cotsel promote Base from production target-state to active production settlement truth for v1?
+
+This runbook covers:
+- required evidence for production approval
+- required role-based signoff
+- explicit no-go conditions
+- the approval record that must exist before any production cutover begins
+
+This runbook does not cover:
+- protocol feature changes
+- ad hoc launch commands outside approved repo/runtime surfaces
+- product marketing or external launch communications
+
+Hard prerequisite:
+- M4 must already be complete in GitHub state:
+  - PR `#400` merged
+  - issues `#392`, `#393`, `#394`, and `#344` closed
+
+## Authoritative references
+- Production baseline readiness: `docs/runbooks/production-readiness-checklist.md`
+- Staging release gate: `docs/runbooks/staging-e2e-release-gate.md`
+- Staging real release gate: `docs/runbooks/staging-e2e-real-release-gate.md`
+- Mainnet cutover and rollback: `docs/runbooks/base-mainnet-cutover-and-rollback.md`
+- Incident containment baseline: `docs/incidents/first-15-minutes-checklist.md`
+- Signer custody baseline: `docs/runbooks/gateway-governance-signer-custody.md`
+- Gateway operational boundary: `docs/runbooks/dashboard-gateway-operations.md`
+- Reconciliation evidence generation: `docs/runbooks/reconciliation.md`
+- Emergency containment path: `docs/runbooks/emergency-disable-unpause.md`
+- Retirement closure register: `docs/runbooks/polkadot-retirement-checklist.md`
+
+Base network references:
+- Base network/runtime truth in repo: `sdk/src/runtime.ts`
+- Base deployment/runtime truth in repo: `contracts/scripts/lib/baseDeploymentConfig.ts`
+- Official Base docs: `https://docs.base.org/base-chain/quickstart/connecting-to-base`
+- Official Base finality docs: `https://docs.base.org/base-chain/network-information/transaction-finality`
+- Official Base explorer docs: `https://docs.base.org/get-started/block-explorers`
+- Official Circle USDC addresses: `https://developers.circle.com/stablecoins/usdc-contract-addresses`
+
+## Required approval roles
+All four roles must be explicitly recorded in the approval record:
+- `Engineering Lead`
+- `Ops Lead`
+- `Treasury Owner`
+- `Incident Commander`
+
+Role rules:
+- Use operational roles, not personal names, in the canonical record.
+- The launch change record may name the person filling each role for that window.
+- If any role is unassigned, the result is automatically `NO-GO`.
+
+## Required evidence before approval
+The approval record must link all of the following:
+
+1. M4 proof
+- final Base Sepolia evidence packet path or PR reference
+- blocker register result
+- explicit statement that M4 closure artifacts were reviewed
+
+2. Current staging runtime health
+- `scripts/validate-env.sh staging-e2e-real`
+- `scripts/docker-services.sh health staging-e2e-real`
+- `scripts/staging-e2e-real-gate.sh`
+- `scripts/notifications-gate.sh staging-e2e-real`
+- latest reconciliation report generated via:
+  - `npm run -w reconciliation reconcile:report -- --run-key=<runKey> --out reports/reconciliation/<file>.json`
+
+3. Mainnet runtime truth
+- `base-mainnet` runtime selection and chain ID `8453`
+- official Base mainnet explorer base
+- official Base mainnet USDC address
+- current escrow contract address and deployment evidence
+
+4. Provider posture
+- named primary RPC provider
+- named fallback RPC provider
+- confirmation that public Base RPC is not the steady-state production provider
+- provider outage escalation owner
+
+5. Signer custody and execution readiness
+- signer custody review completed against `docs/runbooks/gateway-governance-signer-custody.md`
+- production signer model recorded
+- no production plan relies on long-lived raw private-key env injection
+- governance execution path and containment path verified
+
+6. Treasury readiness
+- treasury operator review completed
+- reconciliation evidence reviewed for treasury-linked flows
+- payout, freeze, and audit expectations confirmed for launch scope
+
+7. Incident readiness
+- incident commander assigned
+- containment path reviewed against `docs/incidents/first-15-minutes-checklist.md`
+- rollback owner and communications owner assigned
+
+8. Deployment/change control reference
+- link to the production deployment system, pipeline, or change record that will perform runtime promotion
+- if the production deployment system is external to this repo, its authoritative runbook or change record URL must be attached
+- if this reference is missing, the result is automatically `NO-GO`
+
+## Repo-grounded validation commands
+These are the required in-repo validation surfaces for launch approval:
+
+```bash
+scripts/validate-env.sh staging-e2e-real
+scripts/docker-services.sh health staging-e2e-real
+scripts/staging-e2e-real-gate.sh
+scripts/notifications-gate.sh staging-e2e-real
+npm run -w reconciliation reconcile:report -- --run-key=<runKey> --out reports/reconciliation/<file>.json
+```
+
+Use these contract deployment commands only when mainnet contract deployment is part of the approved launch window:
+
+```bash
+npm run -w contracts deploy:base-mainnet
+npm run -w contracts verify:base-mainnet
+```
+
+Operator rule:
+- Do not invent a mainnet docker profile or local-only promotion command.
+- Production application deployment and secret rollout are not defined as a repo-local docker profile.
+- Launch approval must reference the actual external deployment system when promotion is not executed directly from this repo.
+
+## No-go conditions
+The approval outcome is `NO-GO` if any of the following are true:
+- M4 is not fully merged and closed remotely
+- any required approval role is unassigned
+- staging-e2e-real validation is red or unresolved
+- reconciliation report includes unresolved critical drift
+- notifications gate is red
+- signer custody model is incomplete or relies on an unapproved production secret posture
+- deployment/change-control record is missing
+- rollback ownership is not explicit
+- the active repo still presents Polkadot as live v1 truth
+
+## Stop conditions after review starts
+Stop the launch approval immediately and move to incident/change review if:
+- new critical security findings appear
+- provider posture changes materially during review
+- production deployment inputs differ from the reviewed approval packet
+- an emergency signer exception is requested without written approval
+- archive/retirement work is still incomplete for active CI or API surfaces
+
+## Approval record
+Populate this record in the launch ticket, change record, or operator evidence packet.
+
+| Field | Value |
+| --- | --- |
+| Launch decision window | `<window-id>` |
+| Base runtime | `base-mainnet` |
+| Chain ID | `8453` |
+| Escrow contract address | `<address>` |
+| Mainnet deploy/verify evidence | `<path or URL>` |
+| M4 evidence packet | `<path or URL>` |
+| Staging gate evidence | `<path or URL>` |
+| Notifications gate evidence | `<path or URL>` |
+| Reconciliation report | `<path or URL>` |
+| Primary RPC provider | `<provider>` |
+| Fallback RPC provider | `<provider>` |
+| Signer custody reference | `<path or URL>` |
+| Deployment/change record | `<path or URL>` |
+| Engineering Lead | `<role holder>` |
+| Ops Lead | `<role holder>` |
+| Treasury Owner | `<role holder>` |
+| Incident Commander | `<role holder>` |
+| Decision | `<GO / NO-GO>` |
+| Decision timestamp (UTC) | `<timestamp>` |
+| Blocking issues | `<none or issue list>` |
+
+## Approval rule
+Launch may proceed only when:
+- all required evidence is linked
+- all four approval roles are recorded
+- decision is explicitly `GO`
+- no blocking issue remains unresolved
+
+If any of those are false, launch must not proceed.

--- a/docs/runbooks/chain-event-parity-retirement.md
+++ b/docs/runbooks/chain-event-parity-retirement.md
@@ -68,3 +68,4 @@ Before marking the legacy ingest retired:
 - `docs/api/cotsel-dashboard-gateway.openapi.yml`
 - `docs/runbooks/operator-audit-evidence-template.md`
 - `docs/incidents/incident-evidence-template.md`
+- `docs/runbooks/polkadot-retirement-checklist.md`

--- a/docs/runbooks/github-roadmap-governance.md
+++ b/docs/runbooks/github-roadmap-governance.md
@@ -8,6 +8,10 @@ Maintain a single execution board for `Cotsel` where every roadmap item and PR i
 - The active milestone model is `M0 Base Migration Decision and Boundary Freeze`, `M1 Base Contract Runtime and Deployment`, `M2 Base Eventing, Reconciliation, and Treasury Safety`, `M3 Backend, Gateway, and Wallet Continuity`, `M4 Base Sepolia Pilot Readiness`, `M5 Base Mainnet Launch and Polkadot Retirement`, plus `Needs Triage`.
 - Historical Milestones A/B/C and their old weighted rollups are retained only for pre-Base traceability. They are not active v1 planning truth.
 - M4 is the operational installation-and-proof gate. M5 must not begin until M4 has a real Base Sepolia rehearsal result, a reviewable evidence packet, and an explicit blocker register.
+- M5 is the production cutover-and-retirement gate. It is not complete until:
+  - `docs/runbooks/base-mainnet-go-no-go.md` exists and is used as the authoritative launch decision record
+  - `docs/runbooks/base-mainnet-cutover-and-rollback.md` exists and is used as the authoritative rollback path
+  - `docs/runbooks/polkadot-retirement-checklist.md` closes the M5-owned residue from issue `#356`
 
 ## Project v2 Definition
 - Project name: `Cotsel Roadmap`
@@ -82,7 +86,8 @@ Auth for project field writes:
 
 Historical-only note:
 - The checker and sync helper apply to the archived A/B/C governance model only.
-- The release-gate job for this historical model is disabled by default during the active Base migration.
+- The active release gate must not depend on the historical A/B/C governance model during M5.
+- Historical governance maintenance belongs only in `.github/workflows/historical-archive-maintenance.yml` and `.github/workflows/roadmap-weighted-progress-sync.yml`.
 - Only enable or run these tools when maintaining archive traceability for the pre-Base roadmap record.
 
 What the checker enforces:

--- a/docs/runbooks/polkadot-retirement-checklist.md
+++ b/docs/runbooks/polkadot-retirement-checklist.md
@@ -1,0 +1,66 @@
+# Polkadot Retirement Checklist
+
+## Purpose and scope
+Close the M5-owned Polkadot retirement items against the stale-artifact register in issue `#356`.
+
+This checklist covers:
+- active CI and release-gate retirement
+- active API contract retirement
+- historical runbook and governance boundary hardening
+- explicit disposition for the M5-owned residue retained for audit
+
+This checklist does not cover:
+- deletion of historical evidence that still has audit value
+- cross-repo migrations that are not represented in the active Cotsel repo surfaces
+
+## Binding register
+- Canonical stale-artifact register: issue `#356`
+- M5 epic: issue `#345`
+- H5 closure issue: issue `#396`
+
+## Retirement decisions
+Each M5-owned item must be in one of these states:
+- removed from active CI or API path
+- archived in place with explicit historical framing
+- retained as compatibility-only with explicit non-canonical status
+
+## M5-owned residue closure table
+| Register item | Path | Final disposition | Validation evidence |
+| --- | --- | --- | --- |
+| Historical A/B/C governance checks | `.github/workflows/release-gate.yml` | Removed from active release gate | Active release gate no longer references historical A/B/C jobs |
+| Historical A/B/C governance maintenance | `.github/workflows/historical-archive-maintenance.yml`, `.github/workflows/roadmap-weighted-progress-sync.yml` | Manual archive-only maintenance | Historical workflows are `workflow_dispatch` only |
+| Historical governance helpers | `scripts/architecture-roadmap-consistency-check.mjs`, `scripts/arch-roadmap-sync.mjs` | Historical maintenance only | Referenced only from archive maintenance and governance docs |
+| Historical asset fee validation | `docs/runbooks/asset-conversion-fee-validation.md`, `scripts/tests/asset-fee-path-gate.test.sh` | Archived in place and removed from active release gate | Active release gate no longer runs asset fee-path checks |
+| Historical PolkaVM deploy verification | `docs/runbooks/polkavm-deploy-verification.md`, `scripts/tests/polkavm-deploy-verify-smoke.test.mjs` | Archived in place and removed from active release gate | Active release gate no longer runs PolkaVM deploy verification |
+| Historical A/B/C matrix | `docs/runbooks/architecture-coverage-matrix.md` | Historical-only with explicit non-authoritative status | Matrix no longer points operators at active weekly maintenance for Base truth |
+| Active settlement ingress `extrinsicHash` field | `docs/api/cotsel-dashboard-gateway.openapi.yml`, `gateway/src/routes/settlement.ts` | Retired from active public contract | OpenAPI no longer exposes `extrinsicHash`; route rejects the field |
+
+## Active-surface retirement checks
+Complete all of the following before closing `#396`:
+1. `ci/release-gate` does not require or summarize historical Polkadot jobs.
+2. Active API docs do not present `extrinsicHash` as a first-class request field.
+3. Active operator runbooks do not instruct launch or rollback operators to use Polkadot-era runtime paths.
+4. Historical docs that remain are immediately identifiable as historical-only.
+5. The active Base mainnet launch docs explicitly treat historical Polkadot artifacts as audit-only during rollback.
+
+## Validation procedure
+Run targeted grep against active repo surfaces:
+
+```bash
+rg -n "Polkadot|PolkaVM|AssetHub|Paseo|extrinsicHash|extrinsicIndex" \
+  .github/workflows \
+  docs/runbooks \
+  docs/api \
+  gateway/src/routes
+```
+
+Review each remaining match and confirm it is one of:
+- historical-only
+- archive-only
+- internal compatibility-only and not part of the active public contract
+
+## Closure rule
+Issue `#396` may close only when:
+- every M5-owned `#356` item above has an explicit final disposition
+- active release paths are Base-only
+- active API and runbook surfaces no longer keep dual-truth ambiguity alive

--- a/docs/runbooks/polkavm-deploy-verification.md
+++ b/docs/runbooks/polkavm-deploy-verification.md
@@ -4,6 +4,7 @@ Historical-only notice:
 - This runbook is retained for pre-Base migration traceability.
 - It is not active operator truth for v1.
 - Do not use this runbook for Base Sepolia pilot execution, M4 readiness, or M5 launch preparation.
+- Use `.github/workflows/historical-archive-maintenance.yml` only when maintaining historical PolkaVM archive evidence.
 - Active runtime and pilot operations must follow the Base-era runbooks, especially:
   - `docs/runbooks/staging-e2e-real-release-gate.md`
   - `docs/runbooks/pilot-environment-onboarding.md`

--- a/docs/runbooks/production-readiness-checklist.md
+++ b/docs/runbooks/production-readiness-checklist.md
@@ -96,6 +96,9 @@ Purpose:
 - Stop affected profiles/services.
 - Revert to last known-good deploy artifact and configuration.
 - Re-run health and gate checks before reopening traffic.
+- For Base mainnet launch governance and ordered rollback control, use:
+  - `docs/runbooks/base-mainnet-go-no-go.md`
+  - `docs/runbooks/base-mainnet-cutover-and-rollback.md`
 
 ### Data rollback policy
 - Schema/database changes require reversible migration strategy or forward-fix plan approved before release.
@@ -114,6 +117,8 @@ Purpose:
   - `docs/runbooks/postgres-backup-restore-recovery.md`
   - `docs/runbooks/staging-e2e-release-gate.md`
   - `docs/runbooks/staging-e2e-real-release-gate.md`
+  - `docs/runbooks/base-mainnet-go-no-go.md`
+  - `docs/runbooks/base-mainnet-cutover-and-rollback.md`
   - `docs/runbooks/compliance-boundary-kyb-kyt-sanctions.md`
   - `docs/runbooks/gateway-governance-signer-custody.md`
   - `docs/runbooks/oracle-redrive.md`

--- a/docs/runbooks/roadmap-policy.md
+++ b/docs/runbooks/roadmap-policy.md
@@ -9,6 +9,11 @@ The workflow `.github/workflows/pr-roadmap-policy.yml` enforces both requirement
 - The active Base migration execution source of truth is issue `#339` and milestones `M0` through `M5`.
 - Historical Milestones A/B/C weighted progress tooling is retained for pre-Base traceability only and must not be used as active v1 migration truth.
 - M4 closure requires operational proof: active Base-only runbooks, a canonical rehearsal path, and a real Base Sepolia evidence packet. Template existence alone is not sufficient.
+- M5 closure requires:
+  - an explicit Base mainnet go/no-go record
+  - an explicit Base mainnet cutover and rollback path
+  - retirement closure against issue `#356`
+  - no active release-gate or API path that still implies Polkadot is live
 
 Validation order is strict:
 1. Direct PR -> `projectItems` match by `ROADMAP_PROJECT_ID`.
@@ -19,7 +24,7 @@ If all checks fail, the workflow fails.
 
 Related automation:
 - `.github/workflows/roadmap-weighted-progress-sync.yml` is retained for manual historical A/B/C archive maintenance only.
-- Historical A/B/C governance checks in `.github/workflows/release-gate.yml` are disabled by default during the active Base migration and must not be treated as active v1 planning controls.
+- Historical A/B/C governance checks and PolkaVM archive validation belong only in `.github/workflows/historical-archive-maintenance.yml` and must not be treated as active v1 planning controls.
 
 ## Temporary rollout mode (current)
 - Milestone check is always enforced (blocking).

--- a/docs/runbooks/staging-e2e-real-release-gate.md
+++ b/docs/runbooks/staging-e2e-real-release-gate.md
@@ -5,6 +5,9 @@ Run a staging-grade release gate against the real indexer pipeline profile (`sta
 For pilot startup sequencing and go/no-go criteria, use `docs/runbooks/pilot-environment-onboarding.md`.
 For the controlled Base Sepolia validation itself, use `scripts/base-sepolia-pilot-validation.sh` and store the resulting packet under `reports/base-sepolia-pilot-validation/`.
 For participant-facing pilot workflow guidance, use `docs/runbooks/non-custodial-pilot-user-guide.md`.
+For Base mainnet launch approval and production rollback control, use:
+- `docs/runbooks/base-mainnet-go-no-go.md`
+- `docs/runbooks/base-mainnet-cutover-and-rollback.md`
 
 ## Profile differences
 - `local-dev`: lightweight in-memory GraphQL responder (`indexer`) for fast iteration.
@@ -69,6 +72,7 @@ GitHub Actions release-gate enforces workspace lint/typecheck/test/build checks 
 CI does not execute the full Docker `up/health/logs/down` staging profile sequence from this runbook.
 This runbook is a prerequisite gate for pilot readiness; it is not the
 canonical pilot rehearsal report or evidence packet.
+It is also not, by itself, a production go/no-go record.
 Source of truth for CI behavior: `.github/workflows/release-gate.yml`.
 CI also runs deterministic notification-path verification and uploads `ci-report-notifications-gate`.
 

--- a/docs/runbooks/staging-e2e-release-gate.md
+++ b/docs/runbooks/staging-e2e-release-gate.md
@@ -4,6 +4,9 @@
 Run deterministic staging checks before merge/release.
 
 For staging-grade validation with the explicit real indexer profile, use `docs/runbooks/staging-e2e-real-release-gate.md`.
+For Base mainnet launch approval and ordered production rollback, use:
+- `docs/runbooks/base-mainnet-go-no-go.md`
+- `docs/runbooks/base-mainnet-cutover-and-rollback.md`
 
 ## Preconditions
 - `.env` and `.env.staging-e2e` populated.
@@ -45,3 +48,7 @@ scripts/staging-e2e-gate.sh
 - Reconciliation cannot stay healthy for 10+ minutes.
 - Drift spikes with repeated CRITICAL mismatches.
 - Indexer pipeline cannot advance head height.
+
+Boundary note:
+- This runbook is a staging validation surface only.
+- It is not sufficient by itself for M5 production approval.

--- a/gateway/src/routes/settlement.ts
+++ b/gateway/src/routes/settlement.ts
@@ -15,7 +15,6 @@ import {
   SETTLEMENT_EXECUTION_STATUSES,
   SETTLEMENT_RECONCILIATION_STATUSES,
 } from '../core/settlementStore';
-import { requiresCanonicalTxHash } from '../core/transactionReference';
 
 export interface SettlementRouterOptions {
   config: GatewayConfig;
@@ -116,6 +115,18 @@ async function handleRequest(handler: () => Promise<unknown>, res: Response, nex
   }
 }
 
+function sanitizeSettlementHandoff<T extends { extrinsicHash?: string | null }>(handoff: T): Omit<T, 'extrinsicHash'> {
+  const { extrinsicHash: _extrinsicHash, ...publicHandoff } = handoff;
+  return publicHandoff;
+}
+
+function sanitizeSettlementExecutionEvent<T extends { extrinsicHash?: string | null }>(
+  event: T,
+): Omit<T, 'extrinsicHash'> {
+  const { extrinsicHash: _extrinsicHash, ...publicEvent } = event;
+  return publicEvent;
+}
+
 export function createSettlementRouter(options: SettlementRouterOptions): Router {
   const router = Router();
   const idempotency = createIdempotencyMiddleware(options.idempotencyStore);
@@ -160,22 +171,21 @@ export function createSettlementRouter(options: SettlementRouterOptions): Router
       sourceApiKeyId: getServiceApiKeyId(req),
     });
 
-    return handoff;
+    return sanitizeSettlementHandoff(handoff);
   }, res, next));
 
   router.post('/settlement/handoffs/:handoffId/execution-events', idempotency, (req, res, next) => handleRequest(async () => {
     const handoffId = requireString(req.params.handoffId, 'handoffId');
     const body = requireObject(req.body, 'body');
-    const executionStatus = requireExecutionStatus(body.executionStatus);
-    const txHash = optionalString(body.txHash, 'txHash');
-    const extrinsicHash = optionalString(body.extrinsicHash, 'extrinsicHash');
-    if (requiresCanonicalTxHash(executionStatus) && !txHash && extrinsicHash) {
+    if (body.extrinsicHash !== undefined && body.extrinsicHash !== null && body.extrinsicHash !== '') {
       throw new GatewayError(
         400,
         'VALIDATION_ERROR',
-        'txHash is required for submitted and confirmed execution events; extrinsicHash is compatibility-only',
+        'extrinsicHash is retired from the active settlement ingress contract; use txHash',
       );
     }
+    const executionStatus = requireExecutionStatus(body.executionStatus);
+    const txHash = optionalString(body.txHash, 'txHash');
     const result = await options.settlementService.recordExecutionEvent({
       handoffId,
       eventType: requireEventType(body.eventType),
@@ -183,7 +193,6 @@ export function createSettlementRouter(options: SettlementRouterOptions): Router
       reconciliationStatus: requireReconciliationStatus(body.reconciliationStatus),
       providerStatus: optionalString(body.providerStatus, 'providerStatus'),
       txHash,
-      extrinsicHash,
       detail: optionalString(body.detail, 'detail'),
       metadata: optionalMetadata(body.metadata),
       observedAt: requireString(body.observedAt, 'observedAt'),
@@ -191,14 +200,18 @@ export function createSettlementRouter(options: SettlementRouterOptions): Router
       sourceApiKeyId: getServiceApiKeyId(req),
     });
 
-    return result;
+    return {
+      handoff: sanitizeSettlementHandoff(result.handoff),
+      event: sanitizeSettlementExecutionEvent(result.event),
+      callbackDelivery: result.callbackDelivery,
+    };
   }, res, next));
 
   router.get('/settlement/handoffs/:handoffId/execution-events', async (req, res, next) => {
     try {
       const handoffId = requireString(req.params.handoffId, 'handoffId');
       const events = await options.settlementService.listExecutionEvents(handoffId);
-      res.status(200).json(successResponse(events));
+      res.status(200).json(successResponse(events.map((event) => sanitizeSettlementExecutionEvent(event))));
     } catch (error) {
       next(error);
     }

--- a/gateway/tests/settlementRoutes.contract.test.ts
+++ b/gateway/tests/settlementRoutes.contract.test.ts
@@ -177,6 +177,7 @@ describe('gateway settlement routes contract', () => {
 
       expect(handoffResponse.status).toBe(202);
       expect(validateHandoffResponse(handoffPayload)).toBe(true);
+      expect(handoffPayload.data.extrinsicHash).toBeUndefined();
 
       const handoffId = handoffPayload.data.handoffId as string;
       const eventBody = {
@@ -206,6 +207,8 @@ describe('gateway settlement routes contract', () => {
       expect(eventResponse.status).toBe(202);
       expect(validateMutationResponse(eventPayload)).toBe(true);
       expect(eventPayload.data.callbackDelivery.status).toBe('disabled');
+      expect(eventPayload.data.handoff.extrinsicHash).toBeUndefined();
+      expect(eventPayload.data.event.extrinsicHash).toBeUndefined();
 
       const listResponse = await fetch(`${baseUrl}/settlement/handoffs/${encodeURIComponent(handoffId)}/execution-events`, {
         headers: {
@@ -218,12 +221,13 @@ describe('gateway settlement routes contract', () => {
       expect(listResponse.status).toBe(200);
       expect(validateEventListResponse(listPayload)).toBe(true);
       expect(listPayload.data).toHaveLength(1);
+      expect(listPayload.data[0].extrinsicHash).toBeUndefined();
     } finally {
       server.close();
     }
   });
 
-  test('submitted execution events reject extrinsic-only compatibility payloads', async () => {
+  test('submitted execution events reject retired extrinsicHash payloads', async () => {
     const { server, baseUrl } = await startServer();
 
     try {
@@ -273,7 +277,7 @@ describe('gateway settlement routes contract', () => {
 
       expect(eventResponse.status).toBe(400);
       expect(eventPayload.error.code).toBe('VALIDATION_ERROR');
-      expect(eventPayload.error.message).toContain('txHash is required');
+      expect(eventPayload.error.message).toContain('extrinsicHash is retired');
     } finally {
       server.close();
     }

--- a/scripts/architecture-roadmap-consistency-check.mjs
+++ b/scripts/architecture-roadmap-consistency-check.mjs
@@ -8,7 +8,7 @@ import path from "node:path";
 import process from "node:process";
 
 const STATUS_VALUES = new Set(["Done", "In Progress", "Blocked", "Backlog", "Out of Scope"]);
-const CADENCE_VALUES = new Set(["daily", "weekly", "biweekly", "monthly", "quarterly", "on-change"]);
+const CADENCE_VALUES = new Set(["daily", "weekly", "biweekly", "monthly", "quarterly", "on-change", "archive-only"]);
 const GATE_ISSUE_NUMBERS = [70, 71, 72];
 const REQUIRED_COLUMNS = [
   "Component",

--- a/scripts/tests/architecture-roadmap-consistency-check.test.sh
+++ b/scripts/tests/architecture-roadmap-consistency-check.test.sh
@@ -11,6 +11,7 @@ pass_matrix="$tmp_dir/matrix-pass.md"
 fail_matrix="$tmp_dir/matrix-fail.md"
 fail_matrix_last_refreshed="$tmp_dir/matrix-fail-last-refreshed.md"
 fail_matrix_refresh_cadence="$tmp_dir/matrix-fail-refresh-cadence.md"
+archive_only_matrix="$tmp_dir/matrix-archive-only.md"
 
 cat > "$pass_matrix" <<'MATRIX'
 # Architecture Coverage Matrix
@@ -125,6 +126,25 @@ MATRIX
 
 if node "$SCRIPT" --offline --matrix "$fail_matrix_refresh_cadence" --out "$tmp_dir/fail-refresh-cadence.json" >/dev/null 2>&1; then
   echo "expected consistency checker to fail when Refresh Cadence is empty" >&2
+  exit 1
+fi
+
+cat > "$archive_only_matrix" <<'MATRIX'
+# Architecture Coverage Matrix
+
+Snapshot date: 2026-04-01
+
+## Component Mapping
+
+| Component | Milestone Target | Status | % Complete | Roadmap Issue(s) | Evidence | Remaining Gap | Owner | Last Refreshed | Refresh Cadence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Historical component | A | Out of Scope | 0 | #999 | `docs/example.md` | Historical evidence retained for audit | roadmap-maintainers | 2026-04-01 | archive-only |
+
+## Gate-to-Row Mapping
+MATRIX
+
+if ! node "$SCRIPT" --offline --matrix "$archive_only_matrix" --out "$tmp_dir/archive-only.json" >/dev/null 2>&1; then
+  echo "expected consistency checker to accept archive-only refresh cadence" >&2
   exit 1
 fi
 

--- a/scripts/tests/base-mainnet-governance-guard.sh
+++ b/scripts/tests/base-mainnet-governance-guard.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+GO_NO_GO_DOC="docs/runbooks/base-mainnet-go-no-go.md"
+CUTOVER_DOC="docs/runbooks/base-mainnet-cutover-and-rollback.md"
+fail=0
+
+if [[ ! -f "$GO_NO_GO_DOC" ]]; then
+  echo "[FAIL] Missing required runbook: ${GO_NO_GO_DOC}" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CUTOVER_DOC" ]]; then
+  echo "[FAIL] Missing required runbook: ${CUTOVER_DOC}" >&2
+  exit 1
+fi
+
+go_no_go_headings=(
+  "## Purpose and scope"
+  "## Authoritative references"
+  "## Required approval roles"
+  "## Required evidence before approval"
+  "## Repo-grounded validation commands"
+  "## No-go conditions"
+  "## Approval record"
+)
+
+for heading in "${go_no_go_headings[@]}"; do
+  if ! grep -Fq "$heading" "$GO_NO_GO_DOC"; then
+    echo "[FAIL] Missing required heading in ${GO_NO_GO_DOC}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+cutover_headings=(
+  "## Purpose and scope"
+  "## Launch-day ownership matrix"
+  "## Preconditions before cutover begins"
+  "## Cutover steps"
+  "## Rollback triggers"
+  "## Rollback steps"
+  "## Containment posture when rollback is partial or blocked"
+  "## Historical Polkadot artifacts during rollback"
+)
+
+for heading in "${cutover_headings[@]}"; do
+  if ! grep -Fq "$heading" "$CUTOVER_DOC"; then
+    echo "[FAIL] Missing required heading in ${CUTOVER_DOC}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+required_refs=(
+  "scripts/validate-env.sh staging-e2e-real"
+  "scripts/staging-e2e-real-gate.sh"
+  "scripts/notifications-gate.sh staging-e2e-real"
+  "npm run -w reconciliation reconcile:report"
+  "docs/runbooks/polkadot-retirement-checklist.md"
+)
+
+for ref in "${required_refs[@]}"; do
+  if ! grep -Fq "$ref" "$GO_NO_GO_DOC" && ! grep -Fq "$ref" "$CUTOVER_DOC"; then
+    echo "[FAIL] Missing required launch-governance reference: ${ref}" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "Base mainnet governance guard: pass"
+  exit 0
+fi
+
+exit 1

--- a/scripts/tests/polkadot-retirement-guard.sh
+++ b/scripts/tests/polkadot-retirement-guard.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RELEASE_GATE=".github/workflows/release-gate.yml"
+HISTORICAL_WORKFLOW=".github/workflows/historical-archive-maintenance.yml"
+RETIREMENT_DOC="docs/runbooks/polkadot-retirement-checklist.md"
+OPENAPI_DOC="docs/api/cotsel-dashboard-gateway.openapi.yml"
+fail=0
+
+if [[ ! -f "$HISTORICAL_WORKFLOW" ]]; then
+  echo "[FAIL] Missing historical archive workflow: ${HISTORICAL_WORKFLOW}" >&2
+  fail=1
+fi
+
+if [[ ! -f "$RETIREMENT_DOC" ]]; then
+  echo "[FAIL] Missing retirement checklist: ${RETIREMENT_DOC}" >&2
+  fail=1
+fi
+
+if grep -Eq 'ci/arch-roadmap-consistency-historical|ci/asset-fee-path-historical|ci/contracts-deploy-verification-historical' "$RELEASE_GATE"; then
+  echo "[FAIL] Active release gate still references historical Polkadot jobs" >&2
+  fail=1
+fi
+
+if grep -Eq 'architecture-roadmap-consistency-check\.test\.sh|architecture-roadmap-sync\.test\.sh' "$RELEASE_GATE"; then
+  echo "[FAIL] Active release gate still runs historical A/B/C regression tests" >&2
+  fail=1
+fi
+
+if grep -Fq 'extrinsicHash:' "$OPENAPI_DOC"; then
+  echo "[FAIL] Active OpenAPI surface still exposes extrinsicHash" >&2
+  fail=1
+fi
+
+required_headings=(
+  "## Purpose and scope"
+  "## Binding register"
+  "## Retirement decisions"
+  "## M5-owned residue closure table"
+  "## Active-surface retirement checks"
+  "## Validation procedure"
+  "## Closure rule"
+)
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "$heading" "$RETIREMENT_DOC"; then
+    echo "[FAIL] Missing required heading in ${RETIREMENT_DOC}: ${heading}" >&2
+    fail=1
+  fi
+done
+
+if ! grep -Fq '#356' "$RETIREMENT_DOC"; then
+  echo "[FAIL] Retirement checklist must bind directly to issue #356" >&2
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "Polkadot retirement guard: pass"
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- add the authoritative Base mainnet go/no-go and cutover/rollback control surfaces for M5
- retire active Polkadot residue from the release gate and settlement ingress contract
- move historical A/B/C, asset-fee, and PolkaVM archive checks into a manual archive-maintenance workflow

## Validation
- bash scripts/tests/base-mainnet-governance-guard.sh
- bash scripts/tests/polkadot-retirement-guard.sh
- bash scripts/tests/chain-event-parity-retirement-guard.sh
- bash scripts/tests/docs-profile-name-guard.sh
- bash scripts/tests/api-gateway-boundary-guard.sh
- bash scripts/tests/programmability-governance-guard.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-gate.yml"); YAML.load_file(".github/workflows/historical-archive-maintenance.yml")'
- npm run -w gateway lint
- npm run -w gateway test -- settlementRoutes.contract.test.ts

## Closes
- closes #395
- closes #396
- closes #345

## Roadmap Mapping
- Milestone: M5 Base Mainnet Launch and Polkadot Retirement
- Project: Cotsel Roadmap
- Related to #395, #396
