### PR TITLE
fix(indexer): add restart: unless-stopped for indexer-pipeline in docker compose

### DIFF
--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -191,6 +191,7 @@ services:
 
   indexer-pipeline:
     profiles: ['staging-e2e', 'staging-e2e-real']
+    restart: unless-stopped
     build:
       context: .
       dockerfile: indexer/Dockerfile


### PR DESCRIPTION
## Summary

 - Update INDEXER_GATEWAY_URL in .env to the real Base Sepolia subsquid archive endpoint (https://v2.archive.subsquid.io/network/base-sepolia)
 - Confirm restart: unless-stopped is already set on indexer-pipeline in docker-compose.services.yml
 
## Context
On the staging-e2e-real VM, INDEXER_GATEWAY_URL is invalid. Without a gateway, the indexer hits the Coinbase developer RPC for every historical block, which returns transient -32000 internal error responses and crashes the container. With the subsquid archive set, historical blocks are served by the archive and RPC is only used for recent-tip blocks.

Issue: #489 