### PR TITLE
Audit/security review

### DIFF
--- a/contracts/scripts/lib/baseDeploymentConfig.ts
+++ b/contracts/scripts/lib/baseDeploymentConfig.ts
@@ -114,6 +114,10 @@ function parseAdminList(env: NodeJS.ProcessEnv): string[] {
     throw new Error("DEPLOY_ADMINS must contain at least one admin address");
   }
 
+  if (admins.length < 2) {
+    throw new Error("DEPLOY_ADMINS must contain at least two admin addresses");
+  }
+
   const unique = new Set(admins);
   if (unique.size !== admins.length) {
     throw new Error("DEPLOY_ADMINS must not contain duplicate addresses");

--- a/contracts/src/AgroasysEscrow.sol
+++ b/contracts/src/AgroasysEscrow.sol
@@ -388,6 +388,7 @@ contract AgroasysEscrow is ReentrancyGuard, Pausable {
         require(_oracleAddress != address(0), "invalid oracle");
         require(_treasuryAddress != address(0), "invalid treasury");
         require(_requiredApprovals > 0, "required approvals must be > 0");
+        require(_admins.length >= 2, "at least 2 admins required");
         require(_admins.length >= _requiredApprovals, "not enough admins");
 
         usdcToken = IERC20(_usdcToken);
@@ -488,7 +489,7 @@ contract AgroasysEscrow is ReentrancyGuard, Pausable {
         hasActiveUnpauseProposal = true;
 
         emit UnpauseProposed(msg.sender);
-        emit UnpauseApproved(msg.sender, 1, requiredApprovals);
+        emit UnpauseApproved(msg.sender, 1, governanceApprovals());
 
         return true;
     }
@@ -505,7 +506,7 @@ contract AgroasysEscrow is ReentrancyGuard, Pausable {
         unpauseHasApproved[msg.sender] = true;
         unpauseProposal.approvalCount++;
 
-        emit UnpauseApproved(msg.sender, unpauseProposal.approvalCount, requiredApprovals);
+        emit UnpauseApproved(msg.sender, unpauseProposal.approvalCount, governanceApprovals());
 
         if (unpauseProposal.approvalCount >= governanceApprovals()) {
             _executeUnpause();

--- a/contracts/tests/AgroasysEscrow.ts
+++ b/contracts/tests/AgroasysEscrow.ts
@@ -236,6 +236,16 @@ describe('AgroasysEscrow', function () {
           oracle.address,
           treasury.address,
           [admin1.address],
+          1,
+        ),
+      ).to.be.revertedWith('at least 2 admins required');
+
+      await expect(
+        EscrowFactory.deploy(
+          await usdc.getAddress(),
+          oracle.address,
+          treasury.address,
+          [admin1.address, admin2.address],
           3,
         ),
       ).to.be.revertedWith('not enough admins');
@@ -261,6 +271,32 @@ describe('AgroasysEscrow', function () {
         escrow,
         'FundsReleasedStage1',
       );
+    });
+
+    it('Should emit the effective governance quorum during unpause for low-quorum dispute configs', async function () {
+      const EscrowFactory = await ethers.getContractFactory('AgroasysEscrow');
+      const lowQuorumEscrow = await EscrowFactory.deploy(
+        await usdc.getAddress(),
+        oracle.address,
+        treasury.address,
+        [admin1.address, admin2.address],
+        1,
+      );
+      await lowQuorumEscrow.waitForDeployment();
+
+      await expect(lowQuorumEscrow.connect(admin1).pause())
+        .to.emit(lowQuorumEscrow, 'Paused')
+        .withArgs(admin1.address);
+
+      await expect(lowQuorumEscrow.connect(admin1).proposeUnpause())
+        .to.emit(lowQuorumEscrow, 'UnpauseApproved')
+        .withArgs(admin1.address, 1, 2);
+
+      await expect(lowQuorumEscrow.connect(admin2).approveUnpause())
+        .to.emit(lowQuorumEscrow, 'UnpauseApproved')
+        .withArgs(admin2.address, 2, 2)
+        .and.to.emit(lowQuorumEscrow, 'Unpaused')
+        .withArgs(admin2.address);
     });
 
     it('Should allow claims while globally paused when claim freeze is not active', async function () {

--- a/contracts/tests/baseDeploymentConfig.ts
+++ b/contracts/tests/baseDeploymentConfig.ts
@@ -50,6 +50,16 @@ describe('Base deployment config', function () {
     ).to.throw(/must not exceed the number of admin addresses/);
   });
 
+  it('rejects single-admin deployment matrices because governance requires two admins', async function () {
+    expect(() =>
+      loadBaseDeploymentConfig('base-sepolia', 84532, {
+        ...validEnv,
+        DEPLOY_ADMINS: '0x20e7E6fC0905E17De2D28E926Ad56324a6844a1D',
+        DEPLOY_REQUIRED_APPROVALS: '1',
+      }),
+    ).to.throw(/must contain at least two admin addresses/);
+  });
+
   it('rejects chain id mismatches for the selected Base network', async function () {
     expect(() => loadBaseDeploymentConfig('base-sepolia', 8453, validEnv)).to.throw(
       /requires chainId=84532, received 8453/,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,9 +8,9 @@ This SDK provides a **type-safe, role-based interface** to the Agroasys smart co
 
 The SDK is organized into **three role-based modules**:
 
-- **BuyerSDK** - Create trades, approve USDC, open disputes
+- **BuyerSDK** - Create trades, approve USDC, open disputes, and claim settled balances
 - **OracleSDK** - Release funds at logistics milestones, confirm arrival, finalize trade (**Auth verification**)
-- **AdminSDK** - Solve frozen trades, propose/approve/execute governance actions (oracle/admin updates) (**Auth verification**)
+- **AdminSDK** - Solve frozen trades, operate protocol controls, manage treasury payout governance, and propose/approve/execute governance actions (**Auth verification**)
 
 All modules extend a shared **Client** base class, which handles provider initialization and common contract reads.
 
@@ -164,6 +164,7 @@ SDK and inject a signer instead.
 | `openDispute(tradeId, signer)`                   | Open a dispute on an existing trade               |
 | `cancelLockedTradeAfterTimeout(tradeId, signer)` | Cancel stale `LOCKED` trade after timeout         |
 | `refundInTransitAfterTimeout(tradeId, signer)`   | Refund remaining principal when transit times out |
+| `claim(signer)`                                  | Claim accumulated USDC assigned to the signer     |
 
 ### OracleSDK
 
@@ -175,24 +176,31 @@ SDK and inject a signer instead.
 
 ### AdminSDK
 
-| Method                                                  | Description                                        |
-| ------------------------------------------------------- | -------------------------------------------------- |
-| `pause(signer)`                                         | Pause normal protocol operations                   |
-| `proposeUnpause(signer)`                                | Propose unpause (multi-admin)                      |
-| `approveUnpause(signer)`                                | Approve unpause proposal                           |
-| `cancelUnpauseProposal(signer)`                         | Cancel active unpause proposal                     |
-| `disableOracleEmergency(signer)`                        | Emergency disable oracle + pause                   |
-| `proposeDisputeSolution(tradeId, status, signer)`       | Propose dispute resolution (`REFUND` or `RESOLVE`) |
-| `approveDisputeSolution(proposalId, signer)`            | Approve dispute proposal                           |
-| `cancelExpiredDisputeProposal(proposalId, signer)`      | Cancel expired dispute proposal                    |
-| `proposeOracleUpdate(newOracle, signer)`                | Propose oracle update                              |
-| `approveOracleUpdate(proposalId, signer)`               | Approve oracle update                              |
-| `executeOracleUpdate(proposalId, signer)`               | Execute approved oracle update                     |
-| `cancelExpiredOracleUpdateProposal(proposalId, signer)` | Cancel expired oracle-update proposal              |
-| `proposeAddAdmin(newAdmin, signer)`                     | Propose adding a new admin                         |
-| `approveAddAdmin(proposalId, signer)`                   | Approve admin-add proposal                         |
-| `executeAddAdmin(proposalId, signer)`                   | Execute approved admin addition                    |
-| `cancelExpiredAddAdminProposal(proposalId, signer)`     | Cancel expired admin-add proposal                  |
+| Method                                                         | Description                                        |
+| -------------------------------------------------------------- | -------------------------------------------------- |
+| `pause(signer)`                                                | Pause normal protocol operations                   |
+| `proposeUnpause(signer)`                                       | Propose unpause (multi-admin)                      |
+| `approveUnpause(signer)`                                       | Approve unpause proposal                           |
+| `cancelUnpauseProposal(signer)`                                | Cancel active unpause proposal                     |
+| `disableOracleEmergency(signer)`                               | Emergency disable oracle + pause                   |
+| `pauseClaims(signer)`                                          | Pause treasury/partner claims                      |
+| `unpauseClaims(signer)`                                        | Resume treasury/partner claims                     |
+| `claimTreasury(signer)`                                        | Sweep claimable treasury USDC                      |
+| `proposeTreasuryPayoutAddressUpdate(address, signer)`          | Propose treasury payout receiver update            |
+| `approveTreasuryPayoutAddressUpdate(id, signer)`               | Approve payout receiver update proposal            |
+| `executeTreasuryPayoutAddressUpdate(id, signer)`               | Execute approved payout receiver update            |
+| `cancelExpiredTreasuryPayoutAddressUpdateProposal(id, signer)` | Cancel expired payout receiver proposal            |
+| `proposeDisputeSolution(tradeId, status, signer)`              | Propose dispute resolution (`REFUND` or `RESOLVE`) |
+| `approveDisputeSolution(proposalId, signer)`                   | Approve dispute proposal                           |
+| `cancelExpiredDisputeProposal(proposalId, signer)`             | Cancel expired dispute proposal                    |
+| `proposeOracleUpdate(newOracle, signer)`                       | Propose oracle update                              |
+| `approveOracleUpdate(proposalId, signer)`                      | Approve oracle update                              |
+| `executeOracleUpdate(proposalId, signer)`                      | Execute approved oracle update                     |
+| `cancelExpiredOracleUpdateProposal(proposalId, signer)`        | Cancel expired oracle-update proposal              |
+| `proposeAddAdmin(newAdmin, signer)`                            | Propose adding a new admin                         |
+| `approveAddAdmin(proposalId, signer)`                          | Approve admin-add proposal                         |
+| `executeAddAdmin(proposalId, signer)`                          | Execute approved admin addition                    |
+| `cancelExpiredAddAdminProposal(proposalId, signer)`            | Cancel expired admin-add proposal                  |
 
 ## Auth ownership boundary
 

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -19,6 +19,26 @@ export class Client {
     this.contract = AgroasysEscrow__factory.connect(config.escrowAddress, this.provider);
   }
 
+  protected async assertSignerCompatibility(
+    signer: ethers.Signer,
+    signerLabel = 'Signer',
+  ): Promise<void> {
+    if (!signer.provider) {
+      throw new ContractError(`${signerLabel} is missing a connected provider`);
+    }
+
+    const signerNetwork = await signer.provider.getNetwork();
+    if (signerNetwork.chainId !== BigInt(this.config.chainId)) {
+      throw new ContractError(
+        `${signerLabel} is connected to the wrong network for this settlement target`,
+        {
+          expectedChainId: this.config.chainId,
+          actualChainId: signerNetwork.chainId.toString(),
+        },
+      );
+    }
+  }
+
   async getBuyerNonce(buyerAddress: string): Promise<bigint> {
     try {
       return await this.contract.getBuyerNonce(buyerAddress);
@@ -122,6 +142,8 @@ export class Client {
   }
 
   async claim(signer: ethers.Signer): Promise<{ txHash: string; blockNumber: number }> {
+    await this.assertSignerCompatibility(signer);
+
     try {
       const contractWithSigner = this.contract.connect(signer);
       const tx = await contractWithSigner.claim();

--- a/sdk/src/modules/adminSDK.ts
+++ b/sdk/src/modules/adminSDK.ts
@@ -3,7 +3,7 @@
  */
 import { Client } from '../client';
 import { ethers } from 'ethers';
-import { DisputeStatus, DisputeResult } from '../types/dispute';
+import { DisputeStatus, DisputeProposalResult, DisputeResult } from '../types/dispute';
 import { GovernanceProposalResult, GovernanceResult } from '../types/governance';
 import {
   AuthorizationError,
@@ -15,6 +15,8 @@ import { validateAddress } from '../utils/validation';
 
 export class AdminSDK extends Client {
   private async verifyAdmin(adminSigner: ethers.Signer): Promise<void> {
+    await this.assertSignerCompatibility(adminSigner, 'Admin signer');
+
     const adminAddress = await adminSigner.getAddress();
     const isAdmin = await this.isAdmin(adminAddress);
 
@@ -226,6 +228,8 @@ export class AdminSDK extends Client {
   }
 
   async claimTreasury(triggerSigner: ethers.Signer): Promise<GovernanceResult> {
+    await this.assertSignerCompatibility(triggerSigner);
+
     try {
       const contractWithSigner = this.contract.connect(triggerSigner);
       const tx = await contractWithSigner.claimTreasury();
@@ -371,7 +375,7 @@ export class AdminSDK extends Client {
     tradeId: string | bigint,
     disputeStatus: DisputeStatus,
     adminSigner: ethers.Signer,
-  ): Promise<DisputeResult> {
+  ): Promise<DisputeProposalResult> {
     await this.verifyAdmin(adminSigner);
 
     if (disputeStatus !== DisputeStatus.REFUND && disputeStatus !== DisputeStatus.RESOLVE) {
@@ -390,6 +394,7 @@ export class AdminSDK extends Client {
       return {
         txHash: receipt.hash,
         blockNumber: receipt.blockNumber,
+        proposalId: this.extractProposalIdFromReceipt(receipt, 'DisputeSolutionProposed'),
       };
     } catch (error: unknown) {
       const message = getErrorMessage(error);
@@ -575,7 +580,10 @@ export class AdminSDK extends Client {
 
   // #################### ADMIN GOVERNANCE ####################
 
-  async proposeAddAdmin(newAdmin: string, adminSigner: ethers.Signer): Promise<GovernanceResult> {
+  async proposeAddAdmin(
+    newAdmin: string,
+    adminSigner: ethers.Signer,
+  ): Promise<GovernanceProposalResult> {
     await this.verifyAdmin(adminSigner);
     validateAddress(newAdmin, 'newAdmin');
 
@@ -591,6 +599,7 @@ export class AdminSDK extends Client {
       return {
         txHash: receipt.hash,
         blockNumber: receipt.blockNumber,
+        proposalId: this.extractProposalIdFromReceipt(receipt, 'AdminAddProposed'),
       };
     } catch (error: unknown) {
       const message = getErrorMessage(error);

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -10,23 +10,6 @@ import { ContractError, getErrorMessage } from '../types/errors';
 import { IERC20__factory } from '../types/typechain-types/factories/@openzeppelin/contracts/token/ERC20/IERC20__factory';
 
 export class BuyerSDK extends Client {
-  private async assertSignerCompatibility(buyerSigner: ethers.Signer): Promise<void> {
-    if (!buyerSigner.provider) {
-      throw new ContractError('Buyer signer is missing a connected provider');
-    }
-
-    const signerNetwork = await buyerSigner.provider.getNetwork();
-    if (signerNetwork.chainId !== BigInt(this.config.chainId)) {
-      throw new ContractError(
-        'Buyer signer is connected to the wrong network for this settlement target',
-        {
-          expectedChainId: this.config.chainId,
-          actualChainId: signerNetwork.chainId.toString(),
-        },
-      );
-    }
-  }
-
   private extractTradeIdFromReceipt(receipt: ethers.TransactionReceipt): string | undefined {
     for (const log of receipt.logs) {
       if (log.address.toLowerCase() !== this.config.escrowAddress.toLowerCase()) {
@@ -52,6 +35,8 @@ export class BuyerSDK extends Client {
   }
 
   async approveUSDC(amount: bigint, buyerSigner: ethers.Signer): Promise<TradeResult> {
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
+
     try {
       const usdcContract = IERC20__factory.connect(this.config.usdcAddress, buyerSigner);
 
@@ -129,7 +114,7 @@ export class BuyerSDK extends Client {
   async createTrade(payload: BuyerLockPayload, buyerSigner: ethers.Signer): Promise<TradeResult> {
     validateTradeParameters(payload);
     const params = payload;
-    await this.assertSignerCompatibility(buyerSigner);
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
 
     const buyerAddress = await buyerSigner.getAddress();
 
@@ -198,6 +183,8 @@ export class BuyerSDK extends Client {
   }
 
   async openDispute(tradeId: string | bigint, buyerSigner: ethers.Signer): Promise<TradeResult> {
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
+
     try {
       const contractWithSigner = this.contract.connect(buyerSigner);
       const tx = await contractWithSigner.openDispute(tradeId);
@@ -224,6 +211,8 @@ export class BuyerSDK extends Client {
     tradeId: string | bigint,
     buyerSigner: ethers.Signer,
   ): Promise<TradeResult> {
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
+
     try {
       const contractWithSigner = this.contract.connect(buyerSigner);
       const tx = await contractWithSigner.cancelLockedTradeAfterTimeout(tradeId);
@@ -250,6 +239,8 @@ export class BuyerSDK extends Client {
     tradeId: string | bigint,
     buyerSigner: ethers.Signer,
   ): Promise<TradeResult> {
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
+
     try {
       const contractWithSigner = this.contract.connect(buyerSigner);
       const tx = await contractWithSigner.refundInTransitAfterTimeout(tradeId);

--- a/sdk/src/modules/oracleSDK.ts
+++ b/sdk/src/modules/oracleSDK.ts
@@ -9,6 +9,8 @@ import { Trade, TradeStatus } from '../types/trade';
 
 export class OracleSDK extends Client {
   private async verifyOracle(oracleSigner: ethers.Signer): Promise<void> {
+    await this.assertSignerCompatibility(oracleSigner, 'Oracle signer');
+
     const oracleAddress = await oracleSigner.getAddress();
     const authorizedOracle = await this.getOracleAddress();
 
@@ -80,6 +82,8 @@ export class OracleSDK extends Client {
     tradeId: string | bigint,
     signer: ethers.Signer,
   ): Promise<OracleResult> {
+    await this.assertSignerCompatibility(signer);
+
     try {
       const contractWithSigner = this.contract.connect(signer);
       const tx = await contractWithSigner.finalizeAfterDisputeWindow(tradeId);

--- a/sdk/src/types/dispute.ts
+++ b/sdk/src/types/dispute.ts
@@ -20,3 +20,7 @@ export interface DisputeResult {
   txHash: string;
   blockNumber: number;
 }
+
+export interface DisputeProposalResult extends DisputeResult {
+  proposalId?: bigint;
+}

--- a/sdk/tests/adminSDK.test.ts
+++ b/sdk/tests/adminSDK.test.ts
@@ -52,13 +52,17 @@ type MockContractWithSigner = {
   cancelExpiredTreasuryPayoutAddressUpdateProposal: jest.Mock;
 };
 
-type SignerLike = Pick<ethers.Signer, 'getAddress'>;
+type SignerLike = Pick<ethers.Signer, 'getAddress' | 'provider'>;
 type AdminSdkContract = AdminSDK['contract'];
 type ContractConnector = Pick<AdminSdkContract, 'connect' | 'interface'>;
 
 function makeSigner(address = '0x1111111111111111111111111111111111111111'): ethers.Signer {
+  const provider = {
+    getNetwork: jest.fn().mockResolvedValue({ chainId: 31337n }),
+  };
   const signer: SignerLike = {
     getAddress: jest.fn().mockResolvedValue(address),
+    provider: provider as unknown as ethers.Signer['provider'],
   };
   return signer as unknown as ethers.Signer;
 }
@@ -128,6 +132,18 @@ describe('AdminSDK unit', () => {
     expect(contractWithSigner.pause).toHaveBeenCalledTimes(1);
     expect(tx.wait).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ txHash: RECEIPT.hash, blockNumber: RECEIPT.blockNumber });
+  });
+
+  test('pause should reject signer network mismatches before admin verification', async () => {
+    const { sdk, connect } = makeSdkUnit(true);
+    const signer = makeSigner() as ethers.Signer & {
+      provider: { getNetwork: jest.Mock };
+    };
+    signer.provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.pause(signer)).rejects.toThrow('wrong network');
+    expect(sdk.isAdmin).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
   });
 
   test('unpause flow methods should call matching contract methods', async () => {
@@ -244,6 +260,19 @@ describe('AdminSDK unit', () => {
     expect(sdk.isAdmin).not.toHaveBeenCalled();
   });
 
+  test('treasury sweep should reject signer network mismatches', async () => {
+    const { sdk, contractWithSigner, connect } = makeSdkUnit(false);
+    const signer = makeSigner() as ethers.Signer & {
+      provider: { getNetwork: jest.Mock };
+    };
+    signer.provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.claimTreasury(signer)).rejects.toThrow('wrong network');
+    expect(contractWithSigner.claimTreasury).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+    expect(sdk.isAdmin).not.toHaveBeenCalled();
+  });
+
   test('treasury payout receiver governance methods should call matching contract methods', async () => {
     const { sdk, contractWithSigner } = makeSdkUnit(true);
     const signer = makeSigner();
@@ -310,6 +339,62 @@ describe('AdminSDK unit', () => {
       txHash: RECEIPT.hash,
       blockNumber: RECEIPT.blockNumber,
       proposalId: 9n,
+    });
+  });
+
+  test('proposeDisputeSolution returns proposal id when receipt contains DisputeSolutionProposed', async () => {
+    const { sdk, contractWithSigner, parseLog } = makeSdkUnit(true);
+    const signer = makeSigner();
+    const tx = mockSuccessCall(contractWithSigner.proposeDisputeSolution);
+    tx.wait.mockResolvedValue({
+      ...RECEIPT,
+      logs: [
+        {
+          topics: ['0x1'],
+          data: '0x2',
+        },
+      ],
+    });
+    parseLog.mockReturnValue({
+      name: 'DisputeSolutionProposed',
+      args: {
+        proposalId: 12n,
+      },
+    });
+
+    await expect(sdk.proposeDisputeSolution(1n, DisputeStatus.REFUND, signer)).resolves.toEqual({
+      txHash: RECEIPT.hash,
+      blockNumber: RECEIPT.blockNumber,
+      proposalId: 12n,
+    });
+  });
+
+  test('proposeAddAdmin returns proposal id when receipt contains AdminAddProposed', async () => {
+    const { sdk, contractWithSigner, parseLog } = makeSdkUnit(true);
+    const signer = makeSigner();
+    const tx = mockSuccessCall(contractWithSigner.proposeAddAdmin);
+    tx.wait.mockResolvedValue({
+      ...RECEIPT,
+      logs: [
+        {
+          topics: ['0x1'],
+          data: '0x2',
+        },
+      ],
+    });
+    parseLog.mockReturnValue({
+      name: 'AdminAddProposed',
+      args: {
+        proposalId: 14n,
+      },
+    });
+
+    await expect(
+      sdk.proposeAddAdmin('0x2222222222222222222222222222222222222222', signer),
+    ).resolves.toEqual({
+      txHash: RECEIPT.hash,
+      blockNumber: RECEIPT.blockNumber,
+      proposalId: 14n,
     });
   });
 

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -4,6 +4,7 @@
 import { BuyerSDK } from '../src/modules/buyerSDK';
 import type { ethers } from 'ethers';
 import { Interface } from 'ethers';
+import { IERC20__factory } from '../src/types/typechain-types/factories/@openzeppelin/contracts/token/ERC20/IERC20__factory';
 import { TEST_CONFIG, assertRequiredEnv, getBuyerSigner, hasRequiredEnv } from './setup';
 
 const describeIntegration = hasRequiredEnv ? describe : describe.skip;
@@ -34,6 +35,7 @@ type MockContractWithSigner = {
 type BuyerSignerLike = Pick<ethers.Signer, 'getAddress' | 'signMessage' | 'provider'>;
 type BuyerSdkContract = BuyerSDK['contract'];
 type BuyerContractConnector = Pick<BuyerSdkContract, 'connect' | 'interface'>;
+type BuyerWriteInvocation = (sdk: BuyerSDK, signer: ethers.Signer) => Promise<unknown>;
 
 function makeBuyerSigner(address = '0x2222222222222222222222222222222222222222'): {
   signer: ethers.Signer;
@@ -86,6 +88,16 @@ function mockSuccessCall(mock: jest.Mock) {
   return tx;
 }
 
+const networkMismatchCases: Array<[string, BuyerWriteInvocation]> = [
+  ['openDispute', (sdk, signer) => sdk.openDispute(10n, signer)],
+  [
+    'cancelLockedTradeAfterTimeout',
+    (sdk, signer) => sdk.cancelLockedTradeAfterTimeout(11n, signer),
+  ],
+  ['refundInTransitAfterTimeout', (sdk, signer) => sdk.refundInTransitAfterTimeout(12n, signer)],
+  ['claim', (sdk, signer) => sdk.claim(signer)],
+];
+
 describe('BuyerSDK unit', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -110,6 +122,16 @@ describe('BuyerSDK unit', () => {
         signer,
       ),
     ).rejects.toThrow('wrong network');
+  });
+
+  test('approveUSDC should reject signer network mismatches', async () => {
+    const { sdk } = makeSdkUnit();
+    const { signer, provider } = makeBuyerSigner();
+    const connectSpy = jest.spyOn(IERC20__factory, 'connect');
+    provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.approveUSDC(1000000n, signer)).rejects.toThrow('wrong network');
+    expect(connectSpy).not.toHaveBeenCalled();
   });
 
   test('createTrade should surface tradeId from TradeLocked receipt logs', async () => {
@@ -212,6 +234,17 @@ describe('BuyerSDK unit', () => {
     expect(tx.wait).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ txHash: RECEIPT.hash, blockNumber: RECEIPT.blockNumber });
   });
+
+  for (const [name, invoke] of networkMismatchCases) {
+    test(`${name} should reject signer network mismatches`, async () => {
+      const { sdk, connect } = makeSdkUnit();
+      const { signer, provider } = makeBuyerSigner();
+      provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+      await expect(invoke(sdk, signer)).rejects.toThrow('wrong network');
+      expect(connect).not.toHaveBeenCalled();
+    });
+  }
 });
 
 describeIntegration('BuyerSDK integration smoke', () => {

--- a/sdk/tests/oracleSDK.test.ts
+++ b/sdk/tests/oracleSDK.test.ts
@@ -3,9 +3,133 @@
  */
 import { OracleSDK } from '../src/modules/oracleSDK';
 import type { ethers } from 'ethers';
+import { AuthorizationError } from '../src/types/errors';
 import { TEST_CONFIG, assertRequiredEnv, getOracleSigner, hasRequiredEnv } from './setup';
 
 const describeIntegration = hasRequiredEnv ? describe : describe.skip;
+const UNIT_CONFIG = {
+  rpc: 'http://127.0.0.1:8545',
+  chainId: 31337,
+  escrowAddress: '0x1000000000000000000000000000000000000001',
+  usdcAddress: '0x2000000000000000000000000000000000000002',
+};
+const RECEIPT = {
+  hash: `0x${'4'.repeat(64)}`,
+  blockNumber: 789,
+};
+
+type MockContractWithSigner = {
+  releaseFundsStage1: jest.Mock;
+  confirmArrival: jest.Mock;
+  finalizeAfterDisputeWindow: jest.Mock;
+};
+
+type OracleSignerLike = Pick<ethers.Signer, 'getAddress' | 'provider'>;
+type OracleSdkContract = OracleSDK['contract'];
+type OracleContractConnector = Pick<OracleSdkContract, 'connect'>;
+
+function makeOracleSigner(address = '0x1111111111111111111111111111111111111111'): {
+  signer: ethers.Signer;
+  provider: { getNetwork: jest.Mock };
+} {
+  const provider = {
+    getNetwork: jest.fn().mockResolvedValue({ chainId: 31337n }),
+  };
+  const signer: OracleSignerLike = {
+    getAddress: jest.fn().mockResolvedValue(address),
+    provider: provider as unknown as ethers.Signer['provider'],
+  };
+
+  return {
+    signer: signer as unknown as ethers.Signer,
+    provider,
+  };
+}
+
+function makeSdkUnit(authorizedOracle = '0x1111111111111111111111111111111111111111') {
+  const sdk = new OracleSDK(UNIT_CONFIG);
+  const contractWithSigner: MockContractWithSigner = {
+    releaseFundsStage1: jest.fn(),
+    confirmArrival: jest.fn(),
+    finalizeAfterDisputeWindow: jest.fn(),
+  };
+  const connect = jest.fn().mockReturnValue(contractWithSigner);
+  (sdk as unknown as { contract: OracleContractConnector }).contract = {
+    connect,
+  } as unknown as OracleContractConnector;
+  jest.spyOn(sdk, 'getOracleAddress').mockResolvedValue(authorizedOracle);
+
+  return { sdk, contractWithSigner, connect };
+}
+
+function mockSuccessCall(mock: jest.Mock) {
+  const tx = {
+    wait: jest.fn().mockResolvedValue(RECEIPT),
+  };
+  mock.mockResolvedValue(tx);
+  return tx;
+}
+
+describe('OracleSDK unit', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('releaseFundsStage1 should call contract and return tx result', async () => {
+    const { sdk, contractWithSigner, connect } = makeSdkUnit();
+    const { signer } = makeOracleSigner();
+    const tx = mockSuccessCall(contractWithSigner.releaseFundsStage1);
+
+    const result = await sdk.releaseFundsStage1(2n, signer);
+
+    expect(connect).toHaveBeenCalledWith(signer);
+    expect(contractWithSigner.releaseFundsStage1).toHaveBeenCalledWith(2n);
+    expect(tx.wait).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ txHash: RECEIPT.hash, blockNumber: RECEIPT.blockNumber });
+  });
+
+  test('confirmArrival should reject unauthorized oracle signer', async () => {
+    const { sdk, connect } = makeSdkUnit('0x2222222222222222222222222222222222222222');
+    const { signer } = makeOracleSigner();
+
+    await expect(sdk.confirmArrival(3n, signer)).rejects.toBeInstanceOf(AuthorizationError);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  test('releaseFundsStage1 should reject signer network mismatches before oracle verification', async () => {
+    const { sdk, connect } = makeSdkUnit();
+    const { signer, provider } = makeOracleSigner();
+    provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.releaseFundsStage1(2n, signer)).rejects.toThrow('wrong network');
+    expect(sdk.getOracleAddress).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  test('finalizeAfterDisputeWindow should call contract without oracle authorization', async () => {
+    const { sdk, contractWithSigner, connect } = makeSdkUnit();
+    const { signer } = makeOracleSigner('0x3333333333333333333333333333333333333333');
+    const tx = mockSuccessCall(contractWithSigner.finalizeAfterDisputeWindow);
+
+    const result = await sdk.finalizeAfterDisputeWindow(4n, signer);
+
+    expect(connect).toHaveBeenCalledWith(signer);
+    expect(contractWithSigner.finalizeAfterDisputeWindow).toHaveBeenCalledWith(4n);
+    expect(tx.wait).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ txHash: RECEIPT.hash, blockNumber: RECEIPT.blockNumber });
+    expect(sdk.getOracleAddress).not.toHaveBeenCalled();
+  });
+
+  test('finalizeAfterDisputeWindow should reject signer network mismatches', async () => {
+    const { sdk, connect } = makeSdkUnit();
+    const { signer, provider } = makeOracleSigner();
+    provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.finalizeAfterDisputeWindow(4n, signer)).rejects.toThrow('wrong network');
+    expect(sdk.getOracleAddress).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+});
 
 describeIntegration('OracleSDK', () => {
   let oracleSDK: OracleSDK;


### PR DESCRIPTION
## Summary

This PR addresses two audit findings across contracts/ and sdk/.

  - On the contract side, it tightens governance safety by enforcing a minimum admin count of 2 and renames the UnpauseApproved event field from requiredApprovals to governanceApprovals for consistency. Oracle rotation, admin addition, and treasury payout rotation all refuse to proceed unless admins.length >= governanceApprovals(), so with 1 admin, those actions would be impossible. 

  - On the SDK side, it hardens all mutating flows by enforcing signer chain validation before transactions are submitted, instead of only checking selected paths. It also makes governance proposal responses consistent by returning proposalId.
