### PR TITLE
Stage 6: add gasless settlement SDK helpers

### DIFF
--- a/docs/runbooks/buyer-lock-payload.md
+++ b/docs/runbooks/buyer-lock-payload.md
@@ -1,18 +1,21 @@
 # Buyer Lock Payload — Checkout UI Integration Guide
 
-This document is the reference for external checkout UIs that
-integrate with `BuyerSDK.createTrade(...)`.
+This document is the reference for external checkout UIs that generate typed
+settlement authorizations with `BuyerSDK`.
 
 **Relevant SDK type:** `BuyerLockPayload` (`sdk/src/types/trade.ts`)
 **Backward-compatible alias:** `TradeParameters`
-**Entry point method:** `BuyerSDK.createTrade(payload, buyerSigner)`
+**Primary entry point method:** `BuyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, input)`
+**Legacy compatibility method:** `BuyerSDK.createTrade(payload, buyerSigner)`
 
 ## Overview
 
 When a buyer initiates settlement on the Agroasys platform, the checkout UI
-must assemble a `BuyerLockPayload` and pass it to `BuyerSDK.createTrade(...)`.
-The SDK validates the payload, handles the USDC approval if needed, derives the
-nonce, constructs the EIP-191 signature, and submits the lock transaction.
+must assemble a `BuyerLockPayload` and pass it to
+`BuyerSDK.createGaslessTradeExecutionRequest(...)`. The SDK validates the
+payload, derives the on-chain authorization nonce, builds the escrow EIP-712
+create-trade authorization, builds the USDC receive-with-authorization payload,
+and returns a gateway-ready gasless execution request.
 
 The checkout UI is responsible for:
 
@@ -20,7 +23,9 @@ The checkout UI is responsible for:
    `createTrade`.
 2. Decomposing the trade value into its four canonical amount components.
 3. Providing the supplier's wallet address.
-4. Optionally setting a `deadline`.
+4. Providing the Cotsel settlement `handoffId`.
+5. Setting a short `expiresAt` timestamp for the gasless execution request.
+6. Optionally setting a signature `deadline`.
 
 ## Canonical Payload Shape
 
@@ -79,7 +84,7 @@ The nonce is **not** part of `BuyerLockPayload`. The SDK derives the current
 per-buyer on-chain nonce automatically:
 
 ```ts
-const nonce = await this.getBuyerNonce(buyerAddress);
+const nonce = await this.getAuthorizationNonce(buyerAddress);
 ```
 
 Checkout UIs MUST NOT pass a nonce.
@@ -98,15 +103,33 @@ the canonical contract is unambiguous across SDK docs and examples.
 const deadline = payload.deadline ?? Math.floor(Date.now() / 1000) + 3600;
 ```
 
-## USDC Approval
+## Gasless USDC Funding
 
-The SDK checks the buyer's current USDC allowance for the escrow contract
-before signing. If `allowance < totalAmount`, it automatically issues an
-`approve` transaction:
+The primary path uses USDC EIP-3009 `receiveWithAuthorization`. The buyer signs
+a typed USDC authorization and the relayer submits it with the escrow
+create-trade authorization. The buyer does not need native gas for deposit.
+
+```ts
+const request = await buyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, {
+  handoffId: 'handoff-from-cotsel-gateway',
+  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+});
+```
+
+The returned request contains stringified amounts and a `payloadHash` that the
+Cotsel gateway recomputes before relaying.
+
+## Legacy Direct Mode
+
+`BuyerSDK.createTrade(...)` remains for compatibility only. It checks the
+buyer's current USDC allowance for the escrow contract before signing. If
+`allowance < totalAmount`, it automatically issues an `approve` transaction:
 
 ```ts
 await usdcContract.approve(escrowAddress, payload.totalAmount);
 ```
 
 Checkout UIs do **not** need to call `approveUSDC` separately; `createTrade`
-handles this transparently.
+handles this transparently. This mode still requires the buyer signer to pay gas
+for approval and settlement submission, so it is not the recommended production
+path for non-technical buyers.

--- a/docs/runbooks/demo/community-demo-script.md
+++ b/docs/runbooks/demo/community-demo-script.md
@@ -92,12 +92,16 @@ const tradeParams = {
   ricardianHash: 'ricardian-hash',
 };
 
-const trade = await buyerSDK.createTrade(tradeParams, buyerSigner);
+const gaslessRequest = await buyerSDK.createGaslessTradeExecutionRequest(tradeParams, buyerSigner, {
+  handoffId: 'demo-handoff-id',
+  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+});
 ```
 
 **Show:**
 
-- `TradeLocked` event emitted on-chain.
+- Buyer signs typed authorizations; the relayer submits the gasless request.
+- `TradeLocked` event emitted on-chain after relayer submission.
 - Trade status transitions to `LOCKED`.
 - Escrow balance increases by 10,000 USDC.
 - Buyer balance decreases by 10,000 USDC.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,7 +8,7 @@ This SDK provides a **type-safe, role-based interface** to the Agroasys smart co
 
 The SDK is organized into **three role-based modules**:
 
