### PR TITLE
fix(scripts): correct trusted session exchange URL

### DIFF
--- a/scripts/tests/trusted-dashboard-session.test.mjs
+++ b/scripts/tests/trusted-dashboard-session.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { createServer } from 'node:http';
 import path from 'node:path';
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..');
@@ -30,6 +31,107 @@ test('trusted dashboard session helper fails closed without service-auth keys', 
   );
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /No active trusted session exchange API key is available/u);
+  assert.match(result.stderr, /Missing required TRUSTED_SESSION_EXCHANGE_API_KEYS_JSON/u);
   assert.doesNotMatch(result.stdout, /sessionId/u);
+});
+
+function spawnNode(args, options) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, options);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+test('trusted dashboard session helper posts to the versioned agroasys exchange route', async () => {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let rawBody = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      rawBody += chunk;
+    });
+    req.on('end', () => {
+      requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: rawBody,
+      });
+
+      if (req.method !== 'POST' || req.url !== '/api/auth/v1/session/exchange/agroasys') {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'unexpected route' }));
+        return;
+      }
+
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          success: true,
+          data: {
+            sessionId: 'test-session-id',
+            expiresAt: 1777486223,
+          },
+        }),
+      );
+    });
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert(address && typeof address !== 'string');
+
+    const result = await spawnNode(
+      [
+        'scripts/trusted-dashboard-session.mjs',
+        '--auth-base-url',
+        `http://127.0.0.1:${address.port}/api/auth/v1`,
+        '--account-id',
+        'demo-admin-001',
+        '--role',
+        'admin',
+        '--wallet-address',
+        '0x4beB8eeEC8dA57CaB76D2cAFD27Af6dFA22f972a',
+        '--profile-file',
+        '.env.missing-for-test',
+        '--output',
+        '/tmp/cotsel-dashboard-session-test.json',
+      ],
+      {
+        cwd: ROOT_DIR,
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          TRUSTED_SESSION_EXCHANGE_API_KEYS_JSON:
+            '[{"id":"test-key","secret":"test-secret","active":true}]',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].method, 'POST');
+    assert.equal(requests[0].url, '/api/auth/v1/session/exchange/agroasys');
+    assert.equal(requests[0].headers['x-api-key'], 'test-key');
+    assert.match(result.stdout, /test-ses/);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 });

--- a/scripts/trusted-dashboard-session.mjs
+++ b/scripts/trusted-dashboard-session.mjs
@@ -34,10 +34,10 @@ const SENSITIVE_KEY_PATTERN_SOURCE =
   '(?:token|access_token|refresh_token|api[_-]?key|secret|password|authorization|session(?:[_-]?id)?)';
 // 16 random bytes = 128-bit nonce baseline for signed request uniqueness.
 const NONCE_BYTES = 16;
-const DEFAULT_TRUSTED_SESSION_EXCHANGE_PATH = 'session/exchange/agrosys';
+const DEFAULT_TRUSTED_SESSION_EXCHANGE_PATH = 'session/exchange/agroasys';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const DEFAULT_AUTH_BASE_URL = 'https://cotsel.sys.agrosys.com/api/auth/v1';
-const DEFAULT_PROFILE_FILE = '.env.staging-e2e-integration';
+const DEFAULT_AUTH_BASE_URL = 'https://cotsel.sys.agroasys.com/api/auth/v1';
+const DEFAULT_PROFILE_FILE = '.env.staging-e2e-real';
 
 function fail(message) {
   console.error(`ERROR: ${message}`);
@@ -132,7 +132,8 @@ function loadRuntimeEnv(profileFile) {
 }
 
 function buildUrl(baseUrl, pathname) {
-  const url = new URL(pathname, baseUrl);
+  const base = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  const url = new URL(pathname.replace(/^\/+/u, ''), base);
   return {
     href: url.toString(),
     pathname: url.pathname,


### PR DESCRIPTION
## Summary

Fixes the trusted dashboard session helper so it targets the deployed Cotsel auth exchange route:

- corrects `agrosys` to `agroasys`
- uses `/session/exchange/agroasys`
- preserves `/api/auth/v1` when `--auth-base-url` is passed without a trailing slash
- defaults the profile file to `.env.staging-e2e-real`

## Validation

- `node --test scripts/tests/trusted-dashboard-session.test.mjs`
- `npx prettier --check scripts/trusted-dashboard-session.mjs scripts/tests/trusted-dashboard-session.test.mjs`
- `npx eslint --max-warnings=0 scripts/trusted-dashboard-session.mjs scripts/tests/trusted-dashboard-session.test.mjs`

## Context

This fixes the staging helper failure where `npm run dashboard:trusted-session` called the wrong path (`/api/auth/session/exchange/agrosys`) instead of the live route (`/api/auth/v1/session/exchange/agroasys`).
