### PR TITLE
docs: redact remote staging coordinates

### DIFF
--- a/docs/runbooks/dashboard-api-gateway-boundary.md
+++ b/docs/runbooks/dashboard-api-gateway-boundary.md
@@ -41,13 +41,13 @@ Operations read surface:
 
 Current connected-validation contract:
 - local/docker parity:
-  - gateway base from the local/docker env contract
-  - auth base from the local/docker env contract
+  - gateway `http://127.0.0.1:3600/api/dashboard-gateway/v1`
+  - auth `http://127.0.0.1:3005/api/auth/v1`
 - approved remote staging:
   - gateway base from the approved private staging inventory
   - auth base from the approved private staging inventory
   - Base Sepolia (`84532`)
-  - approved Base Sepolia explorer base
+  - explorer `https://sepolia-explorer.base.org/tx/`
   - read-only posture
 - Connected mode must not silently fall back to preview behavior.
 

--- a/docs/runbooks/dashboard-gateway-operations.md
+++ b/docs/runbooks/dashboard-gateway-operations.md
@@ -18,15 +18,15 @@ Automation-governance source of truth:
 Approved current-state contracts:
 
 Local parity contract:
-- gateway target: local/docker gateway base from `.env.example`
-- auth-service target: local/docker auth base from `.env.example`
+- gateway target: `http://127.0.0.1:3600/api/dashboard-gateway/v1`
+- auth-service target: `http://127.0.0.1:3005/api/auth/v1`
 - runtime scope: local/docker parity only
 
 Approved remote staging contract:
 - gateway target: approved remote staging gateway base from the private ops inventory
 - auth-service target: approved remote staging auth base from the private ops inventory
 - chain target: Base Sepolia (`84532`)
-- explorer base: approved Base Sepolia transaction explorer base
+- explorer base: `https://sepolia-explorer.base.org/tx/`
 - mode: read-only first
 - executor mode: manual only
 

--- a/docs/runbooks/pilot-environment-onboarding.md
+++ b/docs/runbooks/pilot-environment-onboarding.md
@@ -35,7 +35,7 @@ For remote connected-read validation against this staging target:
 - dashboard gateway: approved remote staging gateway base from the private ops inventory
 - auth service: approved remote staging auth base from the private ops inventory
 - chain target: Base Sepolia (`84532`)
-- explorer base: approved Base Sepolia transaction explorer base
+- explorer base: `https://sepolia-explorer.base.org/tx/`
 - posture: read-only
 
 These public dashboard endpoints are not copied into `.env.staging-e2e-real`. That env file remains the internal container-profile contract for the pilot stack.


### PR DESCRIPTION
## Summary
- remove raw remote staging coordinates from public markdown runbooks
- replace them with private-ops references and placeholder contract language
- keep Base Sepolia and read-only posture explicit without advertising endpoints

## Notes
- do not merge until reviewed
- related to Cotsel #234