### PR TITLE
fix(ci): stabilize brace-expansion dependency gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
       "axios": "1.15.0"
     },
     "brace-expansion@^1.1.7": "1.1.14",
-    "brace-expansion@>=2 <2.0.3": "2.0.3",
+    "brace-expansion@^2.0.1": "2.1.0",
+    "brace-expansion@^2.0.2": "2.1.0",
     "brace-expansion@>=4 <5.0.5": "5.0.5",
     "hardhat": "2.28.6",
     "@nomicfoundation/hardhat-ethers": "3.1.3",


### PR DESCRIPTION
## Summary
Fixes the post-merge `ci/dependency-security` failure on `main` after #452.

The failing main run reported:

- `npm ls --all: exit=1`
- `invalid: brace-expansion@2.1.0 /node_modules/glob/node_modules/brace-expansion`

The existing override targeted an artificial version interval instead of the actual transitive dependency ranges. This update pins the real 2.x ranges used by minimatch/glob to `brace-expansion@2.1.0`, matching the lockfile and making `npm ls --all` valid under Node 20/npm 10.

## Validation
Runtime: Node 20.20.2 / npm 10.8.2.

- `npm install --package-lock-only`
- `npm ci`
- `npm ls --all`
- `npm run security:deps:gate`
- `npx prettier --check --ignore-unknown package.json package-lock.json`
- `git diff --check`

## Scope
CI/dependency-gate metadata only. No runtime code, auth code, contract logic, or lockfile churn.

Follow-up to #452.
