### PR TITLE
chore(indexer): regenerate models and refresh setup docs

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -1,219 +1,67 @@
 # Indexer
 
-This module indexes **AgroasysEscrow** EVM logs from **Base Sepolia** and **Base Mainnet** into a queryable PostgreSQL datastore (TypeORM) and exposes a read-only GraphQL API for the rest of the platform.
+Indexes **AgroasysEscrow** events from Base into Postgres (TypeORM) and exposes a read-only GraphQL API.
 
 ---
 
-## What this indexer does
+## Initial setup
 
-### Core responsibilities
+```bash
+# From Cotsel/ (monorepo root)
+pnpm install --frozen-lockfile
 
-- **Ingest escrow contract logs** from the configured Base settlement runtime.
-- **Persist** normalized trade state + event history into Postgres (TypeORM models generated from `schema.graphql`).
-- Provide a **read-only GraphQL interface** for the platform backend to query:
-  - trades, participants, amounts, statuses
-  - settlement milestones
-  - dispute lifecycle and approvals
-  - event timeline / audit trail
-- Ensure indexing is:
-  - **Idempotent** (replays do not duplicate rows or double-count amounts)
-  - **Re-org safe** (EVM log identity is stable and replay-safe)
-  - **Config-driven** (runtime, start block, and finality confirmation come from env/config)
-
-### Events indexed (must match the on-chain contract)
-
-The indexer is expected to capture and store the following escrow events:
-
-- `TradeLocked`
-- `FundsReleasedStage1`
-- `PlatformFeesPaidStage1`
-- `ArrivalConfirmed`
-- `FinalTrancheReleased`
-- `DisputeOpenedByBuyer`
-- `DisputeSolutionProposed`
-- `DisputeApproved`
-- `DisputeFinalized`
-- `OracleUpdateProposed`
-- `OracleUpdateApproved`
-- `OracleUpdated`
-- `AdminAddProposed`
-- `AdminAddApproved`
-- `AdminAdded`
-
-> Note: If the contract changes event names/arguments, update:
->
-> - the ABI/event decoder
-> - `schema.graphql` types
-> - mappings/handlers
-> - this README’s event list
-
----
-
-## Security & correctness requirements
-
-### Configuration rules
-
-- **No hardcoded RPC endpoints** or API keys.
-- Use environment variables (`.env`) and validate configuration at startup.
-- Use **approved/whitelisted endpoints only** (internal RPC or approved providers).
-- Enforce **explicit block range limits** to avoid unbounded historical queries.
-
-### Data integrity rules
-
-- Writes must be **atomic and retry-safe**.
-- Event handlers must:
-  - validate the **expected contract address**
-  - verify the **expected contract address**
-  - decode only the frozen Base-era escrow ABI
-  - enforce **deterministic primary keys** (`txHash + logIndex`) to guarantee idempotency
-
-### Re-org handling
-
-- Must handle chain **re-orgs** using deterministic event identity and configured confirmation depth.
-- Avoid assumptions of immediate finality; active downstream workflow and treasury gates rely on Base `safe` and `finalized` stages.
-
----
-
-## Suggested directory layout
-
-```text
-indexer/
-├── db/
-├── src/
-├── .dockerignore
-├── .env.example
-├── .gitignore
-├── Dockerfile
-├── README.md
-├── docker-compose.yml
-├── package.json
-├── schema.graphql
-├── tsconfig.json
-```
-
-### Validation checklist
-
-- Schema enforces strict types (no any equivalents).
-- Event handlers verify the expected contract address and event types.
-- Inserts/updates are idempotent and replay-safe.
-- Re-org rollback behavior is deterministic and tested.
-- GraphQL is read-only (no mutations).
-- No secrets / endpoints are hardcoded in code.
-
----
-
-### Local Dev
-
-#### Prerequisites
-
-- Node.js + npm
-- Docker + Docker Compose
-- A reachable Base RPC endpoint for the target environment
-- A deployed AgroasysEscrow contract address + deployment start block
-- .env configured (see below)
-
-#### Install and generate models/migrations
-
-```
-npm install
-
-# generate TypeORM models from schema.graphql
-npx squid-typeorm-codegen
-
-# start the db container
+# Start the database
 docker compose up -d db
 
-# generate migrations
-rm -rf db/migrations
-npx squid-typeorm-migration generate
-
-# apply the migrations
-npx squid-typeorm-migration apply
+# Compile then apply existing migrations
+pnpm run build
+pnpm exec squid-typeorm-migration apply
 ```
 
-#### Build and run
+---
 
-```
-# compile the code
-npm run build
+## After changing `schema.graphql`
 
-# run the indexer
+Only run `codegen` and `generate` when you actually edit `schema.graphql`. Do NOT run them on a first-time setup — the existing migrations in `db/migrations/` already cover the full schema.
+
+```bash
+# 1. Regenerate TypeORM entities
+pnpm exec squid-typeorm-codegen
+
+# 2. Compile (migration tool reads from lib/, not src/)
+pnpm run build
+
+# 3. Generate a new incremental migration
+pnpm exec squid-typeorm-migration generate
+
+# 4. Apply it
+pnpm exec squid-typeorm-migration apply
+
+# 5. Restart
 node -r dotenv/config lib/main.js
 ```
 
----
+## After changing handlers / ABI only (no schema change)
 
-### Updating `schema.graphql`
-
-When you edit `schema.graphql`, you must re-generate models and migrations:
-
-```
-npx squid-typeorm-codegen
-
-rm -rf db/migrations
-
-npx squid-typeorm-migration generate
-
-npx squid-typeorm-migration apply
-
-npm run build
+```bash
+pnpm run build
 node -r dotenv/config lib/main.js
 ```
 
----
-
-### Running the indexer in Docker
-
-```
-# generate TypeORM models
-npx squid-typeorm-codegen
-
-# start the db
-docker compose up -d db
-
-# regenerate migrations
-rm -r db/migrations
-npx squid-typeorm-migration generate
-
-# apply migrations inside the container context
-docker compose run --rm indexer npx squid-typeorm-migration apply
-
-# start everything
-docker compose up -d
-
-# follow logs
-docker compose logs -f
-```
+> **Warning:** running `generate` against an empty DB will produce a "create everything" migration that conflicts with the existing ones. Always apply existing migrations first, then generate on top.
 
 ---
 
-### Operational notes
+## Command reference
 
-1. Always confirm the GraphQL endpoint and RPC point to the same Base runtime.
-2. If you see missing blocks / “Failed to fetch block …” errors:
-   - confirm your start block exists in the configured Base dataset
-   - confirm your gateway URL matches the deployed Base runtime
-   - reduce RPC rate limits if your provider is throttling
-
-3. If events appear in the configured Base explorer but not in the indexer:
-   - confirm the processor event filters match the emitted event names
-   - confirm the ABI/decoder matches the deployed contract build
-   - confirm contract address filtering is correct
-
----
-
-### GraphQL API
-
-The indexer exposes a GraphQL endpoint for read-only queries. Use it from the backend to retrieve:
-
-- Trade lifecycle state (LOCKED → IN_TRANSIT → ARRIVAL_CONFIRMED → CLOSED/FROZEN)
-- Milestone settlements (stage 1 releases and final tranche)
-- Dispute proposals, approvals, and final outcomes
-- Full event timelines for audits
-
-> Do not expose write/mutation operations from this indexer.
-
-## License
-
-Licensed under Apache-2.0.
-See the repository root `LICENSE` file.
+| Command                                      | Description                                       |
+| -------------------------------------------- | ------------------------------------------------- |
+| `pnpm exec squid-typeorm-codegen`            | Regenerate TypeORM entities from `schema.graphql` |
+| `pnpm exec squid-typeorm-migration generate` | Generate a new incremental migration              |
+| `pnpm exec squid-typeorm-migration apply`    | Apply pending migrations                          |
+| `pnpm run build`                             | Compile TypeScript                                |
+| `pnpm run typecheck`                         | Type-check without compiling                      |
+| `pnpm run lint`                              | Run linter                                        |
+| `pnpm run test`                              | Run tests                                         |
+| `docker compose up -d db`                    | Start Postgres                                    |
+| `docker compose logs -f`                     | Tail logs                                         |

--- a/indexer/db/migrations/1780127074814-Data.js
+++ b/indexer/db/migrations/1780127074814-Data.js
@@ -1,0 +1,105 @@
+module.exports = class Data1780127074814 {
+  name = 'Data1780127074814';
+
+  async up(db) {
+    await db.query(`DROP INDEX "public"."IDX_trade_event_log_index"`);
+    await db.query(`DROP INDEX "public"."IDX_trade_event_transaction_index"`);
+    await db.query(`DROP INDEX "public"."IDX_dispute_event_log_index"`);
+    await db.query(`DROP INDEX "public"."IDX_dispute_event_transaction_index"`);
+    await db.query(`DROP INDEX "public"."IDX_oracle_event_log_index"`);
+    await db.query(`DROP INDEX "public"."IDX_oracle_event_transaction_index"`);
+    await db.query(`DROP INDEX "public"."IDX_admin_event_log_index"`);
+    await db.query(`DROP INDEX "public"."IDX_admin_event_transaction_index"`);
+    await db.query(`DROP INDEX "public"."IDX_system_event_log_index"`);
+    await db.query(`DROP INDEX "public"."IDX_system_event_transaction_index"`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "tx_hash" SET NOT NULL`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "log_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "transaction_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "tx_hash" SET NOT NULL`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "log_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "transaction_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "tx_hash" SET NOT NULL`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "log_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "transaction_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "tx_hash" SET NOT NULL`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "log_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "transaction_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "tx_hash" SET NOT NULL`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "log_index" DROP DEFAULT`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "transaction_index" DROP DEFAULT`);
+    await db.query(`CREATE INDEX "IDX_35f6b75b862075574f9717e932" ON "trade_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_fa1da05ab74bf9059fb5c62d8e" ON "trade_event" ("transaction_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_3158ee87b826d9938dc8286659" ON "dispute_event" ("log_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_d8ac170d5890b1eab54b47bac1" ON "dispute_event" ("transaction_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_e683fd8f2d081d4a881d4531c6" ON "oracle_event" ("log_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_5386b64673890d248c5cfb5444" ON "oracle_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_c8700c9378d8adb23441145c73" ON "admin_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_659046f8eaf29c332feb74e9da" ON "admin_event" ("transaction_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_99bb8e7bc80926a00c2d938cfa" ON "system_event" ("log_index") `,
+    );
+    await db.query(
+      `CREATE INDEX "IDX_0fe321e0735f87264082f498fc" ON "system_event" ("transaction_index") `,
+    );
+  }
+
+  async down(db) {
+    await db.query(`DROP INDEX "public"."IDX_0fe321e0735f87264082f498fc"`);
+    await db.query(`DROP INDEX "public"."IDX_99bb8e7bc80926a00c2d938cfa"`);
+    await db.query(`DROP INDEX "public"."IDX_659046f8eaf29c332feb74e9da"`);
+    await db.query(`DROP INDEX "public"."IDX_c8700c9378d8adb23441145c73"`);
+    await db.query(`DROP INDEX "public"."IDX_5386b64673890d248c5cfb5444"`);
+    await db.query(`DROP INDEX "public"."IDX_e683fd8f2d081d4a881d4531c6"`);
+    await db.query(`DROP INDEX "public"."IDX_d8ac170d5890b1eab54b47bac1"`);
+    await db.query(`DROP INDEX "public"."IDX_3158ee87b826d9938dc8286659"`);
+    await db.query(`DROP INDEX "public"."IDX_fa1da05ab74bf9059fb5c62d8e"`);
+    await db.query(`DROP INDEX "public"."IDX_35f6b75b862075574f9717e932"`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "transaction_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "log_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "system_event" ALTER COLUMN "tx_hash" DROP NOT NULL`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "transaction_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "log_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "admin_event" ALTER COLUMN "tx_hash" DROP NOT NULL`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "transaction_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "log_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "oracle_event" ALTER COLUMN "tx_hash" DROP NOT NULL`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "transaction_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "log_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "dispute_event" ALTER COLUMN "tx_hash" DROP NOT NULL`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "transaction_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "log_index" SET DEFAULT '0'`);
+    await db.query(`ALTER TABLE "trade_event" ALTER COLUMN "tx_hash" DROP NOT NULL`);
+    await db.query(
+      `CREATE INDEX "IDX_system_event_transaction_index" ON "system_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_system_event_log_index" ON "system_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_admin_event_transaction_index" ON "admin_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_admin_event_log_index" ON "admin_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_oracle_event_transaction_index" ON "oracle_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_oracle_event_log_index" ON "oracle_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_dispute_event_transaction_index" ON "dispute_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_dispute_event_log_index" ON "dispute_event" ("log_index") `);
+    await db.query(
+      `CREATE INDEX "IDX_trade_event_transaction_index" ON "trade_event" ("transaction_index") `,
+    );
+    await db.query(`CREATE INDEX "IDX_trade_event_log_index" ON "trade_event" ("log_index") `);
+  }
+};

--- a/indexer/src/model/generated/adminAddProposal.model.ts
+++ b/indexer/src/model/generated/adminAddProposal.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_, OneToMany as OneToMany_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_, OneToMany as OneToMany_, Relation as Relation_} from "@subsquid/typeorm-store"
 import {AdminEvent} from "./adminEvent.model"
 
 @Entity_()
@@ -44,5 +44,5 @@ export class AdminAddProposal {
     cancelled!: boolean
 
     @OneToMany_(() => AdminEvent, e => e.adminAddProposal)
-    events!: AdminEvent[]
+    events!: Relation_<AdminEvent[]>
 }

--- a/indexer/src/model/generated/adminEvent.model.ts
+++ b/indexer/src/model/generated/adminEvent.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, Relation as Relation_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
 import {AdminAddProposal} from "./adminAddProposal.model"
 
 @Entity_()
@@ -12,7 +12,7 @@ export class AdminEvent {
 
     @Index_()
     @ManyToOne_(() => AdminAddProposal, {nullable: true})
-    adminAddProposal!: AdminAddProposal | undefined | null
+    adminAddProposal!: Relation_<AdminAddProposal> | undefined | null
 
     @Index_()
     @StringColumn_({nullable: false})

--- a/indexer/src/model/generated/disputeEvent.model.ts
+++ b/indexer/src/model/generated/disputeEvent.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, Relation as Relation_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_} from "@subsquid/typeorm-store"
 import {DisputeProposal} from "./disputeProposal.model"
 import {DisputeStatus} from "./_disputeStatus"
 
@@ -13,7 +13,7 @@ export class DisputeEvent {
 
     @Index_()
     @ManyToOne_(() => DisputeProposal, {nullable: true})
-    dispute!: DisputeProposal
+    dispute!: Relation_<DisputeProposal>
 
     @Index_()
     @StringColumn_({nullable: false})

--- a/indexer/src/model/generated/disputeProposal.model.ts
+++ b/indexer/src/model/generated/disputeProposal.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, ManyToOne as ManyToOne_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, OneToMany as OneToMany_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, ManyToOne as ManyToOne_, Relation as Relation_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, OneToMany as OneToMany_} from "@subsquid/typeorm-store"
 import {Trade} from "./trade.model"
 import {DisputeStatus} from "./_disputeStatus"
 import {DisputeEvent} from "./disputeEvent.model"
@@ -18,7 +18,7 @@ export class DisputeProposal {
 
     @Index_()
     @ManyToOne_(() => Trade, {nullable: true})
-    trade!: Trade
+    trade!: Relation_<Trade>
 
     @Index_()
     @Column_("varchar", {length: 7, nullable: false})
@@ -47,5 +47,5 @@ export class DisputeProposal {
     cancelled!: boolean
 
     @OneToMany_(() => DisputeEvent, e => e.dispute)
-    events!: DisputeEvent[]
+    events!: Relation_<DisputeEvent[]>
 }

--- a/indexer/src/model/generated/oracleEvent.model.ts
+++ b/indexer/src/model/generated/oracleEvent.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, Relation as Relation_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
 import {OracleUpdateProposal} from "./oracleUpdateProposal.model"
 
 @Entity_()
@@ -12,7 +12,7 @@ export class OracleEvent {
 
     @Index_()
     @ManyToOne_(() => OracleUpdateProposal, {nullable: true})
-    oracleUpdate!: OracleUpdateProposal | undefined | null
+    oracleUpdate!: Relation_<OracleUpdateProposal> | undefined | null
 
     @Index_()
     @StringColumn_({nullable: false})

--- a/indexer/src/model/generated/oracleUpdateProposal.model.ts
+++ b/indexer/src/model/generated/oracleUpdateProposal.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_, OneToMany as OneToMany_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_, OneToMany as OneToMany_, Relation as Relation_} from "@subsquid/typeorm-store"
 import {OracleEvent} from "./oracleEvent.model"
 
 @Entity_()
@@ -47,5 +47,5 @@ export class OracleUpdateProposal {
     cancelled!: boolean
 
     @OneToMany_(() => OracleEvent, e => e.oracleUpdate)
-    events!: OracleEvent[]
+    events!: Relation_<OracleEvent[]>
 }

--- a/indexer/src/model/generated/overviewSnapshot.model.ts
+++ b/indexer/src/model/generated/overviewSnapshot.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, IntColumn as IntColumn_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, IntColumn as IntColumn_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_} from "@subsquid/typeorm-store"
 
 @Entity_()
 export class OverviewSnapshot {

--- a/indexer/src/model/generated/systemEvent.model.ts
+++ b/indexer/src/model/generated/systemEvent.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
 
 @Entity_()
 export class SystemEvent {

--- a/indexer/src/model/generated/trade.model.ts
+++ b/indexer/src/model/generated/trade.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_, OneToMany as OneToMany_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_, OneToMany as OneToMany_, Relation as Relation_} from "@subsquid/typeorm-store"
 import {TradeStatus} from "./_tradeStatus"
 import {TradeEvent} from "./tradeEvent.model"
 import {DisputeProposal} from "./disputeProposal.model"
@@ -60,8 +60,8 @@ export class Trade {
     arrivalTimestamp!: Date | undefined | null
 
     @OneToMany_(() => TradeEvent, e => e.trade)
-    events!: TradeEvent[]
+    events!: Relation_<TradeEvent[]>
 
     @OneToMany_(() => DisputeProposal, e => e.trade)
-    disputes!: DisputeProposal[]
+    disputes!: Relation_<DisputeProposal[]>
 }

--- a/indexer/src/model/generated/tradeEvent.model.ts
+++ b/indexer/src/model/generated/tradeEvent.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, Relation as Relation_, StringColumn as StringColumn_, IntColumn as IntColumn_, DateTimeColumn as DateTimeColumn_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
 import {Trade} from "./trade.model"
 import {DisputeStatus} from "./_disputeStatus"
 import {ClaimType} from "./_claimType"
@@ -14,7 +14,7 @@ export class TradeEvent {
 
     @Index_()
     @ManyToOne_(() => Trade, {nullable: true})
-    trade!: Trade
+    trade!: Relation_<Trade>
 
     @Index_()
     @StringColumn_({nullable: false})


### PR DESCRIPTION
## Summary

Regenerated the indexer TypeORM models using the official Subsquid commands, so the generated model files now match the current Subsquid output format. This updates relation fields to use `Relation_<...>` typings and refreshes the generated model export formatting.

Also refreshed the indexer README with the correct model/migration workflow, including the official `squid-typeorm-codegen` and `squid-typeorm-migration` commands.