### PR TITLE
docs(base): harden final post-migration truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Cotsel was initially developed to support the Agroasys platform, but it is open-
 
 ## Status and Maturity
 
-- **Current phase:** Pilot readiness (active development).
+- **Current phase:** Post-migration Base operations and launch-governance maintenance.
 - **Operational readiness criteria:** `docs/runbooks/production-readiness-checklist.md`.
-- **Active chain truth:** Base Sepolia is the controlled pilot environment and Base mainnet is the production target-state. Historical Polkadot/PolkaVM material in this repo is retained for archive traceability only.
+- **Active chain truth:** Base is the only active v1 settlement target in this repo. Base Sepolia has verified pilot evidence, and Base mainnet go/no-go plus rollback control surfaces are installed. This repo does not, by itself, prove a completed Base mainnet launch unless a filled approval record and mainnet deployment evidence are attached.
 
 ## Who Should Read Next
 
@@ -90,7 +90,7 @@ Action: the remaining supplier tranche is released, completing settlement.
 - Storage: Postgres for indexed and operational views
 
 **Network and assets**  
-- Settlement rails: Base Sepolia for pilot validation and Base mainnet for production target-state settlement flows.
+- Settlement rails: Base Sepolia for verified pilot validation; Base mainnet runtime configuration and launch controls are implemented, but live mainnet activation evidence is external unless separately recorded in-repo.
 - Stablecoin rail: USDC on Base for active settlement design.
 - Gas management: any sponsorship or fee abstraction is optional, buyer-bounded, and not a prerequisite for settlement safety.
 

--- a/docs/runbooks/base-mainnet-go-no-go.md
+++ b/docs/runbooks/base-mainnet-go-no-go.md
@@ -22,6 +22,11 @@ Hard prerequisite:
   - PR `#400` merged
   - issues `#392`, `#393`, `#394`, and `#344` closed
 
+Control-surface note:
+- This file is the authoritative approval template and review checklist for Base mainnet launch readiness.
+- It is not, by itself, proof that a Base mainnet launch has already occurred.
+- A real launch window must attach a filled approval record, the deployment/change record used for promotion, and any mainnet deployment evidence that exists for that window.
+
 ## Authoritative references
 - Production baseline readiness: `docs/runbooks/production-readiness-checklist.md`
 - Staging release gate: `docs/runbooks/staging-e2e-release-gate.md`

--- a/docs/runbooks/github-roadmap-governance.md
+++ b/docs/runbooks/github-roadmap-governance.md
@@ -18,7 +18,8 @@ Maintain a single execution board for `Cotsel` where every roadmap item and PR i
 - Project URL: `https://github.com/orgs/Agroasys/projects/5`
 - Project node ID: `PVT_kwDODMhsg84BPnYZ`
 - Status values: `Backlog`, `In Progress`, `In Review`, `Blocked`, `Done`
-- Milestone values: `M0 Base Migration Decision and Boundary Freeze`, `M1 Base Contract Runtime and Deployment`, `M2 Base Eventing, Reconciliation, and Treasury Safety`, `M3 Backend, Gateway, and Wallet Continuity`, `M4 Base Sepolia Pilot Readiness`, `M5 Base Mainnet Launch and Polkadot Retirement`, `Needs Triage`
+- Repository milestone model: `M0 Base Migration Decision and Boundary Freeze`, `M1 Base Contract Runtime and Deployment`, `M2 Base Eventing, Reconciliation, and Treasury Safety`, `M3 Backend, Gateway, and Wallet Continuity`, `M4 Base Sepolia Pilot Readiness`, `M5 Base Mainnet Launch and Polkadot Retirement`, `Needs Triage`
+- Active Project v2 fields: `Status`, `Area`, `Priority`, `Work Type`, `Risk`, `% Complete`, `Target Date`
 - Area values: `Contracts`, `Oracle`, `Indexer`, `SDK`, `Reconciliation`, `Ricardian`, `Treasury`, `Notifications`, `Ops/CI`, `Docs/Runbooks`, `Security`
 - Work type values: `Feature`, `Bug`, `Refactor`, `Ops`, `Docs`, `Security` (`Type` is a reserved project field name in GitHub UI/API).
 
@@ -60,7 +61,7 @@ gh api graphql \
   -F project="$ROADMAP_PROJECT_ID" \
   -F content="$pr_id"
 ```
-3. Set project fields (`Status`, `Roadmap Milestone`, `Area`, `Priority`, `Work Type`, `Risk`, `% Complete`, `Target Date`).
+3. Set active project fields (`Status`, `Area`, `Priority`, `Work Type`, `Risk`, `% Complete`, `Target Date`).
 
 ## Required Repository Configuration
 - Repository variable: `ROADMAP_PROJECT_ID` (Project v2 node id).

--- a/indexer/schema.graphql
+++ b/indexer/schema.graphql
@@ -250,6 +250,8 @@ type AdminEvent @entity {
   txHash: String! @index
   logIndex: Int! @index
   transactionIndex: Int! @index
+  # Historical compatibility fields retained for archived Substrate-era replay
+  # evidence. Base-originated records keep these null.
   extrinsicHash: String @index
   extrinsicIndex: Int
 
@@ -280,6 +282,8 @@ type SystemEvent @entity {
   txHash: String! @index
   logIndex: Int! @index
   transactionIndex: Int! @index
+  # Historical compatibility fields retained for archived Substrate-era replay
+  # evidence. Base-originated records keep these null.
   extrinsicHash: String @index
   extrinsicIndex: Int
 


### PR DESCRIPTION
## Summary
- harden post-migration Base truth in the active repo surfaces
- make mainnet-readiness docs explicit about what is a control surface vs launch proof
- label internal `extrinsicHash` / `extrinsicIndex` compatibility fields consistently as historical-only bridge fields

## Validation
- bash scripts/tests/polkadot-retirement-guard.sh
- bash scripts/tests/base-mainnet-governance-guard.sh
- git diff --check

## Roadmap Mapping
- Milestone: M5 Base Mainnet Launch and Polkadot Retirement
- Project: Cotsel Roadmap
- Related to #392, #396
