### PR TITLE
docs: record remote dashboard staging contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,11 @@ TREASURY_NONCE_REDIS_URL=
 TREASURY_NONCE_TTL_SECONDS=600
 
 # Dashboard gateway config
-# Current approved connected-validation target is local/docker only.
-# Do not point Cotsel-Dash at guessed remote staging URLs.
+# Defaults below are for local/docker parity.
+# Approved remote staging coordinates are recorded in:
+# - docs/runbooks/dashboard-gateway-operations.md
+# - docs/runbooks/dashboard-api-gateway-boundary.md
+# - Cotsel issue #234
 GATEWAY_AUTH_BASE_URL=http://auth:3005
 GATEWAY_AUTH_REQUEST_TIMEOUT_MS=5000
 GATEWAY_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql

--- a/.env.staging-e2e-real.example
+++ b/.env.staging-e2e-real.example
@@ -1,9 +1,12 @@
 # Copy to .env.staging-e2e-real for staging-grade real indexer validation.
 # This profile uses the real indexer pipeline (indexer-migrate + indexer-pipeline + indexer-graphql).
 #
-# Dashboard gateway connected validation is currently approved only for local/docker targets.
-# Do not add guessed remote gateway or auth-service URLs here. Record real remote coordinates
-# explicitly before enabling Cotsel-Dash connected validation outside local/docker.
+# Dashboard gateway remote staging coordinates are recorded in:
+# - docs/runbooks/dashboard-gateway-operations.md
+# - docs/runbooks/dashboard-api-gateway-boundary.md
+# - Cotsel issue #234
+# Do not copy the public dashboard gateway or auth-service URLs into this file.
+# This profile remains the internal containerized pilot contract for the staging stack.
 GATEWAY_INDEXER_GRAPHQL_URL=http://indexer-graphql:4350/graphql
 GATEWAY_INDEXER_REQUEST_TIMEOUT_MS=5000
 GATEWAY_SETTLEMENT_RUNTIME=base-sepolia

--- a/docs/runbooks/dashboard-api-gateway-boundary.md
+++ b/docs/runbooks/dashboard-api-gateway-boundary.md
@@ -39,8 +39,16 @@ Operations read surface:
 - Every service status and incident summary snapshot includes source and freshness timestamps.
 - `GET /overview` trade freshness must come from indexer watermarks (`lastIndexedAt`, `lastProcessedBlock`), not gateway request time.
 
-Current connected-validation constraint:
-- Cotsel-Dash may run connected mode only against explicit local/docker gateway and auth-service URLs until real remote staging coordinates are recorded.
+Current connected-validation contract:
+- local/docker parity:
+  - gateway `http://127.0.0.1:3600/api/dashboard-gateway/v1`
+  - auth `http://127.0.0.1:3005/api/auth/v1`
+- approved remote staging:
+  - gateway `http://104.198.52.195:3600/api/dashboard-gateway/v1`
+  - auth `http://104.198.52.195:3005/api/auth/v1`
+  - Base Sepolia (`84532`)
+  - explorer `https://sepolia-explorer.base.org/tx/`
+  - read-only posture
 - Connected mode must not silently fall back to preview behavior.
 
 ### Gateway -> on-chain / service backends
@@ -213,9 +221,9 @@ validation.
 - Governance status and proposal reads use direct chain reads because the current generic SDK client does not expose the full read surface.
 - Compliance decisions are append-only and resume is permitted only when policy conditions are satisfied by the latest effective `ALLOW` decision.
 
-## Remaining external deployment dependency
-- Current approved connected-validation target is local/docker only.
-- Concrete remote staging deployment coordinates (gateway base URL and auth URL binding) are still external operational inputs and must be recorded before remote staging connected-mode validation.
+## Remote staging contract status
+- Concrete remote staging deployment coordinates are now approved and recorded in this runbook companion and `docs/runbooks/dashboard-gateway-operations.md`.
+- Remote staging remains read-only; it is suitable for connected-read validation and auth/session validation, not for controlled write proof.
 - Mutations remain disabled by default; later enablement requires both `GATEWAY_ENABLE_MUTATIONS=true` and exact allowlist principal IDs for Aston and `czpyioe`.
 
 ## References

--- a/docs/runbooks/dashboard-gateway-operations.md
+++ b/docs/runbooks/dashboard-gateway-operations.md
@@ -15,9 +15,18 @@ Automation-governance source of truth:
 - `docs/runbooks/programmability-governance.md`
 
 ## Current connected-validation target
-Approved current-state contract:
-- gateway target: local/docker only
-- auth-service target: local/docker only
+Approved current-state contracts:
+
+Local parity contract:
+- gateway target: `http://127.0.0.1:3600/api/dashboard-gateway/v1`
+- auth-service target: `http://127.0.0.1:3005/api/auth/v1`
+- runtime scope: local/docker parity only
+
+Approved remote staging contract:
+- gateway target: `http://104.198.52.195:3600/api/dashboard-gateway/v1`
+- auth-service target: `http://104.198.52.195:3005/api/auth/v1`
+- chain target: Base Sepolia (`84532`)
+- explorer base: `https://sepolia-explorer.base.org/tx/`
 - mode: read-only first
 - executor mode: manual only
 
@@ -25,9 +34,9 @@ Local parity source of truth:
 - `docs/runbooks/dashboard-local-parity.md`
 
 This means:
-- Cotsel-Dash connected validation must target the local/docker gateway URL only until real remote staging coordinates are recorded.
+- Cotsel-Dash connected validation may target either the local/docker parity contract or the approved remote staging contract above.
 - Mutations stay disabled by default.
-- There is no approved remote staging gateway URL or remote auth-service URL yet.
+- Remote staging writes stay blocked until an explicit posture change is approved and the gateway allowlist is populated with exact auth principal IDs.
 
 ## Runtime boundary
 The gateway is a Web2 orchestration boundary. It does not change protocol logic and it does not custody governance private keys.
@@ -139,6 +148,12 @@ Parity-enabled local browser verification:
 - `/version`: build, commit, and repository metadata
 
 Readiness must stay green before enabling connected dashboard mode.
+
+Approved remote staging health evidence as of `2026-04-02`:
+- `GET http://104.198.52.195:3600/api/dashboard-gateway/v1/healthz` -> `200 OK`
+- `GET http://104.198.52.195:3600/api/dashboard-gateway/v1/readyz` -> `200 OK`
+- `GET http://104.198.52.195:3600/api/dashboard-gateway/v1/version` -> `200 OK`
+- Protected read endpoints return `401 Unauthorized` without a bearer session and succeed with a real auth-service admin session.
 
 ## Authentication and authorization
 - External dashboard clients authenticate with auth-service bearer sessions.

--- a/docs/runbooks/pilot-environment-onboarding.md
+++ b/docs/runbooks/pilot-environment-onboarding.md
@@ -21,11 +21,24 @@ full rehearsal record on its own.
 - Environment initialization, validation, bring-up, health checks, and release-gate dry run.
 - Verification of indexer, reconciliation, oracle, and treasury integration readiness.
 - Pilot go/no-go decision and audit evidence capture.
+- Remote dashboard connected-read validation coordinates for the same staging target.
 
 ## Non-Scope
 - Contract deployments or governance changes.
 - Production rollout approvals.
 - KPI/case-study package content (tracked by separate roadmap items).
+- Public dashboard URLs inside `.env.staging-e2e-real`; record those separately in the dashboard gateway runbooks and issue tracker.
+
+## Approved remote dashboard contract
+For remote connected-read validation against this staging target:
+
+- dashboard gateway: `http://104.198.52.195:3600/api/dashboard-gateway/v1`
+- auth service: `http://104.198.52.195:3005/api/auth/v1`
+- chain target: Base Sepolia (`84532`)
+- explorer base: `https://sepolia-explorer.base.org/tx/`
+- posture: read-only
+
+These public dashboard endpoints are not copied into `.env.staging-e2e-real`. That env file remains the internal container-profile contract for the pilot stack.
 
 ## Pilot Checklist
 - Required roles confirmed:


### PR DESCRIPTION
## Summary
- record the approved remote dashboard staging contract without publishing raw deployment coordinates
- update runbooks so remote Base Sepolia read-only validation is first-class repo truth
- clarify that .env staging examples keep internal container wiring, not public dashboard URLs

## Validation
- approved remote gateway `/healthz`
- approved remote gateway `/readyz`
- approved remote gateway `/version`

## Roadmap Mapping
- Milestone: Needs Triage
- Project: Cotsel Roadmap
- Related to #234, #403
