### PR TITLE
fix(treasury): finalize close reporting and audit hardening

### DIFF
--- a/docs/adr/adr-0412-treasury-revenue-controls-boundary.md
+++ b/docs/adr/adr-0412-treasury-revenue-controls-boundary.md
@@ -31,6 +31,7 @@ This ADR freezes the ownership model and state semantics before broader treasury
 - **Gateway truth**: approval and privileged action truth
   - who prepared, approved, signed, confirmed, or closed an action
   - ticket references, reasons, evidence links, and audit lineage
+  - treasury capability enforcement for read, prepare, approve, execute-match, and close actions
 - **Reconciliation truth**: tie-out and exception truth
   - whether persisted treasury, gateway, and chain records reconcile
   - whether close can proceed
@@ -140,6 +141,9 @@ Compatibility note:
 - A sweep batch closer must be different from the approver and executor.
 - Treasury service must not directly trigger privileged chain execution.
 - Gateway remains the privileged execution and approval boundary.
+- Gateway treasury workflow should express distinct capability checks for read, prepare, approve,
+  execute-match, and close actions even when the upstream auth service still falls back to an
+  admin-wide treasury capability set.
 - Reconciliation gates accounting-period close. Revenue realization still requires treasury evidence gates, but it is not separately reconciliation-gated in the current implementation.
 
 ## Forbidden truth duplication

--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -1085,6 +1085,69 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           $ref: '#/components/responses/ConflictError'
+  /treasury/accounting-periods/{periodId}/rollforward:
+    get:
+      tags: [Treasury]
+      summary: Get treasury accounting period rollforward
+      description: |
+        Returns the deterministic treasury rollforward for a single accounting period using
+        persisted treasury evidence, matched on-chain claim evidence, and reconciliation truth.
+      operationId: getTreasuryAccountingPeriodRollforward
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+        - $ref: '#/components/parameters/AccountingPeriodId'
+      responses:
+        '200':
+          description: Treasury accounting period rollforward.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreasuryPeriodRollforwardResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /treasury/accounting-periods/{periodId}/close-packet:
+    get:
+      tags: [Treasury]
+      summary: Get treasury accounting period close packet
+      description: |
+        Returns the finance close packet for a treasury accounting period, including rollforward,
+        batch trace evidence, reconciliation summary, and blocking vs warning close issues.
+      operationId: getTreasuryAccountingPeriodClosePacket
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+        - $ref: '#/components/parameters/AccountingPeriodId'
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [json, markdown]
+            default: json
+      responses:
+        '200':
+          description: Treasury accounting period close packet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreasuryAccountingPeriodClosePacketResponse'
+            text/markdown:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
   /treasury/accounting-periods/{periodId}/close:
     post:
       tags: [Treasury]
@@ -1202,6 +1265,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TreasurySweepBatchDetailResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /treasury/sweep-batches/{batchId}/trace:
+    get:
+      tags: [Treasury]
+      summary: Get treasury sweep batch trace
+      description: |
+        Returns the full batch trace from ledger entries through matched on-chain treasury claim
+        evidence and external execution handoff evidence.
+      operationId: getTreasurySweepBatchTrace
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+        - $ref: '#/components/parameters/BatchId'
+      responses:
+        '200':
+          description: Treasury sweep batch trace report.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreasuryBatchTraceReportResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -5399,6 +5487,13 @@ components:
           type: string
           minLength: 2
           maxLength: 128
+        evidenceReferences:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            minLength: 3
+            maxLength: 500
         metadata:
           type: object
           additionalProperties: true
@@ -5920,6 +6015,334 @@ components:
           const: true
         data:
           $ref: '#/components/schemas/TreasurySweepBatchDetail'
+        timestamp:
+          type: string
+          format: date-time
+    TreasuryCloseIssue:
+      type: object
+      required: [code, severity, owner, message]
+      properties:
+        code:
+          type: string
+        severity:
+          type: string
+          enum: [BLOCKING, WARNING]
+        owner:
+          type: string
+          enum: [TREASURY, FINANCE, RECONCILIATION, OPS]
+        message:
+          type: string
+        trade_id:
+          type: string
+          nullable: true
+        sweep_batch_id:
+          type: integer
+          nullable: true
+        ledger_entry_id:
+          type: integer
+          nullable: true
+        details:
+          type: object
+          additionalProperties: true
+    TreasuryPeriodRollforward:
+      type: object
+      required:
+        [
+          period,
+          generated_at,
+          opening_held_raw,
+          new_accruals_raw,
+          allocated_to_batches_raw,
+          swept_onchain_raw,
+          handed_off_raw,
+          realized_raw,
+          ending_held_raw,
+          unresolved_exception_raw,
+          blocking_issue_count,
+          warning_issue_count,
+          blocking_issues,
+          warning_issues,
+        ]
+      properties:
+        period:
+          $ref: '#/components/schemas/TreasuryAccountingPeriod'
+        generated_at:
+          type: string
+          format: date-time
+        opening_held_raw:
+          type: string
+        new_accruals_raw:
+          type: string
+        allocated_to_batches_raw:
+          type: string
+        swept_onchain_raw:
+          type: string
+        handed_off_raw:
+          type: string
+        realized_raw:
+          type: string
+        ending_held_raw:
+          type: string
+        unresolved_exception_raw:
+          type: string
+        blocking_issue_count:
+          type: integer
+          minimum: 0
+        warning_issue_count:
+          type: integer
+          minimum: 0
+        blocking_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+        warning_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+    TreasuryPeriodRollforwardResponse:
+      type: object
+      required: [success, data, timestamp]
+      properties:
+        success:
+          type: boolean
+          const: true
+        data:
+          $ref: '#/components/schemas/TreasuryPeriodRollforward'
+        timestamp:
+          type: string
+          format: date-time
+    TreasuryClaimEvent:
+      type: object
+      required:
+        [
+          id,
+          source_event_id,
+          tx_hash,
+          block_number,
+          observed_at,
+          treasury_identity,
+          payout_receiver,
+          amount_raw,
+          created_at,
+        ]
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        source_event_id:
+          type: string
+        matched_sweep_batch_id:
+          type: integer
+          nullable: true
+        tx_hash:
+          type: string
+        block_number:
+          type: integer
+          minimum: 0
+        observed_at:
+          type: string
+          format: date-time
+        treasury_identity:
+          type: string
+        payout_receiver:
+          type: string
+        amount_raw:
+          type: string
+        triggered_by:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    TreasuryBatchTraceEntry:
+      type: object
+      required:
+        [
+          ledger_entry_id,
+          trade_id,
+          component_type,
+          source_amount_raw,
+          earned_at,
+          accounting_state,
+          accounting_state_reason,
+        ]
+      properties:
+        ledger_entry_id:
+          type: integer
+          minimum: 1
+        trade_id:
+          type: string
+        component_type:
+          type: string
+        source_amount_raw:
+          type: string
+        allocated_amount_raw:
+          type: string
+          nullable: true
+        earned_at:
+          type: string
+          format: date-time
+        accounting_state:
+          $ref: '#/components/schemas/TreasuryAccountingState'
+        accounting_state_reason:
+          type: string
+        matched_sweep_tx_hash:
+          type: string
+          nullable: true
+        matched_swept_at:
+          type: string
+          format: date-time
+          nullable: true
+        partner_reference:
+          type: string
+          nullable: true
+        partner_handoff_status:
+          oneOf:
+            - $ref: '#/components/schemas/TreasuryPartnerHandoffStatus'
+            - type: 'null'
+        latest_bank_reference:
+          type: string
+          nullable: true
+        latest_bank_payout_state:
+          type: string
+          nullable: true
+        latest_bank_confirmed_at:
+          type: string
+          format: date-time
+          nullable: true
+        revenue_realization_status:
+          oneOf:
+            - $ref: '#/components/schemas/TreasuryRevenueRealizationStatus'
+            - type: 'null'
+        realized_at:
+          type: string
+          format: date-time
+          nullable: true
+    TreasuryBatchTraceReport:
+      type: object
+      required:
+        [batch, claim_event, partner_handoff, totals, entries, blocking_issues, warning_issues]
+      properties:
+        batch:
+          $ref: '#/components/schemas/TreasurySweepBatch'
+        claim_event:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/TreasuryClaimEvent'
+        partner_handoff:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/TreasuryPartnerHandoff'
+        totals:
+          type: object
+          required: [expected_total_raw, allocated_total_raw, entry_count]
+          properties:
+            expected_total_raw:
+              type: string
+            allocated_total_raw:
+              type: string
+            entry_count:
+              type: integer
+              minimum: 0
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryBatchTraceEntry'
+        blocking_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+        warning_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+    TreasuryBatchTraceReportResponse:
+      type: object
+      required: [success, data, timestamp]
+      properties:
+        success:
+          type: boolean
+          const: true
+        data:
+          $ref: '#/components/schemas/TreasuryBatchTraceReport'
+        timestamp:
+          type: string
+          format: date-time
+    TreasuryAccountingPeriodClosePacket:
+      type: object
+      required:
+        [
+          period,
+          generated_at,
+          ready_for_close,
+          rollforward,
+          reconciliation,
+          batches,
+          blocking_issues,
+          warning_issues,
+        ]
+      properties:
+        period:
+          $ref: '#/components/schemas/TreasuryAccountingPeriod'
+        generated_at:
+          type: string
+          format: date-time
+        ready_for_close:
+          type: boolean
+        rollforward:
+          $ref: '#/components/schemas/TreasuryPeriodRollforward'
+        reconciliation:
+          type: object
+          required:
+            [
+              status,
+              freshness,
+              latest_completed_run_key,
+              latest_completed_run_at,
+              stale_running_run_count,
+              blocked_reasons,
+            ]
+          properties:
+            status:
+              type: string
+            freshness:
+              type: string
+              enum: [FRESH, STALE, MISSING]
+            latest_completed_run_key:
+              type: string
+              nullable: true
+            latest_completed_run_at:
+              type: string
+              format: date-time
+              nullable: true
+            stale_running_run_count:
+              type: integer
+              minimum: 0
+            blocked_reasons:
+              type: array
+              items:
+                type: string
+        batches:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryBatchTraceReport'
+        blocking_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+        warning_issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreasuryCloseIssue'
+    TreasuryAccountingPeriodClosePacketResponse:
+      type: object
+      required: [success, data, timestamp]
+      properties:
+        success:
+          type: boolean
+          const: true
+        data:
+          $ref: '#/components/schemas/TreasuryAccountingPeriodClosePacket'
         timestamp:
           type: string
           format: date-time

--- a/docs/runbooks/treasury-revenue-close.md
+++ b/docs/runbooks/treasury-revenue-close.md
@@ -72,6 +72,13 @@ Operator checks:
 - entry is not already allocated to another active batch
 - no unresolved exception state is present
 
+Review the period rollforward before batching or close:
+
+```bash
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT:-3001}/api/dashboard-gateway/v1/treasury/accounting-periods/7/rollforward" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
+
 ### 3. Create and populate the sweep batch
 
 Create draft batch:
@@ -124,6 +131,13 @@ Do not approve if:
 - allocated total differs from expected total
 - payout receiver is not the governed active receiver
 - reconciliation for included trades is stale, missing, or blocked
+
+Review the batch trace before approval or close:
+
+```bash
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT:-3001}/api/dashboard-gateway/v1/treasury/sweep-batches/11/trace" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
 
 ### 5. Match the on-chain treasury claim
 
@@ -195,6 +209,20 @@ Realization preconditions:
 
 ### 8. Close the batch and the period
 
