### PR TITLE
fix(docs): harden Base staging env truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,8 @@ GATEWAY_DOWNSTREAM_MUTATION_TIMEOUT_MS=8000
 # Real indexer pipeline (used by staging-e2e / staging-e2e-real).
 # The active pilot target is Base Sepolia. Do not use historical Asset Hub
 # Paseo or public Base RPC defaults for the controlled pilot runtime.
+# Optional archive gateway for accelerated indexing. Leave blank when running
+# the EVM processor directly against RPC only.
 INDEXER_GATEWAY_URL=https://managed-base-sepolia-indexer.example.invalid
 INDEXER_RPC_ENDPOINT=https://managed-base-sepolia-rpc-primary.example.invalid
 INDEXER_START_BLOCK=39588005

--- a/.env.staging-e2e-real.example
+++ b/.env.staging-e2e-real.example
@@ -17,7 +17,8 @@ RECONCILIATION_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 TREASURY_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 ORACLE_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 
-# Active Base Sepolia managed-provider inputs
+# Active Base Sepolia managed-provider inputs.
+# INDEXER_GATEWAY_URL is optional when the indexer runs directly against RPC.
 INDEXER_GATEWAY_URL=https://managed-base-sepolia-indexer.example.invalid
 INDEXER_RPC_ENDPOINT=https://managed-base-sepolia-rpc-primary.example.invalid
 INDEXER_START_BLOCK=39588005

--- a/.env.staging-e2e.example
+++ b/.env.staging-e2e.example
@@ -6,6 +6,7 @@ TREASURY_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 ORACLE_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 
 # Active Base staging inputs. Use managed provider URLs only.
+# INDEXER_GATEWAY_URL is optional when the indexer runs directly against RPC.
 INDEXER_GATEWAY_URL=https://managed-base-sepolia-indexer.example.invalid
 INDEXER_RPC_ENDPOINT=https://managed-base-sepolia-rpc-primary.example.invalid
 INDEXER_START_BLOCK=39588005

--- a/docs/runbooks/pilot-environment-onboarding.md
+++ b/docs/runbooks/pilot-environment-onboarding.md
@@ -57,9 +57,9 @@ full rehearsal record on its own.
   - `RECONCILIATION_INDEXER_GRAPHQL_URL`
   - `RECONCILIATION_CHAIN_ID`
 - Indexer routing configured:
-  - `INDEXER_GATEWAY_URL`
   - `INDEXER_RPC_ENDPOINT`
   - `INDEXER_START_BLOCK`
+  - `INDEXER_GATEWAY_URL` only when an archive gateway is explicitly provisioned for the pilot profile
 
 ## Prerequisites
 - Docker Engine + Compose plugin installed.

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -125,7 +125,6 @@ fi
 if [[ "$PROFILE" == "staging-e2e" || "$PROFILE" == "staging-e2e-real" ]]; then
   required_groups+=(
     # indexer pipeline aliases (indexer/src/config.ts)
-    INDEXER_GATEWAY_URL\|GATEWAY_URL
     INDEXER_RPC_ENDPOINT\|RPC_ENDPOINT
     INDEXER_START_BLOCK\|START_BLOCK
     INDEXER_RATE_LIMIT\|RATE_LIMIT

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -59,7 +59,7 @@ import type { BuyerLockPayload } from '@agroasys/sdk';
 
 const config = {
   rpc: '',
-  chainId: 420420417,
+  chainId: 84532,
   escrowAddress: '',
   usdcAddress: ''
 };


### PR DESCRIPTION
## Summary
- keep the tracked staging env examples aligned with the active Base Sepolia pilot contract
- stop treating the optional indexer archive gateway URL as a required staging input
- update the SDK README example from the old chain ID to Base Sepolia

## Validation
- bash -n scripts/validate-env.sh
- git diff --check
- residue re-scan over active env/docs surfaces

Refs #234

## Roadmap Mapping
- Milestone: M4 Base Sepolia Pilot Readiness
- Project: Cotsel Roadmap
- Related to #393, #394