-- **BuyerSDK** - Create trades, approve USDC, open disputes, and claim settled balances
+- **BuyerSDK** - Create gasless settlement authorization packages, approve USDC in legacy mode, and open/refund/cancel buyer actions
 - **OracleSDK** - Release funds at logistics milestones, confirm arrival, finalize trade (**Auth verification**)
 - **AdminSDK** - Solve frozen trades, operate protocol controls, manage treasury payout governance, and propose/approve/execute governance actions (**Auth verification**)
 
@@ -73,7 +73,10 @@ const payload: BuyerLockPayload = {
   ricardianHash: ''
 };
 
-const result = await buyerSDK.createTrade(payload, buyerSigner);
+const request = await buyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, {
+  handoffId: '',
+  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+});
 ```
 
 ### Recommended: external Agroasys-managed signer
@@ -102,7 +105,10 @@ const payload: BuyerLockPayload = {
   ricardianHash: '0x3a4b5c6d...f1e2d3',
 };
 
-const result = await buyerSDK.createTrade(payload, buyerSigner);
+const request = await buyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, {
+  handoffId: 'handoff-from-cotsel-gateway',
+  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+});
 ```
 
 Canonical buyer lock payload contract:
@@ -110,6 +116,62 @@ Canonical buyer lock payload contract:
 - `BuyerLockPayload` is the preferred public type for new integrations.
 - `TradeParameters` remains available as a backward-compatible alias.
 - Source of truth: `docs/runbooks/buyer-lock-payload.md`
+
+### Recommended: gasless settlement execution
+
+New integrations should ask the buyer signer for typed authorizations only, then
+submit the generated package to the Cotsel gasless execution service from a
+server-side caller. The buyer does not need native gas for the create-trade,
+dispute, lock-timeout cancel, in-transit refund, or dispute-window finalization
+paths.
+
+Buyer and supplier `claim()` flows are not exposed because active settlement
+versions transfer buyer refunds and supplier payouts directly. Treasury sweeps
+remain explicit through `AdminSDK.claimTreasury(...)`.
+
+```ts
+import { BuyerSDK, GaslessSettlementClient, SponsoredAction } from '@agroasys/sdk';
+
+const buyerSDK = new BuyerSDK(config);
+const gaslessClient = new GaslessSettlementClient(config);
+
+const createTradeRequest = await buyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, {
+  handoffId: 'handoff-from-cotsel-gateway',
+  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+});
+
+await gaslessClient.submitCreateTradeExecution(createTradeRequest, {
+  baseUrl: process.env.COTSEL_GATEWAY_URL!,
+  idempotencyKey: 'stable-order-or-handoff-key',
+  serviceAuth: {
+    apiKey: process.env.COTSEL_SERVICE_API_KEY!,
+    apiSecret: process.env.COTSEL_SERVICE_API_SECRET!,
+  },
+});
+
+const refundRequest = await buyerSDK.createGaslessUserActionExecutionRequest(
+  SponsoredAction.REFUND_IN_TRANSIT_TIMEOUT,
+  tradeId,
+  buyerSigner,
+  {
+    handoffId: 'handoff-from-cotsel-gateway',
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+  },
+);
+
+await gaslessClient.submitUserActionExecution(refundRequest, {
+  baseUrl: process.env.COTSEL_GATEWAY_URL!,
+  idempotencyKey: 'stable-user-action-key',
+  serviceAuth: {
+    apiKey: process.env.COTSEL_SERVICE_API_KEY!,
+    apiSecret: process.env.COTSEL_SERVICE_API_SECRET!,
+  },
+});
+```
+
+Keep service-auth API secrets on the backend only. Browser/frontend callers
+should generate typed authorizations with the buyer signer, then hand those
+authorization packages to a trusted backend for submission.
 
 ### Embedded-wallet / Web3Auth compatibility contract
 
@@ -154,16 +216,18 @@ SDK and inject a signer instead.
 
 ### BuyerSDK
 
-| Method                                           | Description                                       |
-| ------------------------------------------------ | ------------------------------------------------- |
-| `getBuyerNonce(address)`                         | Retrieve the current nonce for signature          |
-| `approveUSDC(amount, signer)`                    | Approve the escrow contract to spend USDC         |
-| `getUSDCBalance(address)`                        | Check USDC balance                                |
-| `getUSDCAllowance(address)`                      | Check current USDC allowance for escrow           |
-| `createTrade(params, signer)`                    | Lock funds and create a new trade                 |
-| `openDispute(tradeId, signer)`                   | Open a dispute on an existing trade               |
-| `cancelLockedTradeAfterTimeout(tradeId, signer)` | Cancel stale `LOCKED` trade after timeout         |
-| `refundInTransitAfterTimeout(tradeId, signer)`   | Refund remaining principal when transit times out |
+| Method                                                                    | Description                                             |
+| ------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `getBuyerNonce(address)`                                                  | Retrieve the current nonce for signature                |
+| `approveUSDC(amount, signer)`                                             | Approve the escrow contract to spend USDC               |
+| `getUSDCBalance(address)`                                                 | Check USDC balance                                      |
+| `getUSDCAllowance(address)`                                               | Check current USDC allowance for escrow                 |
+| `createGaslessTradeExecutionRequest(params, signer, input)`               | Build typed create-trade and USDC authorization package |
+| `createGaslessUserActionExecutionRequest(action, tradeId, signer, input)` | Build typed dispute/refund/cancel/finalize package      |
+| `createTrade(params, signer)`                                             | Legacy direct-send create-trade flow                    |
+| `openDispute(tradeId, signer)`                                            | Open a dispute on an existing trade                     |
+| `cancelLockedTradeAfterTimeout(tradeId, signer)`                          | Cancel stale `LOCKED` trade after timeout               |
+| `refundInTransitAfterTimeout(tradeId, signer)`                            | Refund remaining principal when transit times out       |
 
 ### OracleSDK
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -8,6 +8,11 @@ export { OracleSDK } from './modules/oracleSDK';
 
 // ricardian helper
 export { RicardianClient } from './modules/ricardianClient';
+export {
+  GaslessSettlementClient,
+  createGaslessExecutionPayloadHash,
+  sponsoredActionToGaslessAction,
+} from './modules/gaslessSettlementClient';
 export { projectTreasuryAccountingState } from './modules/treasuryAccounting';
 export type {
   TreasuryAccountingProjection,

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -5,7 +5,9 @@ import { Client } from '../client';
 import {
   BuyerLockPayload,
   GaslessCreateTradeAuthorization,
+  GaslessCreateTradeExecutionRequest,
   GaslessUserActionAuthorization,
+  GaslessUserActionExecutionRequest,
   SponsoredAction,
   TradeResult,
   UsdcReceiveAuthorization,
@@ -20,8 +22,14 @@ import {
 } from '../utils/signature';
 import { ContractError, getErrorMessage } from '../types/errors';
 import { IERC20__factory } from '../types/typechain-types/factories/@openzeppelin/contracts/token/ERC20/IERC20__factory';
+import { GaslessSettlementClient } from './gaslessSettlementClient';
 
 export class BuyerSDK extends Client {
+  private readonly gaslessSettlementClient = new GaslessSettlementClient({
+    chainId: this.config.chainId,
+    escrowAddress: this.config.escrowAddress,
+  });
+
   private extractTradeIdFromReceipt(receipt: ethers.TransactionReceipt): string | undefined {
     for (const log of receipt.logs) {
       if (log.address.toLowerCase() !== this.config.escrowAddress.toLowerCase()) {
@@ -99,6 +107,36 @@ export class BuyerSDK extends Client {
     });
   }
 
+  async createGaslessTradeExecutionRequest(
+    payload: BuyerLockPayload,
+    buyerSigner: ethers.Signer,
+    input: {
+      handoffId: string;
+      expiresAt: string | Date;
+      usdc?: {
+        validAfter?: number;
+        validBefore?: number;
+        nonce?: string;
+        tokenName?: string;
+        tokenVersion?: string;
+      };
+    },
+  ): Promise<GaslessCreateTradeExecutionRequest> {
+    const authorization = await this.createGaslessTradeAuthorization(payload, buyerSigner);
+    const usdcAuthorization = await this.createUsdcReceiveAuthorization(
+      payload.totalAmount,
+      buyerSigner,
+      input.usdc,
+    );
+
+    return this.gaslessSettlementClient.buildCreateTradeExecutionRequest({
+      handoffId: input.handoffId,
+      expiresAt: input.expiresAt,
+      authorization,
+      usdcAuthorization,
+    });
+  }
+
   async createGaslessUserActionAuthorization(
     action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>,
     tradeId: string | bigint,
@@ -118,6 +156,31 @@ export class BuyerSDK extends Client {
       nonce,
       deadline,
     );
+  }
+
+  async createGaslessUserActionExecutionRequest(
+    action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>,
+    tradeId: string | bigint,
+    buyerSigner: ethers.Signer,
+    input: {
+      handoffId: string;
+      expiresAt: string | Date;
+      deadline?: number;
+    },
+  ): Promise<GaslessUserActionExecutionRequest> {
+    const authorization = await this.createGaslessUserActionAuthorization(
+      action,
+      tradeId,
+      buyerSigner,
+      input.deadline,
+    );
+
+    return this.gaslessSettlementClient.buildUserActionExecutionRequest({
+      action,
+      handoffId: input.handoffId,
+      expiresAt: input.expiresAt,
+      authorization,
+    });
   }
 
   async approveUSDC(amount: bigint, buyerSigner: ethers.Signer): Promise<TradeResult> {
@@ -180,8 +243,9 @@ export class BuyerSDK extends Client {
   /**
    * Lock funds and create a new trade in the escrow contract.
    *
-   * This is the primary entry point for external checkout UIs. The `payload`
-   * parameter MUST conform to the {@link BuyerLockPayload} canonical contract.
+   * @deprecated Prefer `createGaslessTradeExecutionRequest(...)` for production
+   * integrations. This legacy compatibility method requires the buyer signer to
+   * pay gas for approval and settlement submission.
    *
    * **Flow executed by this method:**
    * 1. Validates every field in `payload` (amount invariant, address, hash format).

--- a/sdk/src/modules/gaslessSettlementClient.ts
+++ b/sdk/src/modules/gaslessSettlementClient.ts
@@ -1,0 +1,289 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { getAddress, keccak256, toUtf8Bytes } from 'ethers';
+import { createServiceAuthHeaders } from './serviceAuth';
+import {
+  GaslessCreateTradeAuthorization,
+  GaslessCreateTradeExecutionRequest,
+  GaslessExecutionResponseEnvelope,
+  GaslessExecutionSubmitOptions,
+  GaslessExecutionUsdcAuthorizationFields,
+  GaslessUserAction,
+  GaslessUserActionAuthorization,
+  GaslessUserActionExecutionRequest,
+  SponsoredAction,
+  UsdcReceiveAuthorization,
+} from '../types/trade';
+import { getErrorMessage, ValidationError } from '../types/errors';
+
+type GaslessCreateTradeHashable = Omit<GaslessCreateTradeExecutionRequest, 'payloadHash'>;
+type GaslessUserActionHashable = Omit<GaslessUserActionExecutionRequest, 'payloadHash'>;
+
+export interface GaslessSettlementRuntimeConfig {
+  chainId: number;
+  escrowAddress: string;
+}
+
+export interface GaslessCreateTradeExecutionInput {
+  handoffId: string;
+  expiresAt: string | Date;
+  authorization: GaslessCreateTradeAuthorization;
+  usdcAuthorization: UsdcReceiveAuthorization;
+}
+
+export interface GaslessUserActionExecutionInput {
+  handoffId: string;
+  expiresAt: string | Date;
+  action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>;
+  authorization: GaslessUserActionAuthorization;
+}
+
+export function sponsoredActionToGaslessAction(
+  action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>,
+): GaslessUserAction {
+  switch (action) {
+    case SponsoredAction.OPEN_DISPUTE:
+      return 'open_dispute';
+    case SponsoredAction.CANCEL_LOCKED_TIMEOUT:
+      return 'cancel_locked_timeout';
+    case SponsoredAction.REFUND_IN_TRANSIT_TIMEOUT:
+      return 'refund_in_transit_timeout';
+    case SponsoredAction.FINALIZE_AFTER_DISPUTE_WINDOW:
+      return 'finalize_after_dispute_window';
+    default:
+      throw new ValidationError('Unsupported gasless user action', { action });
+  }
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(',')}}`;
+}
+
+export function createGaslessExecutionPayloadHash(
+  input: GaslessCreateTradeHashable | GaslessUserActionHashable,
+): string {
+  return keccak256(toUtf8Bytes(stableJson(input)));
+}
+
+function normalizeExpiry(expiresAt: string | Date): string {
+  const date = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) {
+    throw new ValidationError('expiresAt must be a valid ISO-8601 timestamp');
+  }
+
+  return date.toISOString();
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ValidationError(`${field} must be a non-empty string`, { field });
+  }
+
+  return trimmed;
+}
+
+function stringAmount(value: bigint): string {
+  return value.toString();
+}
+
+function createAuthorizationFields(authorization: {
+  nonce: bigint;
+  deadline: number;
+  signature: string;
+}) {
+  return {
+    nonce: stringAmount(authorization.nonce),
+    deadline: String(authorization.deadline),
+    signature: authorization.signature,
+  };
+}
+
+function createUsdcAuthorizationFields(
+  authorization: UsdcReceiveAuthorization,
+): GaslessExecutionUsdcAuthorizationFields {
+  return {
+    from: getAddress(authorization.from),
+    to: getAddress(authorization.to),
+    value: stringAmount(authorization.value),
+    validAfter: String(authorization.validAfter),
+    validBefore: String(authorization.validBefore),
+    nonce: authorization.nonce,
+    v: authorization.v,
+    r: authorization.r,
+    s: authorization.s,
+  };
+}
+
+function trimBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+function mergeHeaders(...headers: Array<HeadersInit | undefined>): Headers {
+  const result = new Headers();
+
+  for (const headerSet of headers) {
+    if (!headerSet) {
+      continue;
+    }
+
+    new Headers(headerSet).forEach((value, key) => {
+      result.set(key, value);
+    });
+  }
+
+  return result;
+}
+
+async function readJsonEnvelope(response: Response): Promise<GaslessExecutionResponseEnvelope> {
+  try {
+    return (await response.json()) as GaslessExecutionResponseEnvelope;
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    throw new Error(`Gasless execution response was not JSON: ${message}`);
+  }
+}
+
+export class GaslessSettlementClient {
+  constructor(private readonly config: GaslessSettlementRuntimeConfig) {}
+
+  buildCreateTradeExecutionRequest(
+    input: GaslessCreateTradeExecutionInput,
+  ): GaslessCreateTradeExecutionRequest {
+    const buyerAddress = getAddress(input.authorization.buyer);
+    const supplierAddress = getAddress(input.authorization.supplier);
+    const contractAddress = getAddress(this.config.escrowAddress);
+    if (input.usdcAuthorization.value !== input.authorization.totalAmount) {
+      throw new ValidationError('USDC authorization value must match totalAmount', {
+        totalAmount: input.authorization.totalAmount.toString(),
+        usdcAuthorizationValue: input.usdcAuthorization.value.toString(),
+      });
+    }
+    if (getAddress(input.usdcAuthorization.from) !== buyerAddress) {
+      throw new ValidationError('USDC authorization sender must match buyer', {
+        buyerAddress,
+        usdcAuthorizationFrom: input.usdcAuthorization.from,
+      });
+    }
+    if (getAddress(input.usdcAuthorization.to) !== contractAddress) {
+      throw new ValidationError('USDC authorization recipient must match escrow contract', {
+        contractAddress,
+        usdcAuthorizationTo: input.usdcAuthorization.to,
+      });
+    }
+
+    const requestWithoutHash: GaslessCreateTradeHashable = {
+      action: 'create_trade',
+      handoffId: requireNonEmpty(input.handoffId, 'handoffId'),
+      chainId: this.config.chainId,
+      contractAddress,
+      expiresAt: normalizeExpiry(input.expiresAt),
+      buyerAddress,
+      supplierAddress,
+      totalAmount: stringAmount(input.authorization.totalAmount),
+      logisticsAmount: stringAmount(input.authorization.logisticsAmount),
+      platformFeesAmount: stringAmount(input.authorization.platformFeesAmount),
+      supplierFirstTranche: stringAmount(input.authorization.supplierFirstTranche),
+      supplierSecondTranche: stringAmount(input.authorization.supplierSecondTranche),
+      ricardianHash: input.authorization.ricardianHash,
+      buyerAuthorization: createAuthorizationFields(input.authorization),
+      usdcAuthorization: createUsdcAuthorizationFields(input.usdcAuthorization),
+    };
+
+    return {
+      ...requestWithoutHash,
+      payloadHash: createGaslessExecutionPayloadHash(requestWithoutHash),
+    };
+  }
+
+  buildUserActionExecutionRequest(
+    input: GaslessUserActionExecutionInput,
+  ): GaslessUserActionExecutionRequest {
+    const requestWithoutHash: GaslessUserActionHashable = {
+      action: sponsoredActionToGaslessAction(input.action),
+      handoffId: requireNonEmpty(input.handoffId, 'handoffId'),
+      chainId: this.config.chainId,
+      contractAddress: getAddress(this.config.escrowAddress),
+      expiresAt: normalizeExpiry(input.expiresAt),
+      userAddress: getAddress(input.authorization.user),
+      tradeId: stringAmount(input.authorization.tradeId),
+      userAuthorization: createAuthorizationFields(input.authorization),
+    };
+
+    return {
+      ...requestWithoutHash,
+      payloadHash: createGaslessExecutionPayloadHash(requestWithoutHash),
+    };
+  }
+
+  async submitCreateTradeExecution<T = unknown>(
+    request: GaslessCreateTradeExecutionRequest,
+    options: GaslessExecutionSubmitOptions,
+  ): Promise<T> {
+    return this.submit('/settlement/gasless-executions/create-trade', request, options);
+  }
+
+  async submitUserActionExecution<T = unknown>(
+    request: GaslessUserActionExecutionRequest,
+    options: GaslessExecutionSubmitOptions,
+  ): Promise<T> {
+    return this.submit('/settlement/gasless-executions/user-action', request, options);
+  }
+
+  private async submit<T>(
+    path: string,
+    request: GaslessCreateTradeExecutionRequest | GaslessUserActionExecutionRequest,
+    options: GaslessExecutionSubmitOptions,
+  ): Promise<T> {
+    const body = JSON.stringify(request);
+    const serviceAuthHeaders: HeadersInit | undefined = options.serviceAuth
+      ? {
+          ...createServiceAuthHeaders({
+            apiKey: options.serviceAuth.apiKey,
+            apiSecret: options.serviceAuth.apiSecret,
+            method: 'POST',
+            path,
+            body,
+            timestamp: options.serviceAuth.timestamp,
+            nonce: options.serviceAuth.nonce,
+          }),
+        }
+      : undefined;
+    const headers = mergeHeaders(
+      { 'Content-Type': 'application/json' },
+      options.headers,
+      serviceAuthHeaders,
+      options.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : undefined,
+    );
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${trimBaseUrl(options.baseUrl)}${path}`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+    const envelope = await readJsonEnvelope(response);
+
+    if (!response.ok || !envelope.success) {
+      throw new Error(
+        envelope.message ||
+          envelope.error ||
+          `Gasless execution request failed (${response.status})`,
+      );
+    }
+
+    return envelope.data as T;
+  }
+}

--- a/sdk/src/modules/gaslessSettlementClient.ts
+++ b/sdk/src/modules/gaslessSettlementClient.ts
@@ -87,7 +87,11 @@ function normalizeExpiry(expiresAt: string | Date): string {
   return date.toISOString();
 }
 
-function requireNonEmpty(value: string, field: string): string {
+function requireNonEmpty(value: string | undefined, field: string): string {
+  if (typeof value !== 'string') {
+    throw new ValidationError(`${field} must be a non-empty string`, { field });
+  }
+
   const trimmed = value.trim();
   if (!trimmed) {
     throw new ValidationError(`${field} must be a non-empty string`, { field });
@@ -249,13 +253,16 @@ export class GaslessSettlementClient {
     options: GaslessExecutionSubmitOptions,
   ): Promise<T> {
     const body = JSON.stringify(request);
+    const endpointUrl = `${trimBaseUrl(options.baseUrl)}${path}`;
+    const signingPath = new URL(endpointUrl).pathname;
+    const idempotencyKey = requireNonEmpty(options.idempotencyKey, 'idempotencyKey');
     const serviceAuthHeaders: HeadersInit | undefined = options.serviceAuth
       ? {
           ...createServiceAuthHeaders({
             apiKey: options.serviceAuth.apiKey,
             apiSecret: options.serviceAuth.apiSecret,
             method: 'POST',
-            path,
+            path: signingPath,
             body,
             timestamp: options.serviceAuth.timestamp,
             nonce: options.serviceAuth.nonce,
@@ -266,10 +273,10 @@ export class GaslessSettlementClient {
       { 'Content-Type': 'application/json' },
       options.headers,
       serviceAuthHeaders,
-      options.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : undefined,
+      { 'Idempotency-Key': idempotencyKey },
     );
     const fetchImpl = options.fetchImpl ?? fetch;
-    const response = await fetchImpl(`${trimBaseUrl(options.baseUrl)}${path}`, {
+    const response = await fetchImpl(endpointUrl, {
       method: 'POST',
       headers,
       body,

--- a/sdk/src/types/trade.ts
+++ b/sdk/src/types/trade.ts
@@ -158,6 +158,82 @@ export interface UsdcReceiveAuthorization {
   s: string;
 }
 
+export type GaslessUserAction =
+  | 'open_dispute'
+  | 'cancel_locked_timeout'
+  | 'refund_in_transit_timeout'
+  | 'finalize_after_dispute_window';
+
+export interface GaslessExecutionAuthorizationFields {
+  nonce: string;
+  deadline: string;
+  signature: string;
+}
+
+export interface GaslessExecutionUsdcAuthorizationFields {
+  from: string;
+  to: string;
+  value: string;
+  validAfter: string;
+  validBefore: string;
+  nonce: string;
+  v: number;
+  r: string;
+  s: string;
+}
+
+export interface GaslessCreateTradeExecutionRequest {
+  action: 'create_trade';
+  handoffId: string;
+  chainId: number;
+  contractAddress: string;
+  expiresAt: string;
+  payloadHash: string;
+  buyerAddress: string;
+  supplierAddress: string;
+  totalAmount: string;
+  logisticsAmount: string;
+  platformFeesAmount: string;
+  supplierFirstTranche: string;
+  supplierSecondTranche: string;
+  ricardianHash: string;
+  buyerAuthorization: GaslessExecutionAuthorizationFields;
+  usdcAuthorization: GaslessExecutionUsdcAuthorizationFields;
+}
+
+export interface GaslessUserActionExecutionRequest {
+  action: GaslessUserAction;
+  handoffId: string;
+  chainId: number;
+  contractAddress: string;
+  expiresAt: string;
+  payloadHash: string;
+  userAddress: string;
+  tradeId: string;
+  userAuthorization: GaslessExecutionAuthorizationFields;
+}
+
+export interface GaslessExecutionSubmitOptions {
+  baseUrl: string;
+  idempotencyKey?: string;
+  headers?: HeadersInit;
+  serviceAuth?: {
+    apiKey: string;
+    apiSecret: string;
+    timestamp?: number;
+    nonce?: string;
+  };
+  fetchImpl?: typeof fetch;
+}
+
+export interface GaslessExecutionResponseEnvelope<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+  timestamp?: string;
+}
+
 export interface TradeResult {
   txHash: string;
   blockNumber: number;

--- a/sdk/src/types/trade.ts
+++ b/sdk/src/types/trade.ts
@@ -215,7 +215,7 @@ export interface GaslessUserActionExecutionRequest {
 
 export interface GaslessExecutionSubmitOptions {
   baseUrl: string;
-  idempotencyKey?: string;
+  idempotencyKey: string;
   headers?: HeadersInit;
   serviceAuth?: {
     apiKey: string;

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -8,6 +8,7 @@ import { IERC20__factory } from '../src/types/typechain-types/factories/@openzep
 import { TEST_CONFIG, assertRequiredEnv, getBuyerSigner, hasRequiredEnv } from './setup';
 import { SponsoredAction } from '../src/types/trade';
 import { GaslessSettlementClient } from '../src/modules/gaslessSettlementClient';
+import { createServiceAuthHeaders } from '../src/modules/serviceAuth';
 
 const describeIntegration = hasRequiredEnv ? describe : describe.skip;
 
@@ -395,7 +396,7 @@ describe('BuyerSDK unit', () => {
     );
 
     const result = await client.submitUserActionExecution<{ txHash: string }>(request, {
-      baseUrl: 'https://cotsel.example',
+      baseUrl: 'https://cotsel.example/api/dashboard-gateway/v1',
       idempotencyKey: 'idem-1',
       serviceAuth: {
         apiKey: 'key-1',
@@ -409,14 +410,50 @@ describe('BuyerSDK unit', () => {
     const headers = init.headers as Headers;
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://cotsel.example/settlement/gasless-executions/user-action',
+      'https://cotsel.example/api/dashboard-gateway/v1/settlement/gasless-executions/user-action',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(headers.get('Content-Type')).toBe('application/json');
     expect(headers.get('Idempotency-Key')).toBe('idem-1');
     expect(headers.get('X-Api-Key')).toBe('key-1');
-    expect(headers.get('X-Signature')).toMatch(/^[a-f0-9]{64}$/);
+    expect(headers.get('X-Signature')).toBe(
+      createServiceAuthHeaders({
+        apiKey: 'key-1',
+        apiSecret: 'secret-1',
+        method: 'POST',
+        path: '/api/dashboard-gateway/v1/settlement/gasless-executions/user-action',
+        body: JSON.stringify(request),
+        timestamp: 123,
+        nonce: 'nonce-1',
+      })['X-Signature'],
+    );
     expect(result).toEqual({ txHash: `0x${'8'.repeat(64)}` });
+  });
+
+  test('GaslessSettlementClient rejects execution submissions without idempotency keys', async () => {
+    const client = new GaslessSettlementClient(UNIT_CONFIG);
+    const request = client.buildUserActionExecutionRequest({
+      action: SponsoredAction.OPEN_DISPUTE,
+      handoffId: 'handoff-4',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      authorization: {
+        user: '0x2222222222222222222222222222222222222222',
+        action: SponsoredAction.OPEN_DISPUTE,
+        tradeId: 77n,
+        nonce: 9n,
+        deadline: 654321,
+        signature: `0x${'4'.repeat(130)}`,
+      },
+    });
+    const fetchImpl = jest.fn();
+
+    await expect(
+      client.submitUserActionExecution(request, {
+        baseUrl: 'https://cotsel.example/api/dashboard-gateway/v1',
+        fetchImpl,
+      } as unknown as Parameters<GaslessSettlementClient['submitUserActionExecution']>[1]),
+    ).rejects.toThrow('idempotencyKey must be a non-empty string');
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   test('createTrade should surface tradeId from TradeLocked receipt logs', async () => {

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -7,6 +7,7 @@ import { Interface } from 'ethers';
 import { IERC20__factory } from '../src/types/typechain-types/factories/@openzeppelin/contracts/token/ERC20/IERC20__factory';
 import { TEST_CONFIG, assertRequiredEnv, getBuyerSigner, hasRequiredEnv } from './setup';
 import { SponsoredAction } from '../src/types/trade';
+import { GaslessSettlementClient } from '../src/modules/gaslessSettlementClient';
 
 const describeIntegration = hasRequiredEnv ? describe : describe.skip;
 
@@ -249,6 +250,173 @@ describe('BuyerSDK unit', () => {
       deadline: 654321,
       signature: `0x${'4'.repeat(130)}`,
     });
+  });
+
+  test('createGaslessTradeExecutionRequest builds gateway-ready authorization package', async () => {
+    const { sdk } = makeSdkUnit();
+    const { signer } = makeBuyerSigner();
+    const signature = `0x${'1'.repeat(64)}${'2'.repeat(64)}1b`;
+    (signer.signTypedData as jest.Mock)
+      .mockResolvedValueOnce(`0x${'4'.repeat(130)}`)
+      .mockResolvedValueOnce(signature);
+
+    const request = await sdk.createGaslessTradeExecutionRequest(
+      {
+        supplier: '0x1111111111111111111111111111111111111111',
+        totalAmount: 1000000n,
+        logisticsAmount: 0n,
+        platformFeesAmount: 0n,
+        supplierFirstTranche: 400000n,
+        supplierSecondTranche: 600000n,
+        ricardianHash: `0x${'a'.repeat(64)}`,
+        deadline: 123456,
+      },
+      signer,
+      {
+        handoffId: 'handoff-1',
+        expiresAt: '2026-06-01T00:00:00.000Z',
+        usdc: {
+          validAfter: 10,
+          validBefore: 20,
+          nonce: `0x${'5'.repeat(64)}`,
+        },
+      },
+    );
+    const { payloadHash, ...hashable } = request;
+
+    expect(request).toMatchObject({
+      action: 'create_trade',
+      handoffId: 'handoff-1',
+      chainId: UNIT_CONFIG.chainId,
+      contractAddress: UNIT_CONFIG.escrowAddress,
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      buyerAddress: '0x2222222222222222222222222222222222222222',
+      supplierAddress: '0x1111111111111111111111111111111111111111',
+      totalAmount: '1000000',
+      buyerAuthorization: {
+        nonce: '9',
+        deadline: '123456',
+        signature: `0x${'4'.repeat(130)}`,
+      },
+      usdcAuthorization: {
+        from: '0x2222222222222222222222222222222222222222',
+        to: UNIT_CONFIG.escrowAddress,
+        value: '1000000',
+        validAfter: '10',
+        validBefore: '20',
+        nonce: `0x${'5'.repeat(64)}`,
+      },
+    });
+    expect(payloadHash).toBe(
+      new GaslessSettlementClient(UNIT_CONFIG).buildCreateTradeExecutionRequest({
+        handoffId: 'handoff-1',
+        expiresAt: '2026-06-01T00:00:00.000Z',
+        authorization: {
+          buyer: hashable.buyerAddress,
+          supplier: hashable.supplierAddress,
+          totalAmount: 1000000n,
+          logisticsAmount: 0n,
+          platformFeesAmount: 0n,
+          supplierFirstTranche: 400000n,
+          supplierSecondTranche: 600000n,
+          ricardianHash: `0x${'a'.repeat(64)}`,
+          nonce: 9n,
+          deadline: 123456,
+          signature: `0x${'4'.repeat(130)}`,
+        },
+        usdcAuthorization: {
+          from: hashable.buyerAddress,
+          to: hashable.contractAddress,
+          value: 1000000n,
+          validAfter: 10,
+          validBefore: 20,
+          nonce: `0x${'5'.repeat(64)}`,
+          signature,
+          v: 27,
+          r: `0x${'1'.repeat(64)}`,
+          s: `0x${'2'.repeat(64)}`,
+        },
+      }).payloadHash,
+    );
+  });
+
+  test('createGaslessUserActionExecutionRequest builds gateway-ready refund action package', async () => {
+    const { sdk } = makeSdkUnit();
+    const { signer } = makeBuyerSigner();
+
+    const request = await sdk.createGaslessUserActionExecutionRequest(
+      SponsoredAction.REFUND_IN_TRANSIT_TIMEOUT,
+      42n,
+      signer,
+      {
+        handoffId: 'handoff-2',
+        expiresAt: new Date('2026-06-01T00:00:00.000Z'),
+        deadline: 654321,
+      },
+    );
+
+    expect(request).toMatchObject({
+      action: 'refund_in_transit_timeout',
+      handoffId: 'handoff-2',
+      chainId: UNIT_CONFIG.chainId,
+      contractAddress: UNIT_CONFIG.escrowAddress,
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      userAddress: '0x2222222222222222222222222222222222222222',
+      tradeId: '42',
+      userAuthorization: {
+        nonce: '9',
+        deadline: '654321',
+        signature: `0x${'4'.repeat(130)}`,
+      },
+    });
+    expect(request.payloadHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+  });
+
+  test('GaslessSettlementClient submits execution requests with service auth and idempotency headers', async () => {
+    const client = new GaslessSettlementClient(UNIT_CONFIG);
+    const request = client.buildUserActionExecutionRequest({
+      action: SponsoredAction.OPEN_DISPUTE,
+      handoffId: 'handoff-3',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      authorization: {
+        user: '0x2222222222222222222222222222222222222222',
+        action: SponsoredAction.OPEN_DISPUTE,
+        tradeId: 77n,
+        nonce: 9n,
+        deadline: 654321,
+        signature: `0x${'4'.repeat(130)}`,
+      },
+    });
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { txHash: `0x${'8'.repeat(64)}` } }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.submitUserActionExecution<{ txHash: string }>(request, {
+      baseUrl: 'https://cotsel.example',
+      idempotencyKey: 'idem-1',
+      serviceAuth: {
+        apiKey: 'key-1',
+        apiSecret: 'secret-1',
+        timestamp: 123,
+        nonce: 'nonce-1',
+      },
+      fetchImpl,
+    });
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://cotsel.example/settlement/gasless-executions/user-action',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('Idempotency-Key')).toBe('idem-1');
+    expect(headers.get('X-Api-Key')).toBe('key-1');
+    expect(headers.get('X-Signature')).toMatch(/^[a-f0-9]{64}$/);
+    expect(result).toEqual({ txHash: `0x${'8'.repeat(64)}` });
   });
 
   test('createTrade should surface tradeId from TradeLocked receipt logs', async () => {


### PR DESCRIPTION
## Summary
- adds public SDK helpers for gateway-ready gasless create-trade execution requests
- adds typed buyer user-action packages for dispute, cancel, refund, and dispute-window finalization
- adds a `GaslessSettlementClient` for Cotsel gateway submission with idempotency and service-auth headers
- updates SDK docs and demo notes so gasless typed authorization is the primary path and direct send is legacy compatibility

## Claim/payout note
Buyer and supplier `claim()` is intentionally not reintroduced in the SDK. Active settlement versions transfer buyer refunds and supplier payouts directly; only treasury sweeping remains explicit through `claimTreasury()`.

## Validation
- `corepack pnpm --filter @agroasys/sdk run typecheck`
- `corepack pnpm --filter @agroasys/sdk run test:buyer`
- `corepack pnpm --filter @agroasys/sdk exec eslint src/modules/buyerSDK.ts src/modules/gaslessSettlementClient.ts src/types/trade.ts tests/buyerSDK.test.ts --max-warnings=0`
- `corepack pnpm --filter @agroasys/sdk run build`
- `corepack pnpm --filter @agroasys/sdk exec prettier --check src/modules/buyerSDK.ts src/modules/gaslessSettlementClient.ts src/types/trade.ts tests/buyerSDK.test.ts README.md ../docs/runbooks/buyer-lock-payload.md ../docs/runbooks/demo/community-demo-script.md`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm --filter @agroasys/sdk test`
- `git diff --check`

Closes #522