### PR TITLE
fix(deps): pin transitive security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,11 @@
         "ricardian",
         "treasury"
       ],
+      "devDependencies": {
+        "defu": "6.1.6",
+        "lodash": "4.18.1",
+        "undici": "6.24.0"
+      },
       "engines": {
         "node": ">=20 <23",
         "npm": ">=10 <12"
@@ -97,12 +102,6 @@
         "typechain": "^8.3.0",
         "typescript": ">=6.0.2"
       }
-    },
-    "contracts/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "contracts/node_modules/typescript": {
       "version": "6.0.2",
@@ -4074,6 +4073,19 @@
         "hardhat": "^2.26.0"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/undici": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@nomicfoundation/ignition-core": {
       "version": "0.15.15",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.15.tgz",
@@ -4128,6 +4140,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nomicfoundation/ignition-ui": {
       "version": "0.15.13",
@@ -11712,9 +11731,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "license": "MIT"
     },
     "node_modules/delay": {
@@ -14195,6 +14214,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/hardhat/node_modules/undici": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/hardhat/node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -16487,9 +16519,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -21984,16 +22016,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "licenses:report": "node scripts/generate-license-report.mjs",
     "security:deps": "node scripts/security-deps-report.mjs"
   },
+  "devDependencies": {
+    "defu": "6.1.6",
+    "lodash": "4.18.1",
+    "undici": "6.24.0"
+  },
   "overrides": {
     "axios": "1.14.0",
     "@parity/hardhat-polkadot-node": {
@@ -85,7 +90,9 @@
     "path-to-regexp@<0.1.13": "0.1.13",
     "path-to-regexp@>=8 <8.4.0": "8.4.0",
     "serialize-javascript": "7.0.5",
+    "defu": "6.1.6",
     "lodash": "4.18.1",
+    "undici": "6.24.0",
     "@nomicfoundation/ignition-core": {
       "lodash": "4.18.1"
     }


### PR DESCRIPTION
## Summary
- pin patched transitive versions for defu, lodash, and undici
- regenerate the workspace lockfile so the patched graph is reproducible from a clean install
- keep the existing Hardhat and Polkadot toolchain stable while removing the currently flagged transitive alerts

## Verification
- npm ci
- npm audit --omit=dev --json
- npm run lint
- git diff --check