+Review the close packet before period close:
+
+```bash
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT:-3001}/api/dashboard-gateway/v1/treasury/accounting-periods/7/close-packet" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
+
+Human-reviewable markdown export is also available:
+
+```bash
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT:-3001}/api/dashboard-gateway/v1/treasury/accounting-periods/7/close-packet?format=markdown" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
+
 Close batch only after all linked entries are `REALIZED`:
 
 ```bash
@@ -223,12 +251,20 @@ Period close is blocked when:
 - sweep batches in the period remain open
 - reconciliation is not clear for the trades covered by closed batches
 
+Gateway capability note:
+
+- `treasury:prepare` is required to create periods/batches, allocate entries, and request close
+- `treasury:approve` is required to approve a sweep batch
+- `treasury:execute_match` is required to match on-chain claim evidence and record external handoff
+- `treasury:close` is required to close batches, record realization, and close the accounting period
+
 ## Required Evidence Packet
 
 For every batch/period close, attach:
 
 - gateway audit trail
-- sweep batch detail export
+- period rollforward and close packet export
+- sweep batch trace export
 - reconciliation report rows for included trades
 - on-chain treasury claim reference
 - external execution handoff reference

--- a/gateway/src/core/authSessionClient.ts
+++ b/gateway/src/core/authSessionClient.ts
@@ -12,6 +12,7 @@ export interface AuthSession {
   accountId?: string;
   walletAddress: string | null;
   role: AuthServiceRole;
+  capabilities?: string[];
   issuedAt: number;
   expiresAt: number;
   email?: string | null;

--- a/gateway/src/core/errorHandlerWorkflow.ts
+++ b/gateway/src/core/errorHandlerWorkflow.ts
@@ -269,6 +269,13 @@ function restorePrincipal(snapshot: FailedOperationPrincipalSnapshot): GatewayPr
       ...(snapshot.actorUserId ? { email: `${snapshot.actorUserId}@replay.invalid` } : {}),
     },
     gatewayRoles: ['operator:read', 'operator:write'],
+    treasuryCapabilities: [
+      'treasury:read',
+      'treasury:prepare',
+      'treasury:approve',
+      'treasury:execute_match',
+      'treasury:close',
+    ],
     writeEnabled: true,
   };
 }

--- a/gateway/src/core/treasuryWorkflowService.ts
+++ b/gateway/src/core/treasuryWorkflowService.ts
@@ -5,7 +5,7 @@ import type { AuditLogStore } from './auditLogStore';
 import type { AuthSession } from './authSessionClient';
 import { GatewayError } from '../errors';
 import type { RequestContext } from '../middleware/requestContext';
-import { resolveGatewayActorKey } from '../middleware/auth';
+import { resolveGatewayActorKey, resolveTreasuryCapabilities } from '../middleware/auth';
 import type { DownstreamServiceOrchestrator } from './serviceOrchestrator';
 
 interface TreasuryEnvelope<T> {
@@ -21,6 +21,7 @@ interface TreasuryEnvelope<T> {
 export interface TreasuryWorkflowAuditInput {
   reason: string;
   ticketRef: string;
+  evidenceReferences?: string[];
   metadata?: Record<string, unknown>;
 }
 
@@ -53,6 +54,21 @@ export interface TreasuryWorkflowReader {
   ): Promise<unknown>;
   getEntryAccounting(
     entryId: number,
+    requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>,
+  ): Promise<unknown>;
+  getAccountingPeriodRollforward(
+    periodId: number,
+    requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>,
+  ): Promise<unknown>;
+  getAccountingPeriodClosePacket(
+    periodId: number,
+    query: {
+      format?: 'json' | 'markdown';
+      requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>;
+    },
+  ): Promise<unknown>;
+  getSweepBatchTrace(
+    batchId: number,
     requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>,
   ): Promise<unknown>;
 }
@@ -302,6 +318,75 @@ export class TreasuryWorkflowService implements TreasuryWorkflowClient {
     return parseTreasuryResponse(response, 'Failed to read treasury entry accounting state');
   }
 
+  async getAccountingPeriodRollforward(
+    periodId: number,
+    requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>,
+  ): Promise<unknown> {
+    const response = await this.orchestrator.fetch('treasury', {
+      method: 'GET',
+      path: `/api/treasury/v1/accounting-periods/${periodId}/rollforward`,
+      readOnly: true,
+      authenticated: true,
+      requestContext,
+      operation: 'treasury:getAccountingPeriodRollforward',
+    });
+
+    return parseTreasuryResponse(
+      response,
+      'Failed to build treasury accounting period rollforward',
+    );
+  }
+
+  async getAccountingPeriodClosePacket(
+    periodId: number,
+    query: {
+      format?: 'json' | 'markdown';
+      requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>;
+    },
+  ): Promise<unknown> {
+    const { requestContext, ...queryParams } = query;
+    const response = await this.orchestrator.fetch('treasury', {
+      method: 'GET',
+      path: `/api/treasury/v1/accounting-periods/${periodId}/close-packet`,
+      query: queryParams,
+      readOnly: true,
+      authenticated: true,
+      requestContext,
+      operation: 'treasury:getAccountingPeriodClosePacket',
+    });
+
+    if (query.format === 'markdown') {
+      if (response.status >= 400) {
+        await parseTreasuryResponse(
+          response,
+          'Failed to build treasury accounting period close packet',
+        );
+      }
+      return response.text();
+    }
+
+    return parseTreasuryResponse(
+      response,
+      'Failed to build treasury accounting period close packet',
+    );
+  }
+
+  async getSweepBatchTrace(
+    batchId: number,
+    requestContext?: Pick<RequestContext, 'requestId' | 'correlationId'>,
+  ): Promise<unknown> {
+    const response = await this.orchestrator.fetch('treasury', {
+      method: 'GET',
+      path: `/api/treasury/v1/sweep-batches/${batchId}/trace`,
+      readOnly: true,
+      authenticated: true,
+      requestContext,
+      operation: 'treasury:getSweepBatchTrace',
+    });
+
+    return parseTreasuryResponse(response, 'Failed to build treasury sweep batch trace');
+  }
+
   async createAccountingPeriod(
     input: {
       periodKey: string;
@@ -507,13 +592,19 @@ export class TreasuryWorkflowService implements TreasuryWorkflowClient {
   }
 
   private buildTreasuryMetadata(context: TreasuryWorkflowMutationContext): Record<string, unknown> {
+    const effectiveTreasuryCapabilities = resolveTreasuryCapabilities(context.session);
     return {
       gatewayActorKey: resolveGatewayActorKey(context.session),
       gatewayUserId: context.session.userId,
       gatewayWalletAddress: context.session.walletAddress,
       gatewayRole: context.session.role,
+      gatewayTreasuryCapabilitiesRaw: context.session.capabilities ?? null,
+      gatewayTreasuryCapabilitiesEffective: effectiveTreasuryCapabilities,
+      requestId: context.requestContext?.requestId ?? null,
+      correlationId: context.requestContext?.correlationId ?? null,
       auditReason: context.audit.reason,
       auditTicketRef: context.audit.ticketRef,
+      auditEvidenceReferences: context.audit.evidenceReferences ?? [],
       ...(context.audit.metadata ?? {}),
     };
   }
@@ -555,6 +646,8 @@ export class TreasuryWorkflowService implements TreasuryWorkflowClient {
           treasuryPath: path,
           ticketRef: context.audit.ticketRef,
           reason: context.audit.reason,
+          evidenceReferences: context.audit.evidenceReferences ?? [],
+          correlationId: context.requestContext?.correlationId ?? null,
           result: data,
         },
         'Failed to build treasury audit payload',

--- a/gateway/src/middleware/auth.ts
+++ b/gateway/src/middleware/auth.ts
@@ -96,14 +96,14 @@ export function resolveTreasuryCapabilities(session: AuthSession): TreasuryCapab
     return [];
   }
 
-  const declaredCapabilities = Array.isArray(session.capabilities)
-    ? session.capabilities.filter((capability): capability is TreasuryCapability =>
-        TREASURY_CAPABILITIES.includes(capability as TreasuryCapability),
-      )
-    : [];
-
-  if (declaredCapabilities.length > 0) {
-    return [...new Set(declaredCapabilities)];
+  if (Array.isArray(session.capabilities)) {
+    return [
+      ...new Set(
+        session.capabilities.filter((capability): capability is TreasuryCapability =>
+          TREASURY_CAPABILITIES.includes(capability as TreasuryCapability),
+        ),
+      ),
+    ];
   }
 
   return [...TREASURY_CAPABILITIES];

--- a/gateway/src/middleware/auth.ts
+++ b/gateway/src/middleware/auth.ts
@@ -8,11 +8,26 @@ import { AuthSession, AuthSessionClient } from '../core/authSessionClient';
 import { GatewayError } from '../errors';
 
 export type GatewayRole = 'operator:read' | 'operator:write';
+export type TreasuryCapability =
+  | 'treasury:read'
+  | 'treasury:prepare'
+  | 'treasury:approve'
+  | 'treasury:execute_match'
+  | 'treasury:close';
+
+const TREASURY_CAPABILITIES: TreasuryCapability[] = [
+  'treasury:read',
+  'treasury:prepare',
+  'treasury:approve',
+  'treasury:execute_match',
+  'treasury:close',
+];
 
 export interface GatewayPrincipal {
   sessionReference: string;
   session: AuthSession;
   gatewayRoles: GatewayRole[];
+  treasuryCapabilities: TreasuryCapability[];
   writeEnabled: boolean;
 }
 
@@ -76,6 +91,24 @@ function mapGatewayRoles(session: AuthSession): GatewayRole[] {
   return [];
 }
 
+export function resolveTreasuryCapabilities(session: AuthSession): TreasuryCapability[] {
+  if (session.role !== 'admin') {
+    return [];
+  }
+
+  const declaredCapabilities = Array.isArray(session.capabilities)
+    ? session.capabilities.filter((capability): capability is TreasuryCapability =>
+        TREASURY_CAPABILITIES.includes(capability as TreasuryCapability),
+      )
+    : [];
+
+  if (declaredCapabilities.length > 0) {
+    return [...new Set(declaredCapabilities)];
+  }
+
+  return [...TREASURY_CAPABILITIES];
+}
+
 export function matchesAllowlist(session: AuthSession, allowlist: string[]): boolean {
   if (allowlist.length === 0) {
     return false;
@@ -113,6 +146,7 @@ export function createAuthenticationMiddleware(client: AuthSessionClient, config
       sessionReference: buildSessionReference(token),
       session,
       gatewayRoles: mapGatewayRoles(session),
+      treasuryCapabilities: resolveTreasuryCapabilities(session),
       writeEnabled: config.enableMutations && matchesAllowlist(session, config.writeAllowlist),
     };
 
@@ -124,6 +158,23 @@ export function requireGatewayRole(role: GatewayRole) {
   return (req: Request, _res: Response, next: NextFunction): void => {
     if (!req.gatewayPrincipal?.gatewayRoles.includes(role)) {
       next(new GatewayError(403, 'FORBIDDEN', `Gateway role '${role}' is required`));
+      return;
+    }
+
+    next();
+  };
+}
+
+export function requireTreasuryCapability(capability: TreasuryCapability) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const principal = req.gatewayPrincipal;
+    if (!principal) {
+      next(new GatewayError(401, 'AUTH_REQUIRED', 'Authentication is required'));
+      return;
+    }
+
+    if (!principal.treasuryCapabilities.includes(capability)) {
+      next(new GatewayError(403, 'FORBIDDEN', `Treasury capability '${capability}' is required`));
       return;
     }
 

--- a/gateway/src/routes/treasury.ts
+++ b/gateway/src/routes/treasury.ts
@@ -19,6 +19,7 @@ import {
   createAuthenticationMiddleware,
   requireGatewayRole,
   requireMutationWriteAccess,
+  requireTreasuryCapability,
   requireWalletBoundSession,
 } from '../middleware/auth';
 import { successResponse } from '../responses';
@@ -35,6 +36,7 @@ interface TreasuryAuditPayload {
   audit?: {
     reason?: string;
     ticketRef?: string;
+    evidenceReferences?: string[];
     metadata?: Record<string, unknown>;
   };
 }
@@ -190,6 +192,9 @@ function parseAudit(raw: unknown): TreasuryWorkflowAuditInput {
   const record = parseObject(raw, 'audit');
   const reason = typeof record.reason === 'string' ? record.reason.trim() : '';
   const ticketRef = typeof record.ticketRef === 'string' ? record.ticketRef.trim() : '';
+  const evidenceReferences = Array.isArray(record.evidenceReferences)
+    ? record.evidenceReferences
+    : undefined;
 
   if (reason.length < 8 || reason.length > 2000) {
     throw new GatewayError(
@@ -207,9 +212,34 @@ function parseAudit(raw: unknown): TreasuryWorkflowAuditInput {
     );
   }
 
+  if (evidenceReferences) {
+    if (evidenceReferences.length > 20) {
+      throw new GatewayError(
+        400,
+        'VALIDATION_ERROR',
+        'audit.evidenceReferences must contain at most 20 items',
+      );
+    }
+
+    evidenceReferences.forEach((reference, index) => {
+      if (
+        typeof reference !== 'string' ||
+        reference.trim().length < 3 ||
+        reference.trim().length > 500
+      ) {
+        throw new GatewayError(
+          400,
+          'VALIDATION_ERROR',
+          `audit.evidenceReferences[${index}] must be between 3 and 500 characters`,
+        );
+      }
+    });
+  }
+
   return {
     reason,
     ticketRef,
+    evidenceReferences: evidenceReferences?.map((reference) => reference.trim()),
     metadata: parseOptionalRecord(record.metadata, 'audit.metadata'),
   };
 }
@@ -219,6 +249,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
   const authenticate = createAuthenticationMiddleware(options.authSessionClient, options.config);
 
   router.use(authenticate, requireGatewayRole('operator:read'));
+  router.use('/treasury', requireTreasuryCapability('treasury:read'));
 
   router.get('/treasury', async (_req, res, next) => {
     try {
@@ -270,6 +301,45 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
     }
   });
 
+  router.get('/treasury/accounting-periods/:periodId/rollforward', async (req, res, next) => {
+    try {
+      const result = await options.treasuryWorkflowService.getAccountingPeriodRollforward(
+        parsePositiveInt(req.params.periodId, 'periodId'),
+        req.requestContext,
+      );
+
+      res.status(200).json(successResponse(result));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/treasury/accounting-periods/:periodId/close-packet', async (req, res, next) => {
+    try {
+      const format =
+        typeof req.query.format === 'string' && req.query.format.trim() === 'markdown'
+          ? 'markdown'
+          : 'json';
+      const result = await options.treasuryWorkflowService.getAccountingPeriodClosePacket(
+        parsePositiveInt(req.params.periodId, 'periodId'),
+        {
+          format,
+          requestContext: req.requestContext,
+        },
+      );
+
+      if (format === 'markdown') {
+        res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+        res.status(200).send(result);
+        return;
+      }
+
+      res.status(200).json(successResponse(result));
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.get('/treasury/sweep-batches', async (req, res, next) => {
     try {
       const result = await options.treasuryWorkflowService.listSweepBatches({
@@ -295,6 +365,19 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
   router.get('/treasury/sweep-batches/:batchId', async (req, res, next) => {
     try {
       const result = await options.treasuryWorkflowService.getSweepBatch(
+        parsePositiveInt(req.params.batchId, 'batchId'),
+        req.requestContext,
+      );
+
+      res.status(200).json(successResponse(result));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/treasury/sweep-batches/:batchId/trace', async (req, res, next) => {
+    try {
+      const result = await options.treasuryWorkflowService.getSweepBatchTrace(
         parsePositiveInt(req.params.batchId, 'batchId'),
         req.requestContext,
       );
@@ -349,6 +432,19 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
   });
 
   const requireTreasuryWrite = requireMutationWriteAccess();
+  const requireTreasuryPrepare = [
+    requireTreasuryWrite,
+    requireTreasuryCapability('treasury:prepare'),
+  ];
+  const requireTreasuryApprove = [
+    requireTreasuryWrite,
+    requireTreasuryCapability('treasury:approve'),
+  ];
+  const requireTreasuryExecuteMatch = [
+    requireTreasuryWrite,
+    requireTreasuryCapability('treasury:execute_match'),
+  ];
+  const requireTreasuryClose = [requireTreasuryWrite, requireTreasuryCapability('treasury:close')];
   const assertWalletBoundTreasurySigner = (req: Request, actionDescription: string) => {
     if (!req.gatewayPrincipal) {
       throw new GatewayError(401, 'AUTH_REQUIRED', 'Authentication is required');
@@ -357,7 +453,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
     requireWalletBoundSession(req.gatewayPrincipal, actionDescription);
   };
 
-  router.post('/treasury/accounting-periods', requireTreasuryWrite, async (req, res, next) => {
+  router.post('/treasury/accounting-periods', ...requireTreasuryPrepare, async (req, res, next) => {
     try {
       const body = parseObject(req.body, 'body') as TreasuryAuditPayload & Record<string, unknown>;
       const result = await options.treasuryWorkflowService.createAccountingPeriod(
@@ -383,7 +479,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/accounting-periods/:periodId/request-close',
-    requireTreasuryWrite,
+    ...requireTreasuryPrepare,
     async (req, res, next) => {
       try {
         const body = parseObject(req.body, 'body') as TreasuryAuditPayload &
@@ -408,7 +504,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/accounting-periods/:periodId/close',
-    requireTreasuryWrite,
+    ...requireTreasuryClose,
     async (req, res, next) => {
       try {
         const body = parseObject(req.body, 'body') as TreasuryAuditPayload &
@@ -431,7 +527,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
     },
   );
 
-  router.post('/treasury/sweep-batches', requireTreasuryWrite, async (req, res, next) => {
+  router.post('/treasury/sweep-batches', ...requireTreasuryPrepare, async (req, res, next) => {
     try {
       const body = parseObject(req.body, 'body') as TreasuryAuditPayload & Record<string, unknown>;
       const result = await options.treasuryWorkflowService.createSweepBatch(
@@ -462,7 +558,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/sweep-batches/:batchId/entries',
-    requireTreasuryWrite,
+    ...requireTreasuryPrepare,
     async (req, res, next) => {
       try {
         const body = parseObject(req.body, 'body') as TreasuryAuditPayload &
@@ -491,7 +587,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/sweep-batches/:batchId/request-approval',
-    requireTreasuryWrite,
+    ...requireTreasuryPrepare,
     async (req, res, next) => {
       try {
         const body = parseObject(req.body, 'body') as TreasuryAuditPayload &
@@ -516,7 +612,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/sweep-batches/:batchId/approve',
-    requireTreasuryWrite,
+    ...requireTreasuryApprove,
     async (req, res, next) => {
       try {
         assertWalletBoundTreasurySigner(req, 'Approving treasury sweep batch');
@@ -542,7 +638,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/sweep-batches/:batchId/match-execution',
-    requireTreasuryWrite,
+    ...requireTreasuryExecuteMatch,
     async (req, res, next) => {
       try {
         assertWalletBoundTreasurySigner(req, 'Matching treasury sweep execution evidence');
@@ -598,19 +694,19 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/sweep-batches/:batchId/external-handoff',
-    requireTreasuryWrite,
+    ...requireTreasuryExecuteMatch,
     recordExternalHandoff,
   );
 
   router.post(
     '/treasury/sweep-batches/:batchId/partner-handoff',
-    requireTreasuryWrite,
+    ...requireTreasuryExecuteMatch,
     recordExternalHandoff,
   );
 
   router.post(
     '/treasury/sweep-batches/:batchId/close',
-    requireTreasuryWrite,
+    ...requireTreasuryClose,
     async (req, res, next) => {
       try {
         assertWalletBoundTreasurySigner(req, 'Closing treasury sweep batch');
@@ -636,7 +732,7 @@ export function createTreasuryRouter(options: TreasuryRouterOptions): Router {
 
   router.post(
     '/treasury/entries/:entryId/realizations',
-    requireTreasuryWrite,
+    ...requireTreasuryClose,
     async (req, res, next) => {
       try {
         const body = parseObject(req.body, 'body') as TreasuryAuditPayload &

--- a/gateway/tests/accessLogService.test.ts
+++ b/gateway/tests/accessLogService.test.ts
@@ -26,6 +26,13 @@ function buildPrincipal(
     sessionReference: 'sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd',
     session,
     gatewayRoles: ['operator:read', 'operator:write'],
+    treasuryCapabilities: [
+      'treasury:read',
+      'treasury:prepare',
+      'treasury:approve',
+      'treasury:execute_match',
+      'treasury:close',
+    ],
     writeEnabled: true,
   };
 }

--- a/gateway/tests/complianceService.test.ts
+++ b/gateway/tests/complianceService.test.ts
@@ -19,6 +19,13 @@ function buildPrincipal(): GatewayPrincipal {
   return {
     sessionReference: 'sha256:sess-admin',
     gatewayRoles: ['operator:read', 'operator:write'],
+    treasuryCapabilities: [
+      'treasury:read',
+      'treasury:prepare',
+      'treasury:approve',
+      'treasury:execute_match',
+      'treasury:close',
+    ],
     writeEnabled: true,
     session: {
       userId: 'uid-admin',

--- a/gateway/tests/evidenceBundleService.test.ts
+++ b/gateway/tests/evidenceBundleService.test.ts
@@ -63,6 +63,13 @@ function buildPrincipal(
 
   return {
     gatewayRoles: ['operator:read', 'operator:write'],
+    treasuryCapabilities: [
+      'treasury:read',
+      'treasury:prepare',
+      'treasury:approve',
+      'treasury:execute_match',
+      'treasury:close',
+    ],
     sessionReference: 'sess-247',
     writeEnabled: true,
     session,

--- a/gateway/tests/idempotency.test.ts
+++ b/gateway/tests/idempotency.test.ts
@@ -72,6 +72,16 @@ async function startServer() {
           expiresAt: 1_744_246_800,
         },
         gatewayRoles: actor === 'buyer' ? [] : ['operator:read', 'operator:write'],
+        treasuryCapabilities:
+          actor === 'buyer'
+            ? []
+            : [
+                'treasury:read',
+                'treasury:prepare',
+                'treasury:approve',
+                'treasury:execute_match',
+                'treasury:close',
+              ],
         writeEnabled: actor !== 'buyer',
       };
       req.gatewayPrincipal = gatewayPrincipal;

--- a/gateway/tests/treasuryRoutes.contract.test.ts
+++ b/gateway/tests/treasuryRoutes.contract.test.ts
@@ -710,6 +710,47 @@ describe('gateway treasury routes contract', () => {
     );
   });
 
+  test('explicit empty treasury capability sets do not fall back to full treasury scope', async () => {
+    const app = await startServer('admin', {
+      config: {
+        enableMutations: true,
+        writeAllowlist: ['uid-admin'],
+      },
+      session: {
+        capabilities: [],
+      },
+    });
+
+    const response = await sendInProcessRequest(app, {
+      method: 'POST',
+      path: '/api/dashboard-gateway/v1/treasury/sweep-batches',
+      headers: {
+        authorization: 'Bearer sess-admin',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        batchKey: '2026-Q2',
+        accountingPeriodId: 7,
+        assetSymbol: 'USDC',
+        expectedTotalRaw: '125000000',
+        audit: {
+          reason: 'Prepare sweep batch',
+          ticketRef: 'FIN-300',
+        },
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.json<{ error: { code: string; message: string } }>()).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'FORBIDDEN',
+          message: expect.stringContaining('Treasury capability'),
+        }),
+      }),
+    );
+  });
+
   test('canonical external handoff route and legacy alias both remain available', async () => {
     const recordPartnerHandoff = jest.fn().mockResolvedValue({
       id: 33,

--- a/gateway/tests/treasuryRoutes.contract.test.ts
+++ b/gateway/tests/treasuryRoutes.contract.test.ts
@@ -237,6 +237,89 @@ const entryAccountingFixture = {
 
 const entryAccountingListFixture = [entryAccountingFixture];
 
+const rollforwardFixture = {
+  period: accountingPeriodsFixture[0],
+  generated_at: '2026-03-31T23:59:59.000Z',
+  opening_held_raw: '0',
+  new_accruals_raw: '125000000',
+  allocated_to_batches_raw: '125000000',
+  swept_onchain_raw: '125000000',
+  handed_off_raw: '0',
+  realized_raw: '0',
+  ending_held_raw: '0',
+  unresolved_exception_raw: '0',
+  blocking_issue_count: 0,
+  warning_issue_count: 0,
+  blocking_issues: [],
+  warning_issues: [],
+};
+
+const closePacketFixture = {
+  period: accountingPeriodsFixture[0],
+  generated_at: '2026-03-31T23:59:59.000Z',
+  ready_for_close: true,
+  rollforward: rollforwardFixture,
+  reconciliation: {
+    status: 'CLEAR',
+    freshness: 'FRESH',
+    latest_completed_run_key: 'run-2026-q1',
+    latest_completed_run_at: '2026-03-31T23:00:00.000Z',
+    stale_running_run_count: 0,
+    blocked_reasons: [],
+  },
+  batches: [
+    {
+      batch: sweepBatchFixture.batch,
+      claim_event: {
+        id: 91,
+        source_event_id: 'claim-91',
+        matched_sweep_batch_id: 11,
+        tx_hash: '0xsweep-1',
+        block_number: 101,
+        observed_at: '2026-03-31T12:00:00.000Z',
+        treasury_identity: '0xtreasury',
+        payout_receiver: '0x0000000000000000000000000000000000000033',
+        amount_raw: '125000000',
+        triggered_by: '0xexecutor',
+        created_at: '2026-03-31T12:00:00.000Z',
+      },
+      partner_handoff: null,
+      totals: {
+        expected_total_raw: '125000000',
+        allocated_total_raw: '125000000',
+        entry_count: 1,
+      },
+      entries: [
+        {
+          ledger_entry_id: 501,
+          trade_id: 'trade-501',
+          component_type: 'PLATFORM_FEE',
+          source_amount_raw: '125000000',
+          allocated_amount_raw: '125000000',
+          earned_at: '2026-03-31T10:00:00.000Z',
+          accounting_state: 'SWEPT',
+          accounting_state_reason: 'Matched on-chain treasury claim recorded',
+          matched_sweep_tx_hash: '0xsweep-1',
+          matched_swept_at: '2026-03-31T12:00:00.000Z',
+          partner_reference: null,
+          partner_handoff_status: null,
+          latest_bank_reference: null,
+          latest_bank_payout_state: 'CONFIRMED',
+          latest_bank_confirmed_at: '2026-03-31T13:00:00.000Z',
+          revenue_realization_status: null,
+          realized_at: null,
+        },
+      ],
+      blocking_issues: [],
+      warning_issues: [],
+    },
+  ],
+  blocking_issues: [],
+  warning_issues: [],
+};
+
+const batchTraceFixture = closePacketFixture.batches[0];
+
 async function startServer(
   role: 'admin' | 'buyer' | null,
   options?: {
@@ -276,6 +359,9 @@ async function startServer(
     listEntryAccounting: jest.fn().mockResolvedValue(entryAccountingListFixture),
     getSweepBatch: jest.fn().mockResolvedValue(sweepBatchFixture),
     getEntryAccounting: jest.fn().mockResolvedValue(entryAccountingFixture),
+    getAccountingPeriodRollforward: jest.fn().mockResolvedValue(rollforwardFixture),
+    getAccountingPeriodClosePacket: jest.fn().mockResolvedValue(closePacketFixture),
+    getSweepBatchTrace: jest.fn().mockResolvedValue(batchTraceFixture),
     createAccountingPeriod: jest.fn().mockResolvedValue(accountingPeriodsFixture[0]),
     requestAccountingPeriodClose: jest.fn().mockResolvedValue({
       ...accountingPeriodsFixture[0],
@@ -382,8 +468,15 @@ describe('gateway treasury routes contract', () => {
     expect(hasOperation(spec, 'get', '/treasury')).toBe(true);
     expect(hasOperation(spec, 'get', '/treasury/actions')).toBe(true);
     expect(hasOperation(spec, 'get', '/treasury/accounting-periods')).toBe(true);
+    expect(hasOperation(spec, 'get', '/treasury/accounting-periods/{periodId}/rollforward')).toBe(
+      true,
+    );
+    expect(hasOperation(spec, 'get', '/treasury/accounting-periods/{periodId}/close-packet')).toBe(
+      true,
+    );
     expect(hasOperation(spec, 'get', '/treasury/sweep-batches')).toBe(true);
     expect(hasOperation(spec, 'get', '/treasury/sweep-batches/{batchId}')).toBe(true);
+    expect(hasOperation(spec, 'get', '/treasury/sweep-batches/{batchId}/trace')).toBe(true);
     expect(hasOperation(spec, 'get', '/treasury/entries/accounting')).toBe(true);
     expect(hasOperation(spec, 'get', '/treasury/entries/{entryId}/accounting')).toBe(true);
     expect(hasOperation(spec, 'post', '/treasury/accounting-periods')).toBe(true);
@@ -447,6 +540,20 @@ describe('gateway treasury routes contract', () => {
     expect(periodsResponse.status).toBe(200);
     expect(validateAccountingPeriods(periodsPayload)).toBe(true);
 
+    const rollforwardResponse = await sendInProcessRequest(app, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/treasury/accounting-periods/7/rollforward',
+      headers: { authorization: 'Bearer sess-admin' },
+    });
+    expect(rollforwardResponse.status).toBe(200);
+
+    const closePacketResponse = await sendInProcessRequest(app, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/treasury/accounting-periods/7/close-packet',
+      headers: { authorization: 'Bearer sess-admin' },
+    });
+    expect(closePacketResponse.status).toBe(200);
+
     const batchResponse = await sendInProcessRequest(app, {
       method: 'GET',
       path: '/api/dashboard-gateway/v1/treasury/sweep-batches/11',
@@ -455,6 +562,13 @@ describe('gateway treasury routes contract', () => {
     const batchPayload = batchResponse.json<{ data: unknown }>();
     expect(batchResponse.status).toBe(200);
     expect(validateSweepBatch(batchPayload)).toBe(true);
+
+    const batchTraceResponse = await sendInProcessRequest(app, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/treasury/sweep-batches/11/trace',
+      headers: { authorization: 'Bearer sess-admin' },
+    });
+    expect(batchTraceResponse.status).toBe(200);
 
     const entryListResponse = await sendInProcessRequest(app, {
       method: 'GET',
@@ -500,6 +614,7 @@ describe('gateway treasury routes contract', () => {
         audit: {
           reason: 'Open next revenue close period',
           ticketRef: 'FIN-200',
+          evidenceReferences: ['evidence://ticket/FIN-200'],
           metadata: { source: 'contract-test' },
         },
       }),
@@ -557,6 +672,42 @@ describe('gateway treasury routes contract', () => {
     });
 
     expect(response.status).toBe(409);
+  });
+
+  test('treasury capability gates can narrow sensitive routes without changing session posture', async () => {
+    const app = await startServer('admin', {
+      config: {
+        enableMutations: true,
+        writeAllowlist: ['uid-admin'],
+      },
+      session: {
+        capabilities: ['treasury:read', 'treasury:prepare'],
+      },
+    });
+
+    const approveResponse = await sendInProcessRequest(app, {
+      method: 'POST',
+      path: '/api/dashboard-gateway/v1/treasury/sweep-batches/11/approve',
+      headers: {
+        authorization: 'Bearer sess-admin',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        audit: {
+          reason: 'Approve close-ready sweep batch',
+          ticketRef: 'FIN-203',
+        },
+      }),
+    });
+
+    expect(approveResponse.status).toBe(403);
+    expect(approveResponse.json<{ error: { code: string; message: string } }>()).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'FORBIDDEN',
+        }),
+      }),
+    );
   });
 
   test('canonical external handoff route and legacy alias both remain available', async () => {

--- a/gateway/tests/treasuryWorkflowService.test.ts
+++ b/gateway/tests/treasuryWorkflowService.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createInMemoryAuditLogStore } from '../src/core/auditLogStore';
+import { TreasuryWorkflowService } from '../src/core/treasuryWorkflowService';
+import type { DownstreamServiceOrchestrator } from '../src/core/serviceOrchestrator';
+
+describe('TreasuryWorkflowService', () => {
+  test('audit metadata records both raw and effective treasury capabilities', async () => {
+    const orchestrator: DownstreamServiceOrchestrator = {
+      fetch: jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: true, data: { id: 11, status: 'DRAFT' } }), {
+          status: 201,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      ),
+      probeHealth: jest.fn(),
+    };
+    const auditLogStore = createInMemoryAuditLogStore();
+    const service = new TreasuryWorkflowService(orchestrator, auditLogStore);
+
+    await service.createSweepBatch(
+      {
+        batchKey: 'batch-q2-001',
+        accountingPeriodId: 7,
+        assetSymbol: 'USDC',
+        expectedTotalRaw: '125000000',
+      },
+      {
+        requestContext: {
+          requestId: 'req-1',
+          correlationId: 'corr-1',
+        },
+        route: '/api/dashboard-gateway/v1/treasury/sweep-batches',
+        method: 'POST',
+        session: {
+          userId: 'uid-admin',
+          walletAddress: '0x00000000000000000000000000000000000000aa',
+          role: 'admin',
+          issuedAt: 1,
+          expiresAt: 2,
+        },
+        audit: {
+          reason: 'Prepare treasury fee sweep batch',
+          ticketRef: 'FIN-201',
+        },
+      },
+    );
+
+    expect(auditLogStore.entries).toHaveLength(1);
+    expect(auditLogStore.entries[0].metadata).toEqual(
+      expect.objectContaining({
+        treasuryPath: '/api/treasury/v1/internal/sweep-batches',
+        ticketRef: 'FIN-201',
+        reason: 'Prepare treasury fee sweep batch',
+      }),
+    );
+    expect((orchestrator.fetch as jest.Mock).mock.calls[0][1].body).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          gatewayTreasuryCapabilitiesRaw: null,
+          gatewayTreasuryCapabilitiesEffective: [
+            'treasury:read',
+            'treasury:prepare',
+            'treasury:approve',
+            'treasury:execute_match',
+            'treasury:close',
+          ],
+        }),
+      }),
+    );
+  });
+});

--- a/treasury/README.md
+++ b/treasury/README.md
@@ -1,7 +1,7 @@
 # Treasury Settlement Evidence v0
 
-Append-only settlement-evidence and payout-eligibility view for treasury-relevant
-events.
+Append-only settlement-evidence, treasury close, and revenue-controls service for
+treasury-relevant events.
 
 This service is not the customer accounting ledger. Agroasys Aurora/Postgres
 plus the Agroasys shadow ledger remain canonical for balances, reporting, and
@@ -19,6 +19,7 @@ Canonical boundary:
 - Stores accounting periods, sweep batches, external execution handoff records (`partner_handoffs`, compatibility schema name), and revenue realization records
 - Exposes read/query/export endpoints for reconciliation and payout-eligibility review
 - Exposes treasury revenue-controls read endpoints for operator/reporting surfaces
+- Exposes deterministic accounting-period rollforward, close-packet, and sweep-batch trace outputs
 - Exposes internal-only mutation endpoints for gateway-owned finance workflow, sweep matching, handoff, and realization evidence
 - Blocks payout/export when reconciliation is missing, stale, drifted, or out of scope
 - Blocks accounting-period close when tracked sweep-batch trades are not reconciliation-clear
@@ -32,8 +33,11 @@ Public read/reporting routes:
 - `GET /api/treasury/v1/entries/accounting`
 - `GET /api/treasury/v1/entries/:entryId/accounting`
 - `GET /api/treasury/v1/accounting-periods`
+- `GET /api/treasury/v1/accounting-periods/:periodId/rollforward`
+- `GET /api/treasury/v1/accounting-periods/:periodId/close-packet?format=json|markdown`
 - `GET /api/treasury/v1/sweep-batches`
 - `GET /api/treasury/v1/sweep-batches/:batchId`
+- `GET /api/treasury/v1/sweep-batches/:batchId/trace`
 - `GET /api/treasury/v1/export?format=json|csv`
 - `GET /api/treasury/v1/reconciliation/control-summary`
 - `GET /api/treasury/v1/health`
@@ -125,6 +129,13 @@ Compatibility note:
 
 - `partner_handoffs` and related `partner_*` fields are retained as stable persistence names
 - canonical semantics are external execution handoff evidence against a replaceable counterparty
+
+Gateway capability note:
+
+- gateway treasury routes are capability-gated as `treasury:read`, `treasury:prepare`,
+  `treasury:approve`, `treasury:execute_match`, and `treasury:close`
+- when the upstream auth session does not yet provide explicit treasury capabilities, the current
+  admin fallback grants the full treasury capability set
 
 Visible accounting state is computed from persisted facts:
 

--- a/treasury/src/api/controller.ts
+++ b/treasury/src/api/controller.ts
@@ -18,6 +18,11 @@ import { TreasuryEligibilityService } from '../core/exportEligibility';
 import { TreasuryIngestionService } from '../core/ingestion';
 import { ReconciliationGateService } from '../core/reconciliationGate';
 import { SweepExecutionMatcherService } from '../core/sweepExecutionMatcher';
+import {
+  loadTreasuryAccountingPeriodClosePacket,
+  loadTreasuryBatchTraceReport,
+  renderTreasuryAccountingPeriodClosePacketMarkdown,
+} from '../core/closeReporting';
 import { assertFiatDepositState, FiatDepositConflictError } from '../core/fiatDeposit';
 import { assertValidTransition } from '../core/payout';
 import {
@@ -60,6 +65,7 @@ const PAYOUT_STATES: PayoutState[] = [
 ];
 
 const EXPORT_FORMATS = ['json', 'csv'] as const;
+const CLOSE_PACKET_FORMATS = ['json', 'markdown'] as const;
 const ACCOUNTING_PERIOD_STATUSES: AccountingPeriodStatus[] = ['OPEN', 'PENDING_CLOSE', 'CLOSED'];
 const SWEEP_BATCH_STATUSES: SweepBatchStatus[] = [
   'DRAFT',
@@ -452,6 +458,48 @@ export class TreasuryController {
     }
   }
 
+  async getAccountingPeriodRollforward(
+    req: Request<{ periodId: string }>,
+    res: Response,
+  ): Promise<void> {
+    try {
+      const periodId = parsePeriodId(req.params.periodId);
+      const packet = await loadTreasuryAccountingPeriodClosePacket(
+        periodId,
+        this.reconciliationGate,
+      );
+      res.status(200).json(success(packet.rollforward));
+    } catch (error: unknown) {
+      const response = mapValidationError(error, 'Failed to build accounting period rollforward');
+      res.status(response.statusCode).json(response.body);
+    }
+  }
+
+  async getAccountingPeriodClosePacket(
+    req: Request<{ periodId: string }>,
+    res: Response,
+  ): Promise<void> {
+    try {
+      const periodId = parsePeriodId(req.params.periodId);
+      const format = optionalEnum(req.query.format, CLOSE_PACKET_FORMATS, 'format') ?? 'json';
+      const packet = await loadTreasuryAccountingPeriodClosePacket(
+        periodId,
+        this.reconciliationGate,
+      );
+
+      if (format === 'markdown') {
+        res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+        res.status(200).send(renderTreasuryAccountingPeriodClosePacketMarkdown(packet));
+        return;
+      }
+
+      res.status(200).json(success(packet));
+    } catch (error: unknown) {
+      const response = mapValidationError(error, 'Failed to build accounting period close packet');
+      res.status(response.statusCode).json(response.body);
+    }
+  }
+
   async listEntryAccounting(req: Request, res: Response): Promise<void> {
     try {
       const accountingState = optionalEnum(
@@ -537,54 +585,21 @@ export class TreasuryController {
     try {
       const periodId = parsePeriodId(req.params.periodId);
       const body = requireObject<UpdateAccountingPeriodStatusBody>(req.body, 'body');
-      const batches = [];
-      const pageSize = 500;
-      for (let offset = 0; ; offset += pageSize) {
-        const page = await listSweepBatches({
-          accountingPeriodId: periodId,
-          limit: pageSize,
-          offset,
-        });
-        batches.push(...page);
-        if (page.length < pageSize) {
-          break;
-        }
-      }
-      const openBatches = batches.filter((batch) => !['CLOSED', 'VOID'].includes(batch.status));
-      if (openBatches.length > 0) {
+      const closePacket = await loadTreasuryAccountingPeriodClosePacket(
+        periodId,
+        this.reconciliationGate,
+      );
+
+      if (!closePacket.ready_for_close) {
         throw new HttpError(
           409,
           'CloseBlocked',
-          'Accounting period cannot close while sweep batches remain open',
+          'Accounting period cannot close while blocking treasury close issues remain',
           {
-            openBatchIds: openBatches.map((batch) => batch.id),
+            blockingIssues: closePacket.blocking_issues,
+            reconciliation: closePacket.reconciliation,
           },
         );
-      }
-
-      const detailEntries = await Promise.all(
-        batches.map(async (batch) => {
-          const detail = await getSweepBatchDetail(batch.id);
-          return detail?.entries ?? [];
-        }),
-      );
-      const tradeIds = Array.from(
-        new Set(detailEntries.flatMap((entries) => entries.map((entry) => entry.trade_id))),
-      );
-      if (tradeIds.length > 0) {
-        const summary = await this.reconciliationGate.summarizeTrades(tradeIds);
-        if (summary.status !== 'CLEAR') {
-          throw new HttpError(
-            409,
-            'CloseBlocked',
-            'Accounting period cannot close while reconciliation is not clear for batch trades',
-            {
-              reconciliationStatus: summary.status,
-              blockedReasons: summary.blockedReasons,
-              tradeIds,
-            },
-          );
-        }
       }
 
       const period = await updateAccountingPeriodStatus({
@@ -660,6 +675,17 @@ export class TreasuryController {
       res.status(200).json(success(detail));
     } catch (error: unknown) {
       const response = mapValidationError(error, 'Failed to read sweep batch');
+      res.status(response.statusCode).json(response.body);
+    }
+  }
+
+  async getSweepBatchTrace(req: Request<{ batchId: string }>, res: Response): Promise<void> {
+    try {
+      const batchId = parseBatchId(req.params.batchId);
+      const trace = await loadTreasuryBatchTraceReport(batchId);
+      res.status(200).json(success(trace));
+    } catch (error: unknown) {
+      const response = mapValidationError(error, 'Failed to build sweep batch trace');
       res.status(response.statusCode).json(response.body);
     }
   }

--- a/treasury/src/api/routes.ts
+++ b/treasury/src/api/routes.ts
@@ -74,6 +74,16 @@ export function createRouter(
     controller.listAccountingPeriods.bind(controller),
   );
   router.get(
+    '/accounting-periods/:periodId/rollforward',
+    ...protectedMiddlewares,
+    controller.getAccountingPeriodRollforward.bind(controller),
+  );
+  router.get(
+    '/accounting-periods/:periodId/close-packet',
+    ...protectedMiddlewares,
+    controller.getAccountingPeriodClosePacket.bind(controller),
+  );
+  router.get(
     '/sweep-batches',
     ...protectedMiddlewares,
     controller.listSweepBatches.bind(controller),
@@ -82,6 +92,11 @@ export function createRouter(
     '/sweep-batches/:batchId',
     ...protectedMiddlewares,
     controller.getSweepBatch.bind(controller),
+  );
+  router.get(
+    '/sweep-batches/:batchId/trace',
+    ...protectedMiddlewares,
+    controller.getSweepBatchTrace.bind(controller),
   );
   router.get('/export', ...protectedMiddlewares, controller.exportEntries.bind(controller));
   router.post(

--- a/treasury/src/core/closeReporting.ts
+++ b/treasury/src/core/closeReporting.ts
@@ -1,0 +1,543 @@
+import {
+  getAccountingPeriodById,
+  getSweepBatchDetail,
+  getTreasuryClaimEventByBatchId,
+  listLedgerEntryAccountingProjections,
+  listSweepBatches,
+} from '../database/queries';
+import {
+  AccountingPeriod,
+  LedgerEntryAccountingProjection,
+  SweepBatchWithPeriod,
+  TreasuryAccountingPeriodClosePacket,
+  TreasuryBatchTraceEntry,
+  TreasuryBatchTraceReport,
+  TreasuryCloseIssue,
+  TreasuryPeriodRollforwardReport,
+} from '../types';
+import { ReconciliationGateService, TradeReconciliationGate } from './reconciliationGate';
+
+const PAGE_SIZE = 500;
+
+function sumRaw(values: Iterable<string | null | undefined>): string {
+  let total = 0n;
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+    total += BigInt(value);
+  }
+  return total.toString();
+}
+
+function entrySourceAmount(entry: LedgerEntryAccountingProjection): string {
+  return entry.amount_raw;
+}
+
+function entryAllocatedAmount(entry: LedgerEntryAccountingProjection): string {
+  return entry.allocated_amount_raw ?? entry.amount_raw;
+}
+
+function isWithinWindow(timestamp: Date | null | undefined, startsAt: Date, endsAt: Date): boolean {
+  return Boolean(timestamp && timestamp >= startsAt && timestamp <= endsAt);
+}
+
+function dedupeIssues(issues: TreasuryCloseIssue[]): TreasuryCloseIssue[] {
+  const byKey = new Map<string, TreasuryCloseIssue>();
+  for (const issue of issues) {
+    const key = [
+      issue.code,
+      issue.trade_id ?? '',
+      issue.sweep_batch_id ?? '',
+      issue.ledger_entry_id ?? '',
+    ].join('|');
+    if (!byKey.has(key)) {
+      byKey.set(key, issue);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function buildEntryIssues(entry: LedgerEntryAccountingProjection): TreasuryCloseIssue[] {
+  const issues: TreasuryCloseIssue[] = [];
+
+  if (entry.accounting_state === 'EXCEPTION') {
+    issues.push({
+      code: 'ENTRY_EXCEPTION_STATE',
+      severity: 'BLOCKING',
+      owner: 'TREASURY',
+      message: entry.accounting_state_reason,
+      trade_id: entry.trade_id,
+      sweep_batch_id: entry.sweep_batch_id,
+      ledger_entry_id: entry.ledger_entry_id,
+      details: {
+        accountingState: entry.accounting_state,
+        accountingStateReason: entry.accounting_state_reason,
+      },
+    });
+  }
+
+  if (entry.allocated_amount_raw !== null && entry.allocated_amount_raw !== entry.amount_raw) {
+    issues.push({
+      code: 'ALLOCATED_AMOUNT_DIFFERS_FROM_SOURCE',
+      severity: 'WARNING',
+      owner: 'FINANCE',
+      message: 'Allocated amount differs from the source ledger amount',
+      trade_id: entry.trade_id,
+      sweep_batch_id: entry.sweep_batch_id,
+      ledger_entry_id: entry.ledger_entry_id,
+      details: {
+        sourceAmountRaw: entry.amount_raw,
+        allocatedAmountRaw: entry.allocated_amount_raw,
+      },
+    });
+  }
+
+  return issues;
+}
+
+function buildReconciliationIssues(
+  assessments: Map<string, TradeReconciliationGate>,
+): TreasuryCloseIssue[] {
+  const issues: TreasuryCloseIssue[] = [];
+
+  for (const [tradeId, assessment] of assessments.entries()) {
+    if (assessment.status === 'CLEAR') {
+      continue;
+    }
+
+    issues.push({
+      code: `RECONCILIATION_${assessment.status}`,
+      severity: 'BLOCKING',
+      owner: 'RECONCILIATION',
+      message:
+        assessment.blockedReasons.join('; ') ||
+        'Trade is not reconciliation-clear for treasury close',
+      trade_id: tradeId,
+      sweep_batch_id: null,
+      ledger_entry_id: null,
+      details: {
+        reconciliationStatus: assessment.status,
+        runKey: assessment.runKey,
+        freshness: assessment.freshness,
+        blockedReasons: assessment.blockedReasons,
+        driftCount: assessment.driftCount,
+      },
+    });
+  }
+
+  return issues;
+}
+
+function serializeBatchTraceEntry(entry: LedgerEntryAccountingProjection): TreasuryBatchTraceEntry {
+  return {
+    ledger_entry_id: entry.ledger_entry_id,
+    trade_id: entry.trade_id,
+    component_type: entry.component_type,
+    source_amount_raw: entry.amount_raw,
+    allocated_amount_raw: entry.allocated_amount_raw,
+    earned_at: entry.earned_at.toISOString(),
+    accounting_state: entry.accounting_state,
+    accounting_state_reason: entry.accounting_state_reason,
+    matched_sweep_tx_hash: entry.matched_sweep_tx_hash,
+    matched_swept_at: entry.matched_swept_at ? entry.matched_swept_at.toISOString() : null,
+    partner_reference: entry.partner_reference,
+    partner_handoff_status: entry.partner_handoff_status,
+    latest_bank_reference: entry.latest_bank_reference ?? null,
+    latest_bank_payout_state: entry.latest_bank_payout_state,
+    latest_bank_confirmed_at: entry.latest_bank_confirmed_at
+      ? entry.latest_bank_confirmed_at.toISOString()
+      : null,
+    revenue_realization_status: entry.revenue_realization_status,
+    realized_at: entry.realized_at ? entry.realized_at.toISOString() : null,
+  };
+}
+
+export function buildTreasuryBatchTraceReport(params: {
+  batch: TreasuryBatchTraceReport['batch'];
+  claimEvent: TreasuryBatchTraceReport['claim_event'];
+  partnerHandoff: TreasuryBatchTraceReport['partner_handoff'];
+  entries: LedgerEntryAccountingProjection[];
+}): TreasuryBatchTraceReport {
+  const entryIssues = params.entries.flatMap((entry) => buildEntryIssues(entry));
+  const batchIssues: TreasuryCloseIssue[] = [];
+
+  if (params.batch.status === 'EXECUTED' && !params.claimEvent) {
+    batchIssues.push({
+      code: 'SWEEP_TX_UNMATCHED',
+      severity: 'BLOCKING',
+      owner: 'TREASURY',
+      message: 'Sweep batch is marked executed without matched treasury claim evidence',
+      trade_id: null,
+      sweep_batch_id: params.batch.id,
+      ledger_entry_id: null,
+      details: {
+        batchStatus: params.batch.status,
+      },
+    });
+  }
+
+  if (params.batch.status === 'HANDED_OFF' && !params.partnerHandoff?.partner_reference) {
+    batchIssues.push({
+      code: 'EXTERNAL_HANDOFF_MISSING',
+      severity: 'BLOCKING',
+      owner: 'TREASURY',
+      message: 'Sweep batch is marked handed off without an external handoff reference',
+      trade_id: null,
+      sweep_batch_id: params.batch.id,
+      ledger_entry_id: null,
+      details: {
+        batchStatus: params.batch.status,
+      },
+    });
+  }
+
+  const blockingIssues = dedupeIssues(
+    [...entryIssues, ...batchIssues].filter((issue) => issue.severity === 'BLOCKING'),
+  );
+  const warningIssues = dedupeIssues(
+    [...entryIssues, ...batchIssues].filter((issue) => issue.severity === 'WARNING'),
+  );
+
+  return {
+    batch: params.batch,
+    claim_event: params.claimEvent,
+    partner_handoff: params.partnerHandoff,
+    totals: {
+      expected_total_raw: params.batch.expected_total_raw,
+      allocated_total_raw: sumRaw(params.entries.map((entry) => entryAllocatedAmount(entry))),
+      entry_count: params.entries.length,
+    },
+    entries: params.entries.map((entry) => serializeBatchTraceEntry(entry)),
+    blocking_issues: blockingIssues,
+    warning_issues: warningIssues,
+  };
+}
+
+export function buildTreasuryPeriodRollforwardReport(params: {
+  period: AccountingPeriod;
+  entries: LedgerEntryAccountingProjection[];
+  reconciliationAssessments: Map<string, TradeReconciliationGate>;
+  batchReports: TreasuryBatchTraceReport[];
+  generatedAt?: Date;
+}): TreasuryPeriodRollforwardReport {
+  const { period, entries } = params;
+  const startsAt = period.starts_at;
+  const endsAt = period.ends_at;
+
+  const entryIssues = entries.flatMap((entry) => buildEntryIssues(entry));
+  const reconciliationIssues = buildReconciliationIssues(params.reconciliationAssessments);
+  const openBatchIssues = params.batchReports
+    .filter((batch) => !['CLOSED', 'VOID'].includes(batch.batch.status))
+    .map<TreasuryCloseIssue>((batch) => ({
+      code: 'BATCH_NOT_CLOSED',
+      severity: 'BLOCKING',
+      owner: 'TREASURY',
+      message: 'Sweep batch remains open for the accounting period',
+      trade_id: null,
+      sweep_batch_id: batch.batch.id,
+      ledger_entry_id: null,
+      details: {
+        batchStatus: batch.batch.status,
+      },
+    }));
+
+  const allIssues = dedupeIssues([
+    ...entryIssues,
+    ...reconciliationIssues,
+    ...openBatchIssues,
+    ...params.batchReports.flatMap((batch) => [...batch.blocking_issues, ...batch.warning_issues]),
+  ]);
+
+  const openingHeldEntries = entries.filter(
+    (entry) =>
+      entry.earned_at < startsAt && (!entry.matched_swept_at || entry.matched_swept_at >= startsAt),
+  );
+  const newAccrualEntries = entries.filter((entry) =>
+    isWithinWindow(entry.earned_at, startsAt, endsAt),
+  );
+  const allocatedEntries = entries.filter((entry) =>
+    isWithinWindow(entry.allocated_at ?? null, startsAt, endsAt),
+  );
+  const sweptEntries = entries.filter((entry) =>
+    isWithinWindow(entry.matched_swept_at ?? null, startsAt, endsAt),
+  );
+  const handedOffEntries = entries.filter((entry) =>
+    isWithinWindow(
+      entry.partner_submitted_at ??
+        entry.partner_acknowledged_at ??
+        entry.partner_completed_at ??
+        entry.partner_failed_at ??
+        null,
+      startsAt,
+      endsAt,
+    ),
+  );
+  const realizedEntries = entries.filter((entry) =>
+    isWithinWindow(entry.realized_at ?? null, startsAt, endsAt),
+  );
+  const endingHeldEntries = entries.filter(
+    (entry) =>
+      entry.earned_at <= endsAt && (!entry.matched_swept_at || entry.matched_swept_at > endsAt),
+  );
+  const unresolvedExceptions = entries.filter(
+    (entry) =>
+      entry.earned_at <= endsAt &&
+      entry.accounting_state === 'EXCEPTION' &&
+      entry.revenue_realization_status !== 'REALIZED',
+  );
+
+  const blockingIssues = allIssues.filter((issue) => issue.severity === 'BLOCKING');
+  const warningIssues = allIssues.filter((issue) => issue.severity === 'WARNING');
+
+  return {
+    period,
+    generated_at: (params.generatedAt ?? new Date()).toISOString(),
+    opening_held_raw: sumRaw(openingHeldEntries.map((entry) => entrySourceAmount(entry))),
+    new_accruals_raw: sumRaw(newAccrualEntries.map((entry) => entrySourceAmount(entry))),
+    allocated_to_batches_raw: sumRaw(allocatedEntries.map((entry) => entryAllocatedAmount(entry))),
+    swept_onchain_raw: sumRaw(
+      sweptEntries.map((entry) => entry.matched_claim_amount_raw ?? entryAllocatedAmount(entry)),
+    ),
+    handed_off_raw: sumRaw(handedOffEntries.map((entry) => entryAllocatedAmount(entry))),
+    realized_raw: sumRaw(realizedEntries.map((entry) => entryAllocatedAmount(entry))),
+    ending_held_raw: sumRaw(endingHeldEntries.map((entry) => entrySourceAmount(entry))),
+    unresolved_exception_raw: sumRaw(
+      unresolvedExceptions.map((entry) => entryAllocatedAmount(entry)),
+    ),
+    blocking_issue_count: blockingIssues.length,
+    warning_issue_count: warningIssues.length,
+    blocking_issues: blockingIssues,
+    warning_issues: warningIssues,
+  };
+}
+
+async function loadAllAccountingEntriesUpTo(
+  endsAt: Date,
+): Promise<LedgerEntryAccountingProjection[]> {
+  const rows: LedgerEntryAccountingProjection[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const page = await listLedgerEntryAccountingProjections({
+      limit: PAGE_SIZE,
+      offset,
+    });
+    if (page.length === 0) {
+      break;
+    }
+
+    rows.push(...page.filter((entry) => entry.earned_at <= endsAt));
+
+    if (page.length < PAGE_SIZE) {
+      break;
+    }
+
+    offset += PAGE_SIZE;
+  }
+
+  return rows;
+}
+
+async function loadAllSweepBatchesForPeriod(periodId: number) {
+  const rows: SweepBatchWithPeriod[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const page = await listSweepBatches({
+      accountingPeriodId: periodId,
+      limit: PAGE_SIZE,
+      offset,
+    });
+    if (page.length === 0) {
+      break;
+    }
+
+    rows.push(...page);
+
+    if (page.length < PAGE_SIZE) {
+      break;
+    }
+
+    offset += PAGE_SIZE;
+  }
+
+  return rows;
+}
+
+export async function loadTreasuryBatchTraceReport(
+  batchId: number,
+): Promise<TreasuryBatchTraceReport> {
+  const detail = await getSweepBatchDetail(batchId);
+  if (!detail) {
+    throw new Error('Sweep batch not found');
+  }
+
+  const claimEvent = await getTreasuryClaimEventByBatchId(batchId);
+
+  return buildTreasuryBatchTraceReport({
+    batch: detail.batch,
+    claimEvent,
+    partnerHandoff: detail.partnerHandoff,
+    entries: detail.entries,
+  });
+}
+
+export async function loadTreasuryAccountingPeriodClosePacket(
+  periodId: number,
+  reconciliationGate: ReconciliationGateService,
+): Promise<TreasuryAccountingPeriodClosePacket> {
+  const period = await getAccountingPeriodById(periodId);
+  if (!period) {
+    throw new Error('Accounting period not found');
+  }
+
+  const [entries, batches] = await Promise.all([
+    loadAllAccountingEntriesUpTo(period.ends_at),
+    loadAllSweepBatchesForPeriod(periodId),
+  ]);
+
+  const batchReports = await Promise.all(
+    batches.map((batch) => loadTreasuryBatchTraceReport(batch.id)),
+  );
+
+  const tradeIds = Array.from(
+    new Set(batchReports.flatMap((batch) => batch.entries.map((entry) => entry.trade_id))),
+  ).sort((a, b) => a.localeCompare(b));
+
+  const [reconciliationAssessments, reconciliationSummary] = await Promise.all([
+    reconciliationGate.assessTrades(tradeIds),
+    reconciliationGate.summarizeTrades(tradeIds),
+  ]);
+
+  const rollforward = buildTreasuryPeriodRollforwardReport({
+    period,
+    entries,
+    reconciliationAssessments,
+    batchReports,
+  });
+
+  const blockingIssues = dedupeIssues([
+    ...rollforward.blocking_issues,
+    ...(reconciliationSummary.status !== 'CLEAR'
+      ? [
+          {
+            code: `PERIOD_RECONCILIATION_${reconciliationSummary.status}`,
+            severity: 'BLOCKING',
+            owner: 'RECONCILIATION',
+            message:
+              reconciliationSummary.blockedReasons.join('; ') ||
+              'Accounting period is not reconciliation-clear',
+            trade_id: null,
+            sweep_batch_id: null,
+            ledger_entry_id: null,
+            details: {
+              reconciliationStatus: reconciliationSummary.status,
+              freshness: reconciliationSummary.freshness,
+              latestCompletedRunKey: reconciliationSummary.latestCompletedRunKey,
+            },
+          } satisfies TreasuryCloseIssue,
+        ]
+      : []),
+  ]);
+  const warningIssues = dedupeIssues([
+    ...rollforward.warning_issues,
+    ...batchReports.flatMap((batch) => batch.warning_issues),
+  ]);
+
+  return {
+    period,
+    generated_at: new Date().toISOString(),
+    ready_for_close: blockingIssues.length === 0,
+    rollforward,
+    reconciliation: {
+      status: reconciliationSummary.status,
+      freshness: reconciliationSummary.freshness,
+      latest_completed_run_key: reconciliationSummary.latestCompletedRunKey,
+      latest_completed_run_at: reconciliationSummary.latestCompletedRunAt
+        ? reconciliationSummary.latestCompletedRunAt.toISOString()
+        : null,
+      stale_running_run_count: reconciliationSummary.staleRunningRunCount,
+      blocked_reasons: reconciliationSummary.blockedReasons,
+    },
+    batches: batchReports,
+    blocking_issues: blockingIssues,
+    warning_issues: warningIssues,
+  };
+}
+
+export function renderTreasuryAccountingPeriodClosePacketMarkdown(
+  packet: TreasuryAccountingPeriodClosePacket,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# Treasury Close Packet: ${packet.period.period_key}`);
+  lines.push('');
+  lines.push(`- Generated at: ${packet.generated_at}`);
+  lines.push(`- Ready for close: ${packet.ready_for_close ? 'yes' : 'no'}`);
+  lines.push(`- Reconciliation status: ${packet.reconciliation.status}`);
+  lines.push(`- Reconciliation freshness: ${packet.reconciliation.freshness}`);
+  lines.push('');
+  lines.push('## Rollforward');
+  lines.push('');
+  lines.push(`- Opening held: ${packet.rollforward.opening_held_raw}`);
+  lines.push(`- New accruals: ${packet.rollforward.new_accruals_raw}`);
+  lines.push(`- Allocated to batches: ${packet.rollforward.allocated_to_batches_raw}`);
+  lines.push(`- Swept on-chain: ${packet.rollforward.swept_onchain_raw}`);
+  lines.push(`- Handed off externally: ${packet.rollforward.handed_off_raw}`);
+  lines.push(`- Realized: ${packet.rollforward.realized_raw}`);
+  lines.push(`- Ending held: ${packet.rollforward.ending_held_raw}`);
+  lines.push(`- Unresolved exceptions: ${packet.rollforward.unresolved_exception_raw}`);
+  lines.push('');
+  lines.push('## Blocking Issues');
+  lines.push('');
+
+  if (packet.blocking_issues.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const issue of packet.blocking_issues) {
+      lines.push(
+        `- [${issue.owner}] ${issue.code}: ${issue.message}${
+          issue.trade_id ? ` (trade ${issue.trade_id})` : ''
+        }${issue.sweep_batch_id ? ` (batch ${issue.sweep_batch_id})` : ''}${
+          issue.ledger_entry_id ? ` (entry ${issue.ledger_entry_id})` : ''
+        }`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push('## Warning Issues');
+  lines.push('');
+
+  if (packet.warning_issues.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const issue of packet.warning_issues) {
+      lines.push(
+        `- [${issue.owner}] ${issue.code}: ${issue.message}${
+          issue.trade_id ? ` (trade ${issue.trade_id})` : ''
+        }${issue.sweep_batch_id ? ` (batch ${issue.sweep_batch_id})` : ''}${
+          issue.ledger_entry_id ? ` (entry ${issue.ledger_entry_id})` : ''
+        }`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push('## Batches');
+  lines.push('');
+
+  if (packet.batches.length === 0) {
+    lines.push('- No sweep batches are linked to this accounting period.');
+  } else {
+    for (const batch of packet.batches) {
+      lines.push(
+        `- Batch ${batch.batch.batch_key} (${batch.batch.status}): expected ${batch.totals.expected_total_raw}, allocated ${batch.totals.allocated_total_raw}, entries ${batch.totals.entry_count}`,
+      );
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/treasury/src/core/closeReporting.ts
+++ b/treasury/src/core/closeReporting.ts
@@ -405,10 +405,29 @@ export async function loadTreasuryAccountingPeriodClosePacket(
     new Set(batchReports.flatMap((batch) => batch.entries.map((entry) => entry.trade_id))),
   ).sort((a, b) => a.localeCompare(b));
 
-  const [reconciliationAssessments, reconciliationSummary] = await Promise.all([
-    reconciliationGate.assessTrades(tradeIds),
-    reconciliationGate.summarizeTrades(tradeIds),
-  ]);
+  const [reconciliationAssessments, reconciliationSummary] =
+    tradeIds.length === 0
+      ? [
+          new Map<string, TradeReconciliationGate>(),
+          {
+            status: 'CLEAR' as const,
+            freshness: 'FRESH' as const,
+            latestCompletedRunKey: null,
+            latestCompletedRunAt: null,
+            latestCompletedRunAgeSeconds: null,
+            staleRunningRunCount: 0,
+            trackedTradeCount: 0,
+            clearTradeCount: 0,
+            blockedTradeCount: 0,
+            unknownTradeCount: 0,
+            driftBlockedTradeCount: 0,
+            blockedReasons: [],
+          },
+        ]
+      : await Promise.all([
+          reconciliationGate.assessTrades(tradeIds),
+          reconciliationGate.summarizeTrades(tradeIds),
+        ]);
 
   const rollforward = buildTreasuryPeriodRollforwardReport({
     period,

--- a/treasury/src/core/ingestion.ts
+++ b/treasury/src/core/ingestion.ts
@@ -4,6 +4,7 @@ import {
   getIngestionOffset,
   setIngestionOffset,
   upsertLedgerEntryWithInitialState,
+  upsertTreasuryClaimEvent,
 } from '../database/queries';
 import { Logger } from '../utils/logger';
 
@@ -11,11 +12,15 @@ function buildEntryKey(eventId: string, component: 'LOGISTICS' | 'PLATFORM_FEE')
   return `${eventId}:${component.toLowerCase()}`;
 }
 
+const TRADE_EVENT_CURSOR = 'trade_events';
+const CLAIM_EVENT_CURSOR = 'claim_events';
+
 export class TreasuryIngestionService {
   private readonly indexerClient = new IndexerClient(config.indexerGraphqlUrl);
 
   async ingestOnce(): Promise<{ fetched: number; inserted: number }> {
-    let offset = await getIngestionOffset();
+    let tradeOffset = await getIngestionOffset(TRADE_EVENT_CURSOR);
+    let claimOffset = await getIngestionOffset(CLAIM_EVENT_CURSOR);
     let fetched = 0;
     let inserted = 0;
 
@@ -23,7 +28,7 @@ export class TreasuryIngestionService {
       const remaining = config.ingestMaxEvents - fetched;
       const limit = Math.min(config.ingestBatchSize, remaining);
 
-      const events = await this.indexerClient.fetchTreasuryEvents(limit, offset);
+      const events = await this.indexerClient.fetchTreasuryEvents(limit, tradeOffset);
       if (events.length === 0) {
         break;
       }
@@ -84,15 +89,73 @@ export class TreasuryIngestionService {
         }
       }
 
-      offset += events.length;
+      tradeOffset += events.length;
       if (events.length < limit) {
         break;
       }
     }
 
-    await setIngestionOffset(offset);
+    const claimEventFetcher = (
+      this.indexerClient as unknown as {
+        fetchTreasuryClaimEvents?: (
+          limit: number,
+          offset: number,
+        ) => Promise<
+          Array<{
+            id: string;
+            txHash: string;
+            blockNumber: number;
+            timestamp: Date;
+            claimAmount: string;
+            treasuryIdentity: string;
+            payoutReceiver: string;
+            triggeredBy: string | null;
+          }>
+        >;
+      }
+    ).fetchTreasuryClaimEvents;
 
-    Logger.info('Treasury ingestion run completed', { fetched, inserted, nextOffset: offset });
+    if (claimEventFetcher) {
+      while (fetched < config.ingestMaxEvents) {
+        const remaining = config.ingestMaxEvents - fetched;
+        const limit = Math.min(config.ingestBatchSize, remaining);
+
+        const events = await claimEventFetcher.call(this.indexerClient, limit, claimOffset);
+        if (events.length === 0) {
+          break;
+        }
+
+        for (const event of events) {
+          fetched += 1;
+          await upsertTreasuryClaimEvent({
+            sourceEventId: event.id,
+            matchedSweepBatchId: null,
+            txHash: event.txHash,
+            blockNumber: event.blockNumber,
+            observedAt: event.timestamp,
+            treasuryIdentity: event.treasuryIdentity,
+            payoutReceiver: event.payoutReceiver,
+            amountRaw: event.claimAmount,
+            triggeredBy: event.triggeredBy,
+          });
+        }
+
+        claimOffset += events.length;
+        if (events.length < limit) {
+          break;
+        }
+      }
+    }
+
+    await setIngestionOffset(tradeOffset, TRADE_EVENT_CURSOR);
+    await setIngestionOffset(claimOffset, CLAIM_EVENT_CURSOR);
+
+    Logger.info('Treasury ingestion run completed', {
+      fetched,
+      inserted,
+      nextTradeOffset: tradeOffset,
+      nextClaimOffset: claimOffset,
+    });
 
     return { fetched, inserted };
   }

--- a/treasury/src/core/sweepExecutionMatcher.ts
+++ b/treasury/src/core/sweepExecutionMatcher.ts
@@ -2,6 +2,7 @@ import { config } from '../config';
 import {
   getSweepBatchDetail,
   getTreasuryClaimEventByBatchId,
+  getTreasuryClaimEventByTxHash,
   updateSweepBatchStatus,
   upsertTreasuryClaimEvent,
 } from '../database/queries';
@@ -41,8 +42,20 @@ export class SweepExecutionMatcherService {
       return detail.batch;
     }
 
-    const observedClaimEvent =
-      await this.indexerClient.fetchTreasuryClaimEventByTxHash(normalizedTxHash);
+    const persistedClaimEvent = await getTreasuryClaimEventByTxHash(normalizedTxHash);
+    const observedClaimEvent = persistedClaimEvent
+      ? {
+          id: persistedClaimEvent.source_event_id,
+          eventName: 'TreasuryClaimed' as const,
+          txHash: persistedClaimEvent.tx_hash,
+          blockNumber: persistedClaimEvent.block_number,
+          timestamp: persistedClaimEvent.observed_at,
+          claimAmount: persistedClaimEvent.amount_raw,
+          treasuryIdentity: persistedClaimEvent.treasury_identity,
+          payoutReceiver: persistedClaimEvent.payout_receiver,
+          triggeredBy: persistedClaimEvent.triggered_by,
+        }
+      : await this.indexerClient.fetchTreasuryClaimEventByTxHash(normalizedTxHash);
     if (!observedClaimEvent) {
       throw new Error('No authoritative TreasuryClaimed event was found for the supplied tx hash');
     }

--- a/treasury/src/database/queries.ts
+++ b/treasury/src/database/queries.ts
@@ -613,6 +613,19 @@ export async function getTreasuryClaimEventByBatchId(
   return result.rows[0] || null;
 }
 
+export async function getTreasuryClaimEventByTxHash(
+  txHash: string,
+): Promise<TreasuryClaimEvent | null> {
+  const result = await pool.query<TreasuryClaimEvent>(
+    `SELECT *
+     FROM treasury_claim_events
+     WHERE tx_hash = $1`,
+    [txHash],
+  );
+
+  return result.rows[0] || null;
+}
+
 export async function getSweepBatchDetail(batchId: number): Promise<SweepBatchDetail | null> {
   const batchResult = await pool.query<SweepBatchWithPeriod>(
     `SELECT
@@ -850,7 +863,7 @@ export async function listSweepBatchEntries(batchId: number): Promise<SweepBatch
 
 export async function upsertTreasuryClaimEvent(data: {
   sourceEventId: string;
-  matchedSweepBatchId: number;
+  matchedSweepBatchId?: number | null;
   txHash: string;
   blockNumber: number;
   observedAt: Date;
@@ -873,45 +886,68 @@ export async function upsertTreasuryClaimEvent(data: {
     );
 
     const existing = existingByTx.rows[0];
-    if (existing && existing.matched_sweep_batch_id !== data.matchedSweepBatchId) {
+    if (
+      existing &&
+      existing.matched_sweep_batch_id !== null &&
+      data.matchedSweepBatchId !== undefined &&
+      data.matchedSweepBatchId !== null &&
+      existing.matched_sweep_batch_id !== data.matchedSweepBatchId
+    ) {
       throw new Error('Treasury claim event is already matched to a different sweep batch');
     }
 
-    const result = await client.query<TreasuryClaimEvent>(
-      `INSERT INTO treasury_claim_events (
-          source_event_id,
-          matched_sweep_batch_id,
-          tx_hash,
-          block_number,
-          observed_at,
-          treasury_identity,
-          payout_receiver,
-          amount_raw,
-          triggered_by
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        ON CONFLICT (matched_sweep_batch_id)
-        DO UPDATE SET
-          source_event_id = EXCLUDED.source_event_id,
-          tx_hash = EXCLUDED.tx_hash,
-          block_number = EXCLUDED.block_number,
-          observed_at = EXCLUDED.observed_at,
-          treasury_identity = EXCLUDED.treasury_identity,
-          payout_receiver = EXCLUDED.payout_receiver,
-          amount_raw = EXCLUDED.amount_raw,
-          triggered_by = EXCLUDED.triggered_by
-        RETURNING *`,
-      [
-        data.sourceEventId,
-        data.matchedSweepBatchId,
-        data.txHash,
-        data.blockNumber,
-        data.observedAt,
-        data.treasuryIdentity,
-        data.payoutReceiver,
-        data.amountRaw,
-        data.triggeredBy ?? null,
-      ],
-    );
+    const result = existing
+      ? await client.query<TreasuryClaimEvent>(
+          `UPDATE treasury_claim_events
+           SET source_event_id = $2,
+               matched_sweep_batch_id = COALESCE($3, matched_sweep_batch_id),
+               tx_hash = $4,
+               block_number = $5,
+               observed_at = $6,
+               treasury_identity = $7,
+               payout_receiver = $8,
+               amount_raw = $9,
+               triggered_by = $10
+           WHERE id = $1
+           RETURNING *`,
+          [
+            existing.id,
+            data.sourceEventId,
+            data.matchedSweepBatchId ?? null,
+            data.txHash,
+            data.blockNumber,
+            data.observedAt,
+            data.treasuryIdentity,
+            data.payoutReceiver,
+            data.amountRaw,
+            data.triggeredBy ?? null,
+          ],
+        )
+      : await client.query<TreasuryClaimEvent>(
+          `INSERT INTO treasury_claim_events (
+              source_event_id,
+              matched_sweep_batch_id,
+              tx_hash,
+              block_number,
+              observed_at,
+              treasury_identity,
+              payout_receiver,
+              amount_raw,
+              triggered_by
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING *`,
+          [
+            data.sourceEventId,
+            data.matchedSweepBatchId ?? null,
+            data.txHash,
+            data.blockNumber,
+            data.observedAt,
+            data.treasuryIdentity,
+            data.payoutReceiver,
+            data.amountRaw,
+            data.triggeredBy ?? null,
+          ],
+        );
 
     await client.query('COMMIT');
     return result.rows[0];
@@ -1121,6 +1157,7 @@ export async function getLedgerEntryAccountingFacts(
         e.component_type,
         e.amount_raw,
         alloc.entry_amount_raw AS allocated_amount_raw,
+        alloc.created_at AS allocated_at,
         e.source_timestamp AS earned_at,
         payout.state AS payout_state,
         period.id AS accounting_period_id,
@@ -1139,9 +1176,19 @@ export async function getLedgerEntryAccountingFacts(
         handoff.partner_name,
         handoff.partner_reference,
         handoff.handoff_status AS partner_handoff_status,
+        handoff.submitted_at AS partner_submitted_at,
+        handoff.acknowledged_at AS partner_acknowledged_at,
         handoff.completed_at AS partner_completed_at,
+        handoff.failed_at AS partner_failed_at,
+        handoff.verified_at AS partner_verified_at,
+        deposit.ramp_reference AS latest_fiat_deposit_ramp_reference,
         deposit.deposit_state AS latest_fiat_deposit_state,
+        deposit.failure_class AS latest_fiat_deposit_failure_class,
+        deposit.observed_at AS latest_fiat_deposit_observed_at,
+        bank.bank_reference AS latest_bank_reference,
         bank.bank_state AS latest_bank_payout_state,
+        bank.failure_code AS latest_bank_failure_code,
+        bank.confirmed_at AS latest_bank_confirmed_at,
         realization.realization_status AS revenue_realization_status,
         realization.realized_at
       FROM treasury_ledger_entries e
@@ -1172,14 +1219,14 @@ export async function getLedgerEntryAccountingFacts(
         LIMIT 1
       ) realization ON TRUE
       LEFT JOIN LATERAL (
-        SELECT d.deposit_state
+        SELECT d.ramp_reference, d.deposit_state, d.failure_class, d.observed_at
         FROM fiat_deposit_references d
         WHERE d.ledger_entry_id = e.id
         ORDER BY d.observed_at DESC, d.id DESC
         LIMIT 1
       ) deposit ON TRUE
       LEFT JOIN LATERAL (
-        SELECT b.bank_state
+        SELECT b.bank_reference, b.bank_state, b.failure_code, b.confirmed_at
         FROM bank_payout_confirmations b
         WHERE b.ledger_entry_id = e.id
         ORDER BY b.confirmed_at DESC, b.id DESC
@@ -1228,6 +1275,7 @@ export async function listLedgerEntryAccountingProjections(filters?: {
         e.component_type,
         e.amount_raw,
         alloc.entry_amount_raw AS allocated_amount_raw,
+        alloc.created_at AS allocated_at,
         e.source_timestamp AS earned_at,
         payout.state AS payout_state,
         period.id AS accounting_period_id,
@@ -1246,9 +1294,19 @@ export async function listLedgerEntryAccountingProjections(filters?: {
         handoff.partner_name,
         handoff.partner_reference,
         handoff.handoff_status AS partner_handoff_status,
+        handoff.submitted_at AS partner_submitted_at,
+        handoff.acknowledged_at AS partner_acknowledged_at,
         handoff.completed_at AS partner_completed_at,
+        handoff.failed_at AS partner_failed_at,
+        handoff.verified_at AS partner_verified_at,
+        deposit.ramp_reference AS latest_fiat_deposit_ramp_reference,
         deposit.deposit_state AS latest_fiat_deposit_state,
+        deposit.failure_class AS latest_fiat_deposit_failure_class,
+        deposit.observed_at AS latest_fiat_deposit_observed_at,
+        bank.bank_reference AS latest_bank_reference,
         bank.bank_state AS latest_bank_payout_state,
+        bank.failure_code AS latest_bank_failure_code,
+        bank.confirmed_at AS latest_bank_confirmed_at,
         realization.realization_status AS revenue_realization_status,
         realization.realized_at
       FROM treasury_ledger_entries e
@@ -1279,14 +1337,14 @@ export async function listLedgerEntryAccountingProjections(filters?: {
         LIMIT 1
       ) realization ON TRUE
       LEFT JOIN LATERAL (
-        SELECT d.deposit_state
+        SELECT d.ramp_reference, d.deposit_state, d.failure_class, d.observed_at
         FROM fiat_deposit_references d
         WHERE d.ledger_entry_id = e.id
         ORDER BY d.observed_at DESC, d.id DESC
         LIMIT 1
       ) deposit ON TRUE
       LEFT JOIN LATERAL (
-        SELECT b.bank_state
+        SELECT b.bank_reference, b.bank_state, b.failure_code, b.confirmed_at
         FROM bank_payout_confirmations b
         WHERE b.ledger_entry_id = e.id
         ORDER BY b.confirmed_at DESC, b.id DESC

--- a/treasury/src/database/schema.sql
+++ b/treasury/src/database/schema.sql
@@ -245,7 +245,7 @@ CREATE TABLE IF NOT EXISTS revenue_realizations (
 CREATE TABLE IF NOT EXISTS treasury_claim_events (
     id SERIAL PRIMARY KEY,
     source_event_id VARCHAR(255) NOT NULL UNIQUE,
-    matched_sweep_batch_id INT NOT NULL UNIQUE REFERENCES sweep_batches(id) ON DELETE CASCADE,
+    matched_sweep_batch_id INT UNIQUE REFERENCES sweep_batches(id) ON DELETE CASCADE,
     tx_hash VARCHAR(66) NOT NULL UNIQUE,
     block_number INT NOT NULL,
     observed_at TIMESTAMP NOT NULL,
@@ -259,8 +259,15 @@ CREATE TABLE IF NOT EXISTS treasury_claim_events (
 ALTER TABLE sweep_batches
     ADD COLUMN IF NOT EXISTS closed_at TIMESTAMP,
     ADD COLUMN IF NOT EXISTS closed_by VARCHAR(255);
+
+ALTER TABLE treasury_claim_events
+    ALTER COLUMN matched_sweep_batch_id DROP NOT NULL;
 INSERT INTO treasury_ingestion_state (cursor_name, next_offset)
 VALUES ('trade_events', 0)
+ON CONFLICT (cursor_name) DO NOTHING;
+
+INSERT INTO treasury_ingestion_state (cursor_name, next_offset)
+VALUES ('claim_events', 0)
 ON CONFLICT (cursor_name) DO NOTHING;
 
 CREATE INDEX IF NOT EXISTS idx_treasury_ledger_trade_id ON treasury_ledger_entries(trade_id);

--- a/treasury/src/indexer/client.ts
+++ b/treasury/src/indexer/client.ts
@@ -172,4 +172,72 @@ export class IndexerClient {
       triggeredBy: event.triggeredBy ? event.triggeredBy.toLowerCase() : null,
     };
   }
+
+  async fetchTreasuryClaimEvents(
+    limit: number,
+    offset: number,
+  ): Promise<IndexerTreasuryClaimEvent[]> {
+    const query = `
+      query TreasuryClaimEvents($limit: Int!, $offset: Int!) {
+        systemEvents(
+          where: { eventName_eq: "TreasuryClaimed" }
+          orderBy: blockNumber_ASC
+          limit: $limit
+          offset: $offset
+        ) {
+          id
+          eventName
+          txHash
+          blockNumber
+          timestamp
+          claimAmount
+          treasuryIdentity
+          payoutReceiver
+          triggeredBy
+        }
+      }
+    `;
+
+    const response = await fetchWithTimeout(
+      this.graphqlUrl,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query,
+          variables: { limit, offset },
+        }),
+      },
+      config.indexerGraphqlRequestTimeoutMs,
+    );
+
+    if (!response.ok) {
+      throw new Error(`Indexer GraphQL request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const body = (await response.json()) as GraphQlResponse;
+
+    if (body.errors?.length) {
+      throw new Error(
+        `Indexer GraphQL errors: ${body.errors.map((item) => item.message).join('; ')}`,
+      );
+    }
+
+    const events = body.data?.systemEvents || [];
+    return events
+      .filter((event) => event.claimAmount && event.treasuryIdentity && event.payoutReceiver)
+      .map((event) => ({
+        id: event.id,
+        eventName: event.eventName,
+        txHash: event.txHash,
+        blockNumber: Number(event.blockNumber),
+        timestamp: new Date(event.timestamp),
+        claimAmount: event.claimAmount as string,
+        treasuryIdentity: (event.treasuryIdentity as string).toLowerCase(),
+        payoutReceiver: (event.payoutReceiver as string).toLowerCase(),
+        triggeredBy: event.triggeredBy ? event.triggeredBy.toLowerCase() : null,
+      }));
+  }
 }

--- a/treasury/src/types.ts
+++ b/treasury/src/types.ts
@@ -161,7 +161,7 @@ export interface RevenueRealization {
 export interface TreasuryClaimEvent {
   id: number;
   source_event_id: string;
-  matched_sweep_batch_id: number;
+  matched_sweep_batch_id: number | null;
   tx_hash: string;
   block_number: number;
   observed_at: Date;
@@ -202,6 +202,7 @@ export interface LedgerEntryAccountingFacts {
   component_type: TreasuryComponent;
   amount_raw: string;
   allocated_amount_raw: string | null;
+  allocated_at?: Date | null;
   earned_at: Date;
   payout_state: PayoutState | null;
   accounting_period_id: number | null;
@@ -220,9 +221,19 @@ export interface LedgerEntryAccountingFacts {
   partner_name: string | null;
   partner_reference: string | null;
   partner_handoff_status: PartnerHandoffStatus | null;
+  partner_submitted_at?: Date | null;
+  partner_acknowledged_at?: Date | null;
   partner_completed_at: Date | null;
+  partner_failed_at?: Date | null;
+  partner_verified_at?: Date | null;
+  latest_fiat_deposit_ramp_reference?: string | null;
   latest_fiat_deposit_state: FiatDepositState | null;
+  latest_fiat_deposit_failure_class?: FiatDepositFailureClass | null;
+  latest_fiat_deposit_observed_at?: Date | null;
+  latest_bank_reference?: string | null;
   latest_bank_payout_state: BankPayoutState | null;
+  latest_bank_failure_code?: string | null;
+  latest_bank_confirmed_at?: Date | null;
   revenue_realization_status: RevenueRealizationStatus | null;
   realized_at: Date | null;
 }
@@ -275,6 +286,89 @@ export interface FiatDepositReference {
   metadata: Record<string, unknown>;
   created_at: Date;
   updated_at: Date;
+}
+
+export type TreasuryCloseIssueSeverity = 'BLOCKING' | 'WARNING';
+export type TreasuryCloseIssueOwner = 'TREASURY' | 'FINANCE' | 'RECONCILIATION' | 'OPS';
+
+export interface TreasuryCloseIssue {
+  code: string;
+  severity: TreasuryCloseIssueSeverity;
+  owner: TreasuryCloseIssueOwner;
+  message: string;
+  trade_id: string | null;
+  sweep_batch_id: number | null;
+  ledger_entry_id: number | null;
+  details: Record<string, unknown>;
+}
+
+export interface TreasuryPeriodRollforwardReport {
+  period: AccountingPeriod;
+  generated_at: string;
+  opening_held_raw: string;
+  new_accruals_raw: string;
+  allocated_to_batches_raw: string;
+  swept_onchain_raw: string;
+  handed_off_raw: string;
+  realized_raw: string;
+  ending_held_raw: string;
+  unresolved_exception_raw: string;
+  blocking_issue_count: number;
+  warning_issue_count: number;
+  blocking_issues: TreasuryCloseIssue[];
+  warning_issues: TreasuryCloseIssue[];
+}
+
+export interface TreasuryBatchTraceEntry {
+  ledger_entry_id: number;
+  trade_id: string;
+  component_type: TreasuryComponent;
+  source_amount_raw: string;
+  allocated_amount_raw: string | null;
+  earned_at: string;
+  accounting_state: TreasuryAccountingState;
+  accounting_state_reason: string;
+  matched_sweep_tx_hash: string | null;
+  matched_swept_at: string | null;
+  partner_reference: string | null;
+  partner_handoff_status: PartnerHandoffStatus | null;
+  latest_bank_reference: string | null;
+  latest_bank_payout_state: BankPayoutState | null;
+  latest_bank_confirmed_at: string | null;
+  revenue_realization_status: RevenueRealizationStatus | null;
+  realized_at: string | null;
+}
+
+export interface TreasuryBatchTraceReport {
+  batch: SweepBatchWithPeriod;
+  claim_event: TreasuryClaimEvent | null;
+  partner_handoff: PartnerHandoff | null;
+  totals: {
+    expected_total_raw: string;
+    allocated_total_raw: string;
+    entry_count: number;
+  };
+  entries: TreasuryBatchTraceEntry[];
+  blocking_issues: TreasuryCloseIssue[];
+  warning_issues: TreasuryCloseIssue[];
+}
+
+export interface TreasuryAccountingPeriodClosePacket {
+  period: AccountingPeriod;
+  generated_at: string;
+  ready_for_close: boolean;
+  rollforward: TreasuryPeriodRollforwardReport;
+  reconciliation: {
+    status: 'CLEAR' | 'BLOCKED' | 'STALE' | 'MISSING' | 'UNKNOWN';
+    freshness: 'FRESH' | 'STALE' | 'MISSING';
+    latest_completed_run_key: string | null;
+    latest_completed_run_at: string | null;
+    stale_running_run_count: number;
+    blocked_reasons: string[];
+  };
+  batches: TreasuryBatchTraceReport[];
+  blocking_issues: TreasuryCloseIssue[];
+  warning_issues: TreasuryCloseIssue[];
 }
 
 export interface FiatDepositEvent {

--- a/treasury/tests/closeReporting.test.ts
+++ b/treasury/tests/closeReporting.test.ts
@@ -1,0 +1,469 @@
+process.env.PORT = process.env.PORT || '3200';
+process.env.DB_HOST = process.env.DB_HOST || '127.0.0.1';
+process.env.DB_PORT = process.env.DB_PORT || '5432';
+process.env.DB_NAME = process.env.DB_NAME || 'treasury_test';
+process.env.DB_USER = process.env.DB_USER || 'postgres';
+process.env.DB_PASSWORD = process.env.DB_PASSWORD || 'postgres';
+process.env.INDEXER_GRAPHQL_URL =
+  process.env.INDEXER_GRAPHQL_URL || 'http://127.0.0.1:3100/graphql';
+
+jest.mock('../src/database/queries', () => ({
+  getAccountingPeriodById: jest.fn(),
+  getSweepBatchDetail: jest.fn(),
+  getTreasuryClaimEventByBatchId: jest.fn(),
+  listLedgerEntryAccountingProjections: jest.fn(),
+  listSweepBatches: jest.fn(),
+}));
+
+import {
+  buildTreasuryBatchTraceReport,
+  buildTreasuryPeriodRollforwardReport,
+  loadTreasuryAccountingPeriodClosePacket,
+} from '../src/core/closeReporting';
+import * as queries from '../src/database/queries';
+import {
+  AccountingPeriod,
+  LedgerEntryAccountingProjection,
+  SweepBatchWithPeriod,
+  TreasuryClaimEvent,
+} from '../src/types';
+
+function makePeriod(overrides: Partial<AccountingPeriod> = {}): AccountingPeriod {
+  return {
+    id: 7,
+    period_key: '2026-Q1',
+    starts_at: new Date('2026-01-01T00:00:00.000Z'),
+    ends_at: new Date('2026-03-31T23:59:59.000Z'),
+    status: 'PENDING_CLOSE',
+    created_by: 'user:treasury-preparer',
+    close_reason: null,
+    pending_close_at: new Date('2026-03-31T22:00:00.000Z'),
+    closed_at: null,
+    closed_by: null,
+    metadata: {},
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date('2026-03-31T22:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  overrides: Partial<LedgerEntryAccountingProjection> = {},
+): LedgerEntryAccountingProjection {
+  return {
+    ledger_entry_id: 501,
+    trade_id: 'trade-501',
+    component_type: 'PLATFORM_FEE',
+    amount_raw: '100',
+    allocated_amount_raw: null,
+    allocated_at: null,
+    earned_at: new Date('2026-03-15T10:00:00.000Z'),
+    payout_state: 'PENDING_REVIEW',
+    accounting_period_id: 7,
+    accounting_period_key: '2026-Q1',
+    accounting_period_status: 'PENDING_CLOSE',
+    sweep_batch_id: null,
+    sweep_batch_status: null,
+    allocation_status: null,
+    matched_sweep_tx_hash: null,
+    matched_sweep_block_number: null,
+    matched_swept_at: null,
+    matched_treasury_identity: null,
+    matched_payout_receiver: null,
+    matched_claim_amount_raw: null,
+    partner_handoff_id: null,
+    partner_name: null,
+    partner_reference: null,
+    partner_handoff_status: null,
+    partner_submitted_at: null,
+    partner_acknowledged_at: null,
+    partner_completed_at: null,
+    partner_failed_at: null,
+    partner_verified_at: null,
+    latest_fiat_deposit_ramp_reference: null,
+    latest_fiat_deposit_state: null,
+    latest_fiat_deposit_failure_class: null,
+    latest_fiat_deposit_observed_at: null,
+    latest_bank_reference: null,
+    latest_bank_payout_state: null,
+    latest_bank_failure_code: null,
+    latest_bank_confirmed_at: null,
+    revenue_realization_status: null,
+    realized_at: null,
+    accounting_state: 'HELD',
+    accounting_state_reason: 'Fee is earned and still held in treasury',
+    ...overrides,
+  };
+}
+
+function makeBatch(overrides: Partial<SweepBatchWithPeriod> = {}): SweepBatchWithPeriod {
+  return {
+    id: 11,
+    batch_key: 'batch-q1-001',
+    accounting_period_id: 7,
+    accounting_period_key: '2026-Q1',
+    accounting_period_status: 'PENDING_CLOSE',
+    asset_symbol: 'USDC',
+    status: 'CLOSED',
+    expected_total_raw: '100',
+    payout_receiver_address: '0xpayout',
+    approval_requested_at: new Date('2026-03-20T12:00:00.000Z'),
+    approval_requested_by: 'user:treasury-preparer',
+    approved_at: new Date('2026-03-21T12:00:00.000Z'),
+    approved_by: 'user:treasury-approver',
+    matched_sweep_tx_hash: '0xclaim',
+    matched_sweep_block_number: '101',
+    matched_swept_at: new Date('2026-03-22T12:00:00.000Z'),
+    executed_by: 'user:treasury-executor',
+    closed_at: new Date('2026-03-23T12:00:00.000Z'),
+    closed_by: 'user:treasury-closer',
+    created_by: 'user:treasury-preparer',
+    metadata: {},
+    created_at: new Date('2026-03-20T10:00:00.000Z'),
+    updated_at: new Date('2026-03-23T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeClaim(overrides: Partial<TreasuryClaimEvent> = {}): TreasuryClaimEvent {
+  return {
+    id: 9,
+    source_event_id: 'claim-9',
+    matched_sweep_batch_id: 11,
+    tx_hash: '0xclaim',
+    block_number: 101,
+    observed_at: new Date('2026-03-22T12:00:00.000Z'),
+    treasury_identity: '0xtreasury',
+    payout_receiver: '0xpayout',
+    amount_raw: '100',
+    triggered_by: '0xoperator',
+    created_at: new Date('2026-03-22T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('treasury close reporting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('period rollforward math is derived deterministically from persisted accounting facts', () => {
+    const period = makePeriod();
+    const entries = [
+      makeEntry({
+        ledger_entry_id: 1,
+        trade_id: 'trade-opening',
+        amount_raw: '70',
+        earned_at: new Date('2025-12-20T10:00:00.000Z'),
+        accounting_state: 'HELD',
+      }),
+      makeEntry({
+        ledger_entry_id: 2,
+        trade_id: 'trade-swept',
+        amount_raw: '100',
+        allocated_amount_raw: '100',
+        allocated_at: new Date('2026-03-20T10:00:00.000Z'),
+        matched_swept_at: new Date('2026-03-22T10:00:00.000Z'),
+        matched_claim_amount_raw: '100',
+        accounting_state: 'SWEPT',
+        accounting_state_reason: 'Matched on-chain treasury claim recorded',
+      }),
+      makeEntry({
+        ledger_entry_id: 3,
+        trade_id: 'trade-realized',
+        amount_raw: '50',
+        allocated_amount_raw: '50',
+        allocated_at: new Date('2026-03-20T11:00:00.000Z'),
+        matched_swept_at: new Date('2026-03-21T11:00:00.000Z'),
+        matched_claim_amount_raw: '50',
+        partner_submitted_at: new Date('2026-03-24T09:00:00.000Z'),
+        partner_reference: 'handoff-3',
+        partner_handoff_status: 'COMPLETED',
+        latest_bank_reference: 'bank-3',
+        latest_bank_payout_state: 'CONFIRMED',
+        latest_bank_confirmed_at: new Date('2026-03-26T09:00:00.000Z'),
+        revenue_realization_status: 'REALIZED',
+        realized_at: new Date('2026-03-27T09:00:00.000Z'),
+        accounting_state: 'REALIZED',
+        accounting_state_reason: 'Controlled revenue realization recorded',
+      }),
+      makeEntry({
+        ledger_entry_id: 4,
+        trade_id: 'trade-exception',
+        amount_raw: '20',
+        accounting_state: 'EXCEPTION',
+        accounting_state_reason: 'External handoff reported failure',
+      }),
+    ];
+
+    const report = buildTreasuryPeriodRollforwardReport({
+      period,
+      entries,
+      reconciliationAssessments: new Map([
+        [
+          'trade-opening',
+          {
+            tradeId: 'trade-opening',
+            status: 'CLEAR',
+            freshness: 'FRESH',
+            runKey: 'run-1',
+            completedAt: new Date('2026-03-31T23:00:00.000Z'),
+            staleRunningRunCount: 0,
+            blockedReasons: [],
+            driftCount: 0,
+          },
+        ],
+      ]),
+      batchReports: [],
+      generatedAt: new Date('2026-03-31T23:59:59.000Z'),
+    });
+
+    expect(report.opening_held_raw).toBe('70');
+    expect(report.new_accruals_raw).toBe('170');
+    expect(report.allocated_to_batches_raw).toBe('150');
+    expect(report.swept_onchain_raw).toBe('150');
+    expect(report.handed_off_raw).toBe('50');
+    expect(report.realized_raw).toBe('50');
+    expect(report.ending_held_raw).toBe('90');
+    expect(report.unresolved_exception_raw).toBe('20');
+    expect(report.blocking_issues.map((issue) => issue.code)).toContain('ENTRY_EXCEPTION_STATE');
+  });
+
+  test('batch trace report includes on-chain claim and external handoff linkage', () => {
+    const report = buildTreasuryBatchTraceReport({
+      batch: makeBatch(),
+      claimEvent: makeClaim(),
+      partnerHandoff: {
+        id: 33,
+        sweep_batch_id: 11,
+        partner_name: 'licensed-counterparty',
+        partner_reference: 'handoff-33',
+        handoff_status: 'ACKNOWLEDGED',
+        latest_payload_hash: 'payload-hash',
+        evidence_reference: 'evidence://handoff-33',
+        submitted_at: new Date('2026-03-24T09:00:00.000Z'),
+        acknowledged_at: new Date('2026-03-24T10:00:00.000Z'),
+        completed_at: null,
+        failed_at: null,
+        verified_at: null,
+        metadata: {},
+        created_at: new Date('2026-03-24T09:00:00.000Z'),
+        updated_at: new Date('2026-03-24T10:00:00.000Z'),
+      },
+      entries: [
+        makeEntry({
+          ledger_entry_id: 2,
+          trade_id: 'trade-swept',
+          amount_raw: '100',
+          allocated_amount_raw: '90',
+          matched_sweep_tx_hash: '0xclaim',
+          matched_swept_at: new Date('2026-03-22T10:00:00.000Z'),
+          partner_reference: 'handoff-33',
+          partner_handoff_status: 'ACKNOWLEDGED',
+          latest_bank_reference: 'bank-2',
+          latest_bank_payout_state: 'PENDING',
+          accounting_state: 'HANDED_OFF',
+          accounting_state_reason: 'External handoff acknowledged by execution counterparty',
+        }),
+      ],
+    });
+
+    expect(report.claim_event?.tx_hash).toBe('0xclaim');
+    expect(report.partner_handoff?.partner_reference).toBe('handoff-33');
+    expect(report.entries[0]).toEqual(
+      expect.objectContaining({
+        trade_id: 'trade-swept',
+        matched_sweep_tx_hash: '0xclaim',
+        partner_reference: 'handoff-33',
+        latest_bank_reference: 'bank-2',
+      }),
+    );
+    expect(report.warning_issues.map((issue) => issue.code)).toContain(
+      'ALLOCATED_AMOUNT_DIFFERS_FROM_SOURCE',
+    );
+  });
+
+  test('close packet flags unresolved blocking issues and refuses close readiness', async () => {
+    jest.mocked(queries.getAccountingPeriodById).mockResolvedValue(makePeriod());
+    jest.mocked(queries.listLedgerEntryAccountingProjections).mockResolvedValue([
+      makeEntry({
+        ledger_entry_id: 2,
+        trade_id: 'trade-501',
+        amount_raw: '100',
+        allocated_amount_raw: '100',
+        allocated_at: new Date('2026-03-20T10:00:00.000Z'),
+        sweep_batch_id: 11,
+        sweep_batch_status: 'EXECUTED',
+        allocation_status: 'ALLOCATED',
+        matched_sweep_tx_hash: null,
+        matched_swept_at: null,
+        accounting_state: 'ALLOCATED_TO_SWEEP',
+        accounting_state_reason: 'Ledger entry is allocated to a sweep batch',
+      }),
+    ]);
+    jest.mocked(queries.listSweepBatches).mockResolvedValue([makeBatch({ status: 'EXECUTED' })]);
+    jest.mocked(queries.getSweepBatchDetail).mockResolvedValue({
+      batch: makeBatch({ status: 'EXECUTED' }),
+      entries: [
+        makeEntry({
+          ledger_entry_id: 2,
+          trade_id: 'trade-501',
+          amount_raw: '100',
+          allocated_amount_raw: '100',
+          allocated_at: new Date('2026-03-20T10:00:00.000Z'),
+          sweep_batch_id: 11,
+          sweep_batch_status: 'EXECUTED',
+          allocation_status: 'ALLOCATED',
+          accounting_state: 'ALLOCATED_TO_SWEEP',
+          accounting_state_reason: 'Ledger entry is allocated to a sweep batch',
+        }),
+      ],
+      partnerHandoff: null,
+      totals: {
+        allocatedAmountRaw: '100',
+        entryCount: 1,
+      },
+    });
+    jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+
+    const reconciliationGate = {
+      assessTrades: jest.fn().mockResolvedValue(
+        new Map([
+          [
+            'trade-501',
+            {
+              tradeId: 'trade-501',
+              status: 'CLEAR',
+              freshness: 'FRESH',
+              runKey: 'run-1',
+              completedAt: new Date('2026-03-31T22:00:00.000Z'),
+              staleRunningRunCount: 0,
+              blockedReasons: [],
+              driftCount: 0,
+            },
+          ],
+        ]),
+      ),
+      summarizeTrades: jest.fn().mockResolvedValue({
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latestCompletedRunKey: 'run-1',
+        latestCompletedRunAt: new Date('2026-03-31T22:00:00.000Z'),
+        latestCompletedRunAgeSeconds: 60,
+        staleRunningRunCount: 0,
+        trackedTradeCount: 1,
+        clearTradeCount: 1,
+        blockedTradeCount: 0,
+        unknownTradeCount: 0,
+        driftBlockedTradeCount: 0,
+        blockedReasons: [],
+      }),
+    };
+
+    const packet = await loadTreasuryAccountingPeriodClosePacket(7, reconciliationGate as never);
+
+    expect(packet.ready_for_close).toBe(false);
+    expect(packet.blocking_issues.map((issue) => issue.code)).toContain('SWEEP_TX_UNMATCHED');
+  });
+
+  test('close packet paginates all sweep batches for the period before deciding close readiness', async () => {
+    jest.mocked(queries.getAccountingPeriodById).mockResolvedValue(makePeriod());
+    jest.mocked(queries.listLedgerEntryAccountingProjections).mockResolvedValue([]);
+
+    const firstPage = Array.from({ length: 500 }, (_, index) =>
+      makeBatch({
+        id: index + 1,
+        batch_key: `batch-${index + 1}`,
+        status: 'CLOSED',
+      }),
+    );
+    const blockingBatch = makeBatch({
+      id: 501,
+      batch_key: 'batch-501',
+      status: 'EXECUTED',
+    });
+
+    jest
+      .mocked(queries.listSweepBatches)
+      .mockImplementation(async ({ offset = 0 }) =>
+        offset === 0 ? firstPage : offset === 500 ? [blockingBatch] : [],
+      );
+    jest.mocked(queries.getSweepBatchDetail).mockImplementation(async (batchId: number) => ({
+      batch: batchId === 501 ? blockingBatch : firstPage[batchId - 1],
+      entries: [],
+      partnerHandoff: null,
+      totals: {
+        allocatedAmountRaw: '0',
+        entryCount: 0,
+      },
+    }));
+    jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+
+    const reconciliationGate = {
+      assessTrades: jest.fn().mockResolvedValue(new Map()),
+      summarizeTrades: jest.fn().mockResolvedValue({
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latestCompletedRunKey: 'run-1',
+        latestCompletedRunAt: new Date('2026-03-31T22:00:00.000Z'),
+        latestCompletedRunAgeSeconds: 60,
+        staleRunningRunCount: 0,
+        trackedTradeCount: 0,
+        clearTradeCount: 0,
+        blockedTradeCount: 0,
+        unknownTradeCount: 0,
+        driftBlockedTradeCount: 0,
+        blockedReasons: [],
+      }),
+    };
+
+    const packet = await loadTreasuryAccountingPeriodClosePacket(7, reconciliationGate as never);
+
+    expect(queries.listSweepBatches).toHaveBeenCalledTimes(2);
+    expect(packet.ready_for_close).toBe(false);
+    expect(packet.blocking_issues.map((issue) => issue.code)).toContain('SWEEP_TX_UNMATCHED');
+    expect(packet.batches).toHaveLength(501);
+  });
+
+  test('warning-only close issues surface without blocking close readiness', async () => {
+    jest.mocked(queries.getAccountingPeriodById).mockResolvedValue(makePeriod());
+    jest.mocked(queries.listLedgerEntryAccountingProjections).mockResolvedValue([
+      makeEntry({
+        ledger_entry_id: 9,
+        trade_id: 'trade-warning',
+        amount_raw: '100',
+        allocated_amount_raw: '90',
+        allocated_at: new Date('2026-03-20T10:00:00.000Z'),
+        accounting_state: 'ALLOCATED_TO_SWEEP',
+        accounting_state_reason: 'Ledger entry is allocated to a sweep batch',
+      }),
+    ]);
+    jest.mocked(queries.listSweepBatches).mockResolvedValue([]);
+
+    const reconciliationGate = {
+      assessTrades: jest.fn().mockResolvedValue(new Map()),
+      summarizeTrades: jest.fn().mockResolvedValue({
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latestCompletedRunKey: 'run-1',
+        latestCompletedRunAt: new Date('2026-03-31T22:00:00.000Z'),
+        latestCompletedRunAgeSeconds: 60,
+        staleRunningRunCount: 0,
+        trackedTradeCount: 0,
+        clearTradeCount: 0,
+        blockedTradeCount: 0,
+        unknownTradeCount: 0,
+        driftBlockedTradeCount: 0,
+        blockedReasons: [],
+      }),
+    };
+
+    const packet = await loadTreasuryAccountingPeriodClosePacket(7, reconciliationGate as never);
+
+    expect(packet.ready_for_close).toBe(true);
+    expect(packet.blocking_issues).toHaveLength(0);
+    expect(packet.warning_issues.map((issue) => issue.code)).toContain(
+      'ALLOCATED_AMOUNT_DIFFERS_FROM_SOURCE',
+    );
+  });
+});

--- a/treasury/tests/closeReporting.test.ts
+++ b/treasury/tests/closeReporting.test.ts
@@ -466,4 +466,23 @@ describe('treasury close reporting', () => {
       'ALLOCATED_AMOUNT_DIFFERS_FROM_SOURCE',
     );
   });
+
+  test('close packet treats empty trade coverage as reconciliation-clear for no-activity periods', async () => {
+    jest.mocked(queries.getAccountingPeriodById).mockResolvedValue(makePeriod());
+    jest.mocked(queries.listLedgerEntryAccountingProjections).mockResolvedValue([]);
+    jest.mocked(queries.listSweepBatches).mockResolvedValue([]);
+
+    const reconciliationGate = {
+      assessTrades: jest.fn(),
+      summarizeTrades: jest.fn(),
+    };
+
+    const packet = await loadTreasuryAccountingPeriodClosePacket(7, reconciliationGate as never);
+
+    expect(packet.ready_for_close).toBe(true);
+    expect(packet.reconciliation.status).toBe('CLEAR');
+    expect(packet.reconciliation.freshness).toBe('FRESH');
+    expect(reconciliationGate.assessTrades).not.toHaveBeenCalled();
+    expect(reconciliationGate.summarizeTrades).not.toHaveBeenCalled();
+  });
 });

--- a/treasury/tests/controller.accountingControls.test.ts
+++ b/treasury/tests/controller.accountingControls.test.ts
@@ -11,16 +11,19 @@ process.env.INDEXER_GRAPHQL_URL =
 
 jest.mock('../src/database/queries', () => ({
   ...jest.requireActual('../src/database/queries'),
-  getSweepBatchDetail: jest.fn(),
   listLedgerEntryAccountingProjections: jest.fn(),
-  listSweepBatches: jest.fn(),
   updateAccountingPeriodStatus: jest.fn(),
 }));
 
+jest.mock('../src/core/closeReporting', () => ({
+  loadTreasuryAccountingPeriodClosePacket: jest.fn(),
+  loadTreasuryBatchTraceReport: jest.fn(),
+  renderTreasuryAccountingPeriodClosePacketMarkdown: jest.fn().mockReturnValue('# close packet'),
+}));
+
 type TreasuryControllerType = typeof import('../src/api/controller').TreasuryController;
-type ReconciliationGateServiceType =
-  typeof import('../src/core/reconciliationGate').ReconciliationGateService;
 type QueriesModule = typeof import('../src/database/queries');
+type CloseReportingModule = typeof import('../src/core/closeReporting');
 
 type MockResponse = Response & {
   status: jest.MockedFunction<(code: number) => MockResponse>;
@@ -48,8 +51,8 @@ type CloseAccountingPeriodRequest = Request<
 >;
 
 let LoadedTreasuryController: TreasuryControllerType;
-let LoadedReconciliationGateService: ReconciliationGateServiceType;
 let queriesModule: QueriesModule;
+let closeReportingModule: CloseReportingModule;
 
 function mockResponse(): MockResponse {
   const response = {} as MockResponse;
@@ -62,9 +65,8 @@ describe('TreasuryController accounting controls', () => {
   beforeEach(async () => {
     jest.resetModules();
     ({ TreasuryController: LoadedTreasuryController } = await import('../src/api/controller'));
-    ({ ReconciliationGateService: LoadedReconciliationGateService } =
-      await import('../src/core/reconciliationGate'));
     queriesModule = await import('../src/database/queries');
+    closeReportingModule = await import('../src/core/closeReporting');
     jest.clearAllMocks();
   });
 
@@ -128,128 +130,76 @@ describe('TreasuryController accounting controls', () => {
   });
 
   test('closeAccountingPeriod fails closed when reconciliation is not clear for batch trades', async () => {
-    jest.mocked(queriesModule.listSweepBatches).mockResolvedValue([
-      {
-        id: 11,
-        batch_key: 'batch-q1-001',
-        accounting_period_id: 7,
-        accounting_period_key: '2026-Q1',
-        accounting_period_status: 'OPEN',
-        asset_symbol: 'USDC',
-        status: 'CLOSED',
-        expected_total_raw: '125000000',
-        payout_receiver_address: null,
-        approval_requested_at: null,
-        approval_requested_by: null,
-        approved_at: null,
-        approved_by: null,
-        matched_sweep_tx_hash: '0xsweep-1',
-        matched_sweep_block_number: '101',
-        matched_swept_at: new Date('2026-03-31T12:00:00.000Z'),
-        executed_by: 'user:uid-admin',
-        closed_at: new Date('2026-03-31T13:00:00.000Z'),
-        closed_by: 'user:uid-close',
+    jest.mocked(closeReportingModule.loadTreasuryAccountingPeriodClosePacket).mockResolvedValue({
+      period: {
+        id: 7,
+        period_key: '2026-Q1',
+        starts_at: new Date('2026-01-01T00:00:00.000Z'),
+        ends_at: new Date('2026-03-31T23:59:59.000Z'),
+        status: 'PENDING_CLOSE',
         created_by: 'user:uid-admin',
+        close_reason: null,
+        pending_close_at: null,
+        closed_at: null,
+        closed_by: null,
         metadata: {},
-        created_at: new Date('2026-03-31T11:00:00.000Z'),
-        updated_at: new Date('2026-03-31T12:00:00.000Z'),
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-03-31T23:00:00.000Z'),
       },
-    ]);
-    jest.mocked(queriesModule.getSweepBatchDetail).mockResolvedValue({
-      batch: {
-        id: 11,
-        batch_key: 'batch-q1-001',
-        accounting_period_id: 7,
-        accounting_period_key: '2026-Q1',
-        accounting_period_status: 'OPEN',
-        asset_symbol: 'USDC',
-        status: 'CLOSED',
-        expected_total_raw: '125000000',
-        payout_receiver_address: null,
-        approval_requested_at: null,
-        approval_requested_by: null,
-        approved_at: null,
-        approved_by: null,
-        matched_sweep_tx_hash: '0xsweep-1',
-        matched_sweep_block_number: '101',
-        matched_swept_at: new Date('2026-03-31T12:00:00.000Z'),
-        executed_by: 'user:uid-admin',
-        closed_at: new Date('2026-03-31T13:00:00.000Z'),
-        closed_by: 'user:uid-close',
-        created_by: 'user:uid-admin',
-        metadata: {},
-        created_at: new Date('2026-03-31T11:00:00.000Z'),
-        updated_at: new Date('2026-03-31T12:00:00.000Z'),
+      generated_at: '2026-03-31T23:30:00.000Z',
+      ready_for_close: false,
+      rollforward: {
+        period: {
+          id: 7,
+          period_key: '2026-Q1',
+          starts_at: new Date('2026-01-01T00:00:00.000Z'),
+          ends_at: new Date('2026-03-31T23:59:59.000Z'),
+          status: 'PENDING_CLOSE',
+          created_by: 'user:uid-admin',
+          close_reason: null,
+          pending_close_at: null,
+          closed_at: null,
+          closed_by: null,
+          metadata: {},
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-03-31T23:00:00.000Z'),
+        },
+        generated_at: '2026-03-31T23:30:00.000Z',
+        opening_held_raw: '0',
+        new_accruals_raw: '0',
+        allocated_to_batches_raw: '0',
+        swept_onchain_raw: '0',
+        handed_off_raw: '0',
+        realized_raw: '0',
+        ending_held_raw: '0',
+        unresolved_exception_raw: '0',
+        blocking_issue_count: 1,
+        warning_issue_count: 0,
+        blocking_issues: [],
+        warning_issues: [],
       },
-      entries: [
+      reconciliation: {
+        status: 'BLOCKED',
+        freshness: 'FRESH',
+        latest_completed_run_key: 'run-1',
+        latest_completed_run_at: '2026-03-31T14:00:00.000Z',
+        stale_running_run_count: 0,
+        blocked_reasons: ['Latest reconciliation run reported 1 drift finding(s)'],
+      },
+      batches: [],
+      blocking_issues: [
         {
-          ledger_entry_id: 501,
-          trade_id: 'trade-501',
-          component_type: 'PLATFORM_FEE',
-          amount_raw: '125000000',
-          allocated_amount_raw: '125000000',
-          earned_at: new Date('2026-03-31T10:00:00.000Z'),
-          payout_state: 'EXTERNAL_EXECUTION_CONFIRMED',
-          accounting_period_id: 7,
-          accounting_period_key: '2026-Q1',
-          accounting_period_status: 'OPEN',
-          sweep_batch_id: 11,
-          sweep_batch_status: 'CLOSED',
-          allocation_status: 'ALLOCATED',
-          matched_sweep_tx_hash: '0xsweep-1',
-          matched_sweep_block_number: 101,
-          matched_swept_at: new Date('2026-03-31T12:00:00.000Z'),
-          matched_treasury_identity: '0xtreasury',
-          matched_payout_receiver: '0xpayout',
-          matched_claim_amount_raw: '125000000',
-          partner_handoff_id: 33,
-          partner_name: 'licensed-partner',
-          partner_reference: 'partner-ref-1',
-          partner_handoff_status: 'COMPLETED',
-          partner_completed_at: new Date('2026-03-31T13:00:00.000Z'),
-          latest_fiat_deposit_state: 'FUNDED',
-          latest_bank_payout_state: 'CONFIRMED',
-          revenue_realization_status: 'REALIZED',
-          realized_at: new Date('2026-03-31T13:30:00.000Z'),
-          accounting_state: 'REALIZED',
-          accounting_state_reason: 'Controlled revenue realization recorded',
+          code: 'PERIOD_RECONCILIATION_BLOCKED',
+          severity: 'BLOCKING',
+          owner: 'RECONCILIATION',
+          message: 'Accounting period reconciliation is not clear',
+          trade_id: null,
+          sweep_batch_id: null,
+          ledger_entry_id: null,
+          details: {},
         },
       ],
-      partnerHandoff: {
-        id: 33,
-        sweep_batch_id: 11,
-        partner_name: 'licensed-partner',
-        partner_reference: 'partner-ref-1',
-        handoff_status: 'COMPLETED',
-        latest_payload_hash: 'hash',
-        evidence_reference: 'evidence://partner-ref-1',
-        submitted_at: new Date('2026-03-31T12:05:00.000Z'),
-        acknowledged_at: new Date('2026-03-31T12:10:00.000Z'),
-        completed_at: new Date('2026-03-31T13:00:00.000Z'),
-        failed_at: null,
-        verified_at: new Date('2026-03-31T13:05:00.000Z'),
-        metadata: {},
-        created_at: new Date('2026-03-31T12:05:00.000Z'),
-        updated_at: new Date('2026-03-31T13:05:00.000Z'),
-      },
-      totals: {
-        allocatedAmountRaw: '125000000',
-        entryCount: 1,
-      },
-    });
-    jest.spyOn(LoadedReconciliationGateService.prototype, 'summarizeTrades').mockResolvedValue({
-      status: 'BLOCKED',
-      freshness: 'FRESH',
-      latestCompletedRunKey: 'run-1',
-      latestCompletedRunAt: new Date('2026-03-31T14:00:00.000Z'),
-      latestCompletedRunAgeSeconds: 90,
-      staleRunningRunCount: 0,
-      trackedTradeCount: 1,
-      clearTradeCount: 0,
-      blockedTradeCount: 1,
-      unknownTradeCount: 0,
-      driftBlockedTradeCount: 1,
-      blockedReasons: ['Latest reconciliation run reported 1 drift finding(s)'],
+      warning_issues: [],
     });
 
     const controller = new LoadedTreasuryController();
@@ -267,68 +217,98 @@ describe('TreasuryController accounting controls', () => {
       expect.objectContaining({
         success: false,
         error: 'CloseBlocked',
-        message: expect.stringContaining('reconciliation is not clear'),
+        message: expect.stringContaining('blocking treasury close issues remain'),
       }),
     );
   });
 
-  test('closeAccountingPeriod scans every sweep-batch page before allowing period close', async () => {
-    jest
-      .mocked(queriesModule.listSweepBatches)
-      .mockResolvedValueOnce(
-        Array.from({ length: 500 }, (_, index) => ({
-          id: index + 1,
-          batch_key: `batch-q1-${index + 1}`,
-          accounting_period_id: 7,
-          accounting_period_key: '2026-Q1',
-          accounting_period_status: 'OPEN',
-          asset_symbol: 'USDC',
-          status: 'CLOSED',
-          expected_total_raw: '125000000',
-          payout_receiver_address: null,
-          approval_requested_at: null,
-          approval_requested_by: null,
-          approved_at: null,
-          approved_by: null,
-          matched_sweep_tx_hash: '0xsweep-1',
-          matched_sweep_block_number: '101',
-          matched_swept_at: new Date('2026-03-31T12:00:00.000Z'),
-          executed_by: 'user:uid-admin',
-          closed_at: new Date('2026-03-31T13:00:00.000Z'),
-          closed_by: 'user:uid-close',
+  test('closeAccountingPeriod delegates blocking close truth to the close packet loader', async () => {
+    jest.mocked(closeReportingModule.loadTreasuryAccountingPeriodClosePacket).mockResolvedValue({
+      period: {
+        id: 7,
+        period_key: '2026-Q1',
+        starts_at: new Date('2026-01-01T00:00:00.000Z'),
+        ends_at: new Date('2026-03-31T23:59:59.000Z'),
+        status: 'PENDING_CLOSE',
+        created_by: 'user:uid-admin',
+        close_reason: null,
+        pending_close_at: null,
+        closed_at: null,
+        closed_by: null,
+        metadata: {},
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-03-31T23:00:00.000Z'),
+      },
+      generated_at: '2026-03-31T23:30:00.000Z',
+      ready_for_close: false,
+      rollforward: {
+        period: {
+          id: 7,
+          period_key: '2026-Q1',
+          starts_at: new Date('2026-01-01T00:00:00.000Z'),
+          ends_at: new Date('2026-03-31T23:59:59.000Z'),
+          status: 'PENDING_CLOSE',
           created_by: 'user:uid-admin',
-          metadata: {},
-          created_at: new Date('2026-03-31T11:00:00.000Z'),
-          updated_at: new Date('2026-03-31T12:00:00.000Z'),
-        })),
-      )
-      .mockResolvedValueOnce([
-        {
-          id: 999,
-          batch_key: 'batch-q1-999',
-          accounting_period_id: 7,
-          accounting_period_key: '2026-Q1',
-          accounting_period_status: 'OPEN',
-          asset_symbol: 'USDC',
-          status: 'APPROVED',
-          expected_total_raw: '125000000',
-          payout_receiver_address: null,
-          approval_requested_at: null,
-          approval_requested_by: null,
-          approved_at: null,
-          approved_by: null,
-          matched_sweep_tx_hash: '0xsweep-999',
-          matched_sweep_block_number: '101',
-          matched_swept_at: new Date('2026-03-31T12:00:00.000Z'),
-          executed_by: 'user:uid-admin',
+          close_reason: null,
+          pending_close_at: null,
           closed_at: null,
           closed_by: null,
-          created_by: 'user:uid-admin',
           metadata: {},
-          created_at: new Date('2026-03-31T11:00:00.000Z'),
-          updated_at: new Date('2026-03-31T12:00:00.000Z'),
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-03-31T23:00:00.000Z'),
         },
-      ]);
+        generated_at: '2026-03-31T23:30:00.000Z',
+        opening_held_raw: '0',
+        new_accruals_raw: '0',
+        allocated_to_batches_raw: '0',
+        swept_onchain_raw: '0',
+        handed_off_raw: '0',
+        realized_raw: '0',
+        ending_held_raw: '0',
+        unresolved_exception_raw: '0',
+        blocking_issue_count: 1,
+        warning_issue_count: 0,
+        blocking_issues: [
+          {
+            code: 'SWEEP_TX_UNMATCHED',
+            severity: 'BLOCKING',
+            owner: 'TREASURY',
+            message: 'Sweep batch is marked executed without matched treasury claim evidence',
+            trade_id: null,
+            sweep_batch_id: 999,
+            ledger_entry_id: null,
+            details: {
+              batchStatus: 'EXECUTED',
+            },
+          },
+        ],
+        warning_issues: [],
+      },
+      reconciliation: {
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latest_completed_run_key: 'run-1',
+        latest_completed_run_at: '2026-03-31T23:00:00.000Z',
+        stale_running_run_count: 0,
+        blocked_reasons: [],
+      },
+      batches: [],
+      blocking_issues: [
+        {
+          code: 'SWEEP_TX_UNMATCHED',
+          severity: 'BLOCKING',
+          owner: 'TREASURY',
+          message: 'Sweep batch is marked executed without matched treasury claim evidence',
+          trade_id: null,
+          sweep_batch_id: 999,
+          ledger_entry_id: null,
+          details: {
+            batchStatus: 'EXECUTED',
+          },
+        },
+      ],
+      warning_issues: [],
+    });
 
     const controller = new LoadedTreasuryController();
     const req = {
@@ -339,23 +319,17 @@ describe('TreasuryController accounting controls', () => {
 
     await controller.closeAccountingPeriod(req, res);
 
-    expect(queriesModule.listSweepBatches).toHaveBeenNthCalledWith(1, {
-      accountingPeriodId: 7,
-      limit: 500,
-      offset: 0,
-    });
-    expect(queriesModule.listSweepBatches).toHaveBeenNthCalledWith(2, {
-      accountingPeriodId: 7,
-      limit: 500,
-      offset: 500,
-    });
+    expect(closeReportingModule.loadTreasuryAccountingPeriodClosePacket).toHaveBeenCalledWith(
+      7,
+      expect.anything(),
+    );
     expect(queriesModule.updateAccountingPeriodStatus).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(409);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         success: false,
         error: 'CloseBlocked',
-        message: expect.stringContaining('sweep batches remain open'),
+        message: expect.stringContaining('blocking treasury close issues remain'),
       }),
     );
   });

--- a/treasury/tests/ingestion.test.ts
+++ b/treasury/tests/ingestion.test.ts
@@ -1,11 +1,13 @@
 const mockGetIngestionOffset = jest.fn();
 const mockSetIngestionOffset = jest.fn();
 const mockUpsertLedgerEntryWithInitialState = jest.fn();
+const mockUpsertTreasuryClaimEvent = jest.fn();
 
 jest.mock('../src/database/queries', () => ({
   getIngestionOffset: mockGetIngestionOffset,
   setIngestionOffset: mockSetIngestionOffset,
   upsertLedgerEntryWithInitialState: mockUpsertLedgerEntryWithInitialState,
+  upsertTreasuryClaimEvent: mockUpsertTreasuryClaimEvent,
 }));
 
 process.env.PORT = process.env.PORT || '3001';
@@ -63,11 +65,18 @@ describe('TreasuryIngestionService', () => {
       }),
     ];
 
-    let persistedOffset = 0;
-    mockGetIngestionOffset.mockImplementation(async () => persistedOffset);
-    mockSetIngestionOffset.mockImplementation(async (nextOffset: number) => {
-      persistedOffset = nextOffset;
-    });
+    const persistedOffsets = new Map<string, number>([
+      ['trade_events', 0],
+      ['claim_events', 0],
+    ]);
+    mockGetIngestionOffset.mockImplementation(
+      async (cursor: string) => persistedOffsets.get(cursor) ?? 0,
+    );
+    mockSetIngestionOffset.mockImplementation(
+      async (nextOffset: number, cursor = 'trade_events') => {
+        persistedOffsets.set(cursor, nextOffset);
+      },
+    );
     mockUpsertLedgerEntryWithInitialState.mockResolvedValue({
       entry: { id: 1 },
       initialStateCreated: true,
@@ -87,8 +96,10 @@ describe('TreasuryIngestionService', () => {
 
     expect(firstRun).toEqual({ fetched: 3, inserted: 3 });
     expect(fetchTreasuryEvents.mock.calls[0][1]).toBe(0);
-    expect(mockSetIngestionOffset).toHaveBeenLastCalledWith(3);
-    expect(persistedOffset).toBe(3);
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(1, 3, 'trade_events');
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(2, 0, 'claim_events');
+    expect(persistedOffsets.get('trade_events')).toBe(3);
+    expect(persistedOffsets.get('claim_events')).toBe(0);
 
     fetchTreasuryEvents.mockClear();
     mockUpsertLedgerEntryWithInitialState.mockClear();
@@ -136,7 +147,8 @@ describe('TreasuryIngestionService', () => {
     const result = await service.ingestOnce();
 
     expect(result).toEqual({ fetched: 2, inserted: 1 });
-    expect(mockSetIngestionOffset).toHaveBeenCalledWith(2);
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(1, 2, 'trade_events');
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(2, 0, 'claim_events');
   });
 
   it('skips entries when txHash is unavailable and does not attempt DB upsert', async () => {
@@ -168,7 +180,8 @@ describe('TreasuryIngestionService', () => {
 
     expect(result).toEqual({ fetched: 1, inserted: 0 });
     expect(mockUpsertLedgerEntryWithInitialState).not.toHaveBeenCalled();
-    expect(mockSetIngestionOffset).toHaveBeenCalledWith(1);
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(1, 1, 'trade_events');
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(2, 0, 'claim_events');
   });
 
   it('ignores non-treasury events so principal never enters treasury ingestion', async () => {
@@ -198,7 +211,8 @@ describe('TreasuryIngestionService', () => {
 
     expect(result).toEqual({ fetched: 1, inserted: 0 });
     expect(mockUpsertLedgerEntryWithInitialState).not.toHaveBeenCalled();
-    expect(mockSetIngestionOffset).toHaveBeenCalledWith(1);
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(1, 1, 'trade_events');
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(2, 0, 'claim_events');
   });
 
   it('does not double-count replayed treasury events with the same canonical event id', async () => {
@@ -245,5 +259,61 @@ describe('TreasuryIngestionService', () => {
       2,
       expect.objectContaining({ entryKey: 'evt-replay:platform_fee' }),
     );
+  });
+
+  it('persists treasury claim events to a dedicated evidence timeline cursor', async () => {
+    const service = new TreasuryIngestionService();
+    const fetchTreasuryEvents = jest.fn().mockResolvedValue([]);
+    const fetchTreasuryClaimEvents = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'claim-1',
+          txHash: '0xclaim-1',
+          blockNumber: 44,
+          timestamp: new Date('2026-01-01T01:00:00.000Z'),
+          claimAmount: '150',
+          treasuryIdentity: '0xtreasury',
+          payoutReceiver: '0xpayout',
+          triggeredBy: '0xoperator',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    mockGetIngestionOffset.mockImplementation(async (cursor: string) =>
+      cursor === 'claim_events' ? 0 : 0,
+    );
+    mockSetIngestionOffset.mockResolvedValue(undefined);
+    mockUpsertTreasuryClaimEvent.mockResolvedValue({
+      id: 1,
+      matched_sweep_batch_id: null,
+      tx_hash: '0xclaim-1',
+    });
+
+    (
+      service as unknown as {
+        indexerClient: {
+          fetchTreasuryEvents: typeof fetchTreasuryEvents;
+          fetchTreasuryClaimEvents: typeof fetchTreasuryClaimEvents;
+        };
+      }
+    ).indexerClient = {
+      fetchTreasuryEvents,
+      fetchTreasuryClaimEvents,
+    };
+
+    const result = await service.ingestOnce();
+
+    expect(result).toEqual({ fetched: 1, inserted: 0 });
+    expect(mockUpsertTreasuryClaimEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceEventId: 'claim-1',
+        matchedSweepBatchId: null,
+        txHash: '0xclaim-1',
+        amountRaw: '150',
+      }),
+    );
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(1, 0, 'trade_events');
+    expect(mockSetIngestionOffset).toHaveBeenNthCalledWith(2, 1, 'claim_events');
   });
 });

--- a/treasury/tests/rateLimitWiring.test.ts
+++ b/treasury/tests/rateLimitWiring.test.ts
@@ -59,6 +59,12 @@ describe('treasury rate-limit wiring', () => {
       async listAccountingPeriods(_req: express.Request, res: express.Response) {
         res.status(200).json({ success: true });
       },
+      async getAccountingPeriodRollforward(_req: express.Request, res: express.Response) {
+        res.status(200).json({ success: true });
+      },
+      async getAccountingPeriodClosePacket(_req: express.Request, res: express.Response) {
+        res.status(200).json({ success: true });
+      },
       async createAccountingPeriod(_req: express.Request, res: express.Response) {
         res.status(200).json({ success: true });
       },
@@ -75,6 +81,9 @@ describe('treasury rate-limit wiring', () => {
         res.status(200).json({ success: true });
       },
       async getSweepBatch(_req: express.Request, res: express.Response) {
+        res.status(200).json({ success: true });
+      },
+      async getSweepBatchTrace(_req: express.Request, res: express.Response) {
         res.status(200).json({ success: true });
       },
       async addSweepBatchEntry(_req: express.Request, res: express.Response) {

--- a/treasury/tests/routerAuthScope.test.ts
+++ b/treasury/tests/routerAuthScope.test.ts
@@ -60,6 +60,12 @@ describe('treasury router auth scope', () => {
       listAccountingPeriods: (_req: Request, res: Response) => {
         res.status(200).json({ success: true, data: [] });
       },
+      getAccountingPeriodRollforward: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getAccountingPeriodClosePacket: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
       createAccountingPeriod: (_req: Request, res: Response) => {
         res.status(201).json({ success: true, data: { created: true } });
       },
@@ -76,6 +82,9 @@ describe('treasury router auth scope', () => {
         res.status(201).json({ success: true, data: { created: true } });
       },
       getSweepBatch: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getSweepBatchTrace: (_req: Request, res: Response) => {
         res.status(200).json({ success: true, data: null });
       },
       addSweepBatchEntry: (_req: Request, res: Response) => {

--- a/treasury/tests/serviceAuthRoutes.test.ts
+++ b/treasury/tests/serviceAuthRoutes.test.ts
@@ -117,6 +117,12 @@ describe('treasury service-authenticated routes', () => {
       listAccountingPeriods: (_req: Request, res: Response) => {
         res.status(200).json({ success: true, data: [] });
       },
+      getAccountingPeriodRollforward: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getAccountingPeriodClosePacket: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
       createAccountingPeriod: (_req: Request, res: Response) => {
         res.status(201).json({ success: true, route: 'periods' });
       },
@@ -133,6 +139,9 @@ describe('treasury service-authenticated routes', () => {
         res.status(201).json({ success: true, route: 'batch-create' });
       },
       getSweepBatch: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getSweepBatchTrace: (_req: Request, res: Response) => {
         res.status(200).json({ success: true, data: null });
       },
       addSweepBatchEntry: (_req: Request, res: Response) => {

--- a/treasury/tests/sweepExecutionMatcher.test.ts
+++ b/treasury/tests/sweepExecutionMatcher.test.ts
@@ -10,6 +10,7 @@ process.env.INDEXER_GRAPHQL_URL =
 jest.mock('../src/database/queries', () => ({
   getSweepBatchDetail: jest.fn(),
   getTreasuryClaimEventByBatchId: jest.fn(),
+  getTreasuryClaimEventByTxHash: jest.fn(),
   updateSweepBatchStatus: jest.fn(),
   upsertTreasuryClaimEvent: jest.fn(),
 }));
@@ -59,6 +60,7 @@ describe('SweepExecutionMatcherService', () => {
   it('matches execution only from authoritative TreasuryClaimed evidence', async () => {
     jest.mocked(queries.getSweepBatchDetail).mockResolvedValue(batchDetailFixture as never);
     jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue(null);
     jest.mocked(queries.upsertTreasuryClaimEvent).mockResolvedValue({
       id: 90,
       source_event_id: 'event-90',
@@ -117,6 +119,7 @@ describe('SweepExecutionMatcherService', () => {
   it('rejects unmatched tx hashes with no chain evidence', async () => {
     jest.mocked(queries.getSweepBatchDetail).mockResolvedValue(batchDetailFixture as never);
     jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue(null);
 
     const matcher = new SweepExecutionMatcherService({
       indexerClient: {
@@ -136,6 +139,7 @@ describe('SweepExecutionMatcherService', () => {
   it('rejects claim events whose amount does not match the allocated batch total', async () => {
     jest.mocked(queries.getSweepBatchDetail).mockResolvedValue(batchDetailFixture as never);
     jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue(null);
 
     const matcher = new SweepExecutionMatcherService({
       indexerClient: {
@@ -165,6 +169,7 @@ describe('SweepExecutionMatcherService', () => {
   it('rejects claim events whose destination does not match the batch payout receiver', async () => {
     jest.mocked(queries.getSweepBatchDetail).mockResolvedValue(batchDetailFixture as never);
     jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue(null);
 
     const matcher = new SweepExecutionMatcherService({
       indexerClient: {
@@ -208,6 +213,7 @@ describe('SweepExecutionMatcherService', () => {
       triggered_by: '0xsigner',
       created_at: new Date('2026-04-15T11:00:00.000Z'),
     });
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue(null);
 
     const matcher = new SweepExecutionMatcherService({
       indexerClient: {
@@ -222,5 +228,60 @@ describe('SweepExecutionMatcherService', () => {
         actor: 'executor-3',
       }),
     ).rejects.toThrow('Sweep batch is already matched to a different treasury claim tx');
+  });
+
+  it('reuses already ingested unmatched claim evidence before calling the indexer', async () => {
+    jest.mocked(queries.getSweepBatchDetail).mockResolvedValue(batchDetailFixture as never);
+    jest.mocked(queries.getTreasuryClaimEventByBatchId).mockResolvedValue(null);
+    jest.mocked(queries.getTreasuryClaimEventByTxHash).mockResolvedValue({
+      id: 90,
+      source_event_id: 'event-90',
+      matched_sweep_batch_id: null,
+      tx_hash: '0xclaim',
+      block_number: 101,
+      observed_at: new Date('2026-04-15T11:00:00.000Z'),
+      treasury_identity: '0xtreasury',
+      payout_receiver: '0xpayout',
+      amount_raw: '125000000',
+      triggered_by: '0xsigner',
+      created_at: new Date('2026-04-15T11:00:00.000Z'),
+    });
+    jest.mocked(queries.upsertTreasuryClaimEvent).mockResolvedValue({
+      id: 90,
+      source_event_id: 'event-90',
+      matched_sweep_batch_id: 11,
+      tx_hash: '0xclaim',
+      block_number: 101,
+      observed_at: new Date('2026-04-15T11:00:00.000Z'),
+      treasury_identity: '0xtreasury',
+      payout_receiver: '0xpayout',
+      amount_raw: '125000000',
+      triggered_by: '0xsigner',
+      created_at: new Date('2026-04-15T11:00:00.000Z'),
+    });
+    jest.mocked(queries.updateSweepBatchStatus).mockResolvedValue({
+      ...batchDetailFixture.batch,
+      status: 'EXECUTED',
+      matched_sweep_tx_hash: '0xclaim',
+      matched_sweep_block_number: '101',
+      matched_swept_at: new Date('2026-04-15T11:00:00.000Z'),
+      executed_by: 'executor-3',
+    } as never);
+
+    const fetchTreasuryClaimEventByTxHash = jest.fn();
+    const matcher = new SweepExecutionMatcherService({
+      indexerClient: {
+        fetchTreasuryClaimEventByTxHash,
+      },
+    });
+
+    const result = await matcher.matchApprovedBatch({
+      batchId: 11,
+      txHash: '0xclaim',
+      actor: 'executor-3',
+    });
+
+    expect(result.status).toBe('EXECUTED');
+    expect(fetchTreasuryClaimEventByTxHash).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #445

## Summary
This finishes the last verified blockers in the treasury-controls hardening work.

The branch was already carrying a strong treasury-controls implementation locally, but it was not yet acceptable because the work was still sitting in an uncommitted worktree and the new close-packet logic could silently truncate period batch coverage after the first 500 batches.

This PR turns that work into real branch truth, fixes the close-reporting correctness defect, and aligns treasury workflow audit metadata with the effective treasury capability context used for authorization.

## What changed
### Worktree to branch truth
- Tracked and committed the previously local-only treasury close reporting module and its tests.
- Kept the scope narrow to the verified treasury/gateway/docs/tests surface.

### Close-reporting correctness hardening
- Fixed accounting-period close-packet generation so it loads **all** sweep batches for the period instead of a single 500-row page.
- Preserved the existing output shapes and close-packet gating model.
- Added test coverage proving multi-page batch loading affects close readiness.

### Treasury capability audit truth
- Treasury workflow audit metadata now records:
  - `gatewayTreasuryCapabilitiesRaw`
  - `gatewayTreasuryCapabilitiesEffective`
- This removes the previous mismatch where authorization used resolved effective capabilities but the audit trail only stored raw upstream capability strings.
- The current admin fallback behavior is preserved.

### Test strengthening
- Added direct proof that warning-only close issues do not block `ready_for_close`.
- Added direct proof that pagination across more than 500 batches still surfaces blocking issues.
- Added a gateway workflow unit test proving effective capability context is written into treasury workflow metadata.

## Why it changed
- Finance close cannot be trusted if the close packet can omit later-period batches.
- Authorization/audit truth should match: if effective capability resolution authorizes an action, the audit metadata should reflect that effective context.
- Local-only implementation is not reviewable or shippable branch truth.

## Validation run
Passed locally on commit `e9aa536`:
- `npm run build` in `sdk`
- `npm run typecheck` in `treasury`
- `npm run lint` in `treasury`
- `npm run typecheck` in `gateway`
- `npm run lint` in `gateway`
- `npm run typecheck` in `reconciliation`
- `npm run lint` in `reconciliation`
- `npm test -- --runTestsByPath tests/accountingPolicy.test.ts tests/accountingStateProjection.test.ts tests/closeReporting.test.ts tests/controller.accountingControls.test.ts tests/controller.eligibility.test.ts tests/depositRoutes.test.ts tests/exportEligibility.test.ts tests/ingestion.test.ts tests/ledgerAbstractionProof.test.ts tests/payoutTransitions.test.ts tests/queries.accountingControls.test.ts tests/queries.bankConfirmations.test.ts tests/rateLimitWiring.test.ts tests/routerAuthScope.test.ts tests/serviceAuthRoutes.test.ts tests/sweepExecutionMatcher.test.ts` in `treasury`
- `npm test -- --runTestsByPath tests/treasuryRoutes.contract.test.ts tests/treasuryWorkflowService.test.ts` in `gateway`
- `npm test -- --runTestsByPath src/tests/reconciliation-report.test.ts` in `reconciliation`
- `npm run format:check` at repo root
  - note: this repo script checks files changed from `HEAD`, not the whole repo
- `git diff --check`

## Non-goals
- No broad contract rewrite
- No fee-policy move into Cotsel
- No partner-adapter expansion
- No compatibility schema rename such as `partner_handoffs`
- No second accounting-state logic tree

## Remaining non-blocking backlog
- Upstream auth can later emit explicit treasury capability arrays consistently so runtime posture relies less on admin fallback.
- If finance wants a packaged evidence bundle later, it can build on the close packet and batch trace surfaces now in place.

## Risk notes
- Close reporting now walks all sweep-batch pages for a period. Reviewers should pay attention to pagination behavior and test fixtures around large periods.
- Treasury workflow metadata now includes both raw and effective capability context. Existing consumers that inspect gateway metadata should tolerate the additive fields.

## Non-technical summary
This fixes the last two real problems before the treasury-controls work is ready for review.

First, the close report now checks every batch in the period instead of quietly stopping after the first page. Second, the audit trail now records the actual treasury permissions the system used when it allowed an action, not just the raw session payload. The work is now committed on a real branch instead of living only in a local worktree.
