### PR TITLE
fix(gateway): scope settlement ingress guard

### DIFF
--- a/gateway/src/routes/settlement.ts
+++ b/gateway/src/routes/settlement.ts
@@ -157,7 +157,7 @@ export function createSettlementRouter(options: SettlementRouterOptions): Router
     consumeNonce: options.nonceStore.consume.bind(options.nonceStore),
   });
 
-  router.use((req, _res, next) => {
+  router.use('/settlement', (req, _res, next) => {
     if (!options.config.settlementIngressEnabled) {
       next(
         new GatewayError(403, 'FORBIDDEN', 'Settlement ingress is disabled', {
@@ -170,7 +170,7 @@ export function createSettlementRouter(options: SettlementRouterOptions): Router
     next();
   });
 
-  router.use(serviceAuth);
+  router.use('/settlement', serviceAuth);
 
   router.post('/settlement/handoffs', idempotency, (req, res, next) =>
     handleRequest(

--- a/gateway/tests/settlementRoutes.contract.test.ts
+++ b/gateway/tests/settlementRoutes.contract.test.ts
@@ -73,6 +73,9 @@ async function startServer(overrides: Partial<GatewayConfig> = {}) {
       ),
     }),
   );
+  router.get('/after-settlement', (_req, res) => {
+    res.status(200).json({ success: true });
+  });
 
   const app = createApp(runtimeConfig, {
     version: '0.1.0',
@@ -159,6 +162,20 @@ describe('gateway settlement routes contract', () => {
       expect(response.status).toBe(403);
       expect(payload.error.code).toBe('FORBIDDEN');
       expect(payload.error.details.reason).toBe('settlement_ingress_disabled');
+    } finally {
+      server.close();
+    }
+  });
+
+  test('settlement ingress disabled does not block later non-settlement routes', async () => {
+    const { server, baseUrl } = await startServer({ settlementIngressEnabled: false });
+
+    try {
+      const response = await fetch(`${baseUrl}/after-settlement`);
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.success).toBe(true);
     } finally {
       server.close();
     }


### PR DESCRIPTION
## Summary

Fixes the gateway route guard that made Dash preflight fail on `/overview` and `/operations/summary`.

The settlement ingress middleware was mounted without a path prefix, so when `GATEWAY_SETTLEMENT_INGRESS_ENABLED=false` it also rejected routes mounted after settlement. This scoped the guard and service-auth middleware to `/settlement/*` only.

## Validation

- `npm run test --workspace gateway -- settlementRoutes.contract.test.ts`
- `npx prettier --check gateway/src/routes/settlement.ts gateway/tests/settlementRoutes.contract.test.ts`

## Context

This unblocks the remaining Cotsel-Dash #167 preflight failures after the staging operator session was provisioned with treasury capabilities and signer bindings.
