### PR TITLE
Gasless create-trade dashboard boundary

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,75 @@
+name: SDK Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact @agroasys/sdk version to publish
+        required: true
+        type: string
+      dist_tag:
+        description: npm dist-tag to publish
+        required: true
+        default: next
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish @agroasys/sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+          scope: '@agroasys'
+          cache: pnpm
+
+      - name: Validate requested version
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const requested = process.env.SDK_VERSION;
+          const current = JSON.parse(fs.readFileSync('sdk/package.json', 'utf8')).version;
+          if (requested !== current) {
+            console.error(`Refusing to publish @agroasys/sdk@${current} as ${requested}. Update sdk/package.json first.`);
+            process.exit(1);
+          }
+          if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(requested)) {
+            console.error(`Invalid semver version: ${requested}`);
+            process.exit(1);
+          }
+          NODE
+        env:
+          SDK_VERSION: ${{ inputs.version }}
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate SDK
+        run: |
+          pnpm --filter @agroasys/sdk run lint
+          pnpm --filter @agroasys/sdk run typecheck
+          pnpm --filter @agroasys/sdk run test
+          pnpm --filter @agroasys/sdk run build
+
+      - name: Publish SDK package
+        working-directory: sdk
+        run: npm publish --tag "$SDK_DIST_TAG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SDK_DIST_TAG: ${{ inputs.dist_tag }}

--- a/auth/src/api/adminController.ts
+++ b/auth/src/api/adminController.ts
@@ -61,6 +61,11 @@ interface SignerBindingBody {
   reason?: string;
 }
 
+interface ListQuery {
+  limit?: string;
+  accountId?: string;
+}
+
 function actorFromRequest(req: Request) {
   const apiKeyId = req.serviceAuth?.apiKeyId;
   if (!apiKeyId) {
@@ -152,6 +157,30 @@ function optionalCapabilities(value: unknown): OperatorCapability[] | undefined 
   return [...new Set(value)] as OperatorCapability[];
 }
 
+function parseLimit(value: unknown): number {
+  if (value === undefined) {
+    return 100;
+  }
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new HttpError(400, 'BadRequest', 'limit must be an integer');
+  }
+  const limit = Number.parseInt(value, 10);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new HttpError(400, 'BadRequest', 'limit must be between 1 and 200');
+  }
+  return limit;
+}
+
+function optionalAccountId(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new HttpError(400, 'BadRequest', 'accountId must be a non-empty string');
+  }
+  return value.trim();
+}
+
 function profilePayload(profile: UserProfile) {
   return {
     userId: profile.id,
@@ -191,6 +220,62 @@ function statusForAdminError(error: unknown): number {
 
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
+
+  async listAuthorityProfiles(
+    req: Request<Record<string, never>, unknown, unknown, ListQuery>,
+    res: Response<ApiSuccessResponse | ApiErrorResponse>,
+  ): Promise<void> {
+    try {
+      const profiles = await this.adminService.listAuthorityProfiles({
+        limit: parseLimit(req.query.limit),
+      });
+      res.json(
+        success({
+          items: profiles.map((snapshot) => ({
+            ...profilePayload(snapshot.profile),
+            capabilities: snapshot.capabilities,
+            signerBindings: snapshot.signerBindings,
+            recentAuditEvents: snapshot.recentAuditEvents,
+          })),
+          generatedAt: new Date().toISOString(),
+        }),
+      );
+    } catch (error) {
+      handleControllerError(
+        res,
+        error,
+        'AdminAuthorityListFailed',
+        statusForAdminError(error),
+        'Admin authority list failed',
+      );
+    }
+  }
+
+  async listAuditEvents(
+    req: Request<Record<string, never>, unknown, unknown, ListQuery>,
+    res: Response<ApiSuccessResponse | ApiErrorResponse>,
+  ): Promise<void> {
+    try {
+      const events = await this.adminService.listAuditEvents({
+        accountId: optionalAccountId(req.query.accountId),
+        limit: parseLimit(req.query.limit),
+      });
+      res.json(
+        success({
+          items: events,
+          generatedAt: new Date().toISOString(),
+        }),
+      );
+    } catch (error) {
+      handleControllerError(
+        res,
+        error,
+        'AdminAuditListFailed',
+        statusForAdminError(error),
+        'Admin audit list failed',
+      );
+    }
+  }
 
   async provision(
     req: Request<Record<string, never>, unknown, ProvisionBody>,

--- a/auth/src/api/routes.ts
+++ b/auth/src/api/routes.ts
@@ -105,6 +105,38 @@ export function createRouter(
   }
 
   if (options?.adminController && options.adminControlMiddleware) {
+    router.get(
+      '/admin/profiles',
+      options.adminControlMiddleware,
+      asyncHandler((req, res) =>
+        options.adminController!.listAuthorityProfiles(
+          req as Request<
+            Record<string, never>,
+            unknown,
+            unknown,
+            { limit?: string; accountId?: string }
+          >,
+          res,
+        ),
+      ),
+    );
+
+    router.get(
+      '/admin/audit-events',
+      options.adminControlMiddleware,
+      asyncHandler((req, res) =>
+        options.adminController!.listAuditEvents(
+          req as Request<
+            Record<string, never>,
+            unknown,
+            unknown,
+            { limit?: string; accountId?: string }
+          >,
+          res,
+        ),
+      ),
+    );
+
     router.post(
       '/admin/profiles/provision',
       options.adminControlMiddleware,

--- a/auth/src/core/adminService.ts
+++ b/auth/src/core/adminService.ts
@@ -11,6 +11,7 @@ import {
 } from '../types';
 import { ProfileStore } from './profileStore';
 import { OperatorAuthorityStore } from './operatorAuthorityStore';
+import type { AdminAuditEventRecord, OperatorProfileAuthoritySnapshot } from '../database/queries';
 import {
   incrementAdminBreakGlassGranted,
   incrementAdminBreakGlassRevoked,
@@ -60,6 +61,8 @@ interface SignerBindingInput {
 }
 
 export interface AdminService {
+  listAuthorityProfiles(input?: { limit?: number }): Promise<OperatorProfileAuthoritySnapshot[]>;
+  listAuditEvents(input?: { accountId?: string; limit?: number }): Promise<AdminAuditEventRecord[]>;
   provisionProfile(input: ProvisionProfileInput): Promise<UserProfile>;
   grantBreakGlass(input: GrantBreakGlassInput): Promise<UserProfile>;
   revokeBreakGlass(input: AccountActionInput): Promise<UserProfile | null>;
@@ -86,6 +89,14 @@ export function createAdminService(
   maxBreakGlassTtlSeconds: number,
 ): AdminService {
   return {
+    async listAuthorityProfiles(input = {}) {
+      return profiles.listAuthorityProfiles(input);
+    },
+
+    async listAuditEvents(input = {}) {
+      return profiles.listAuditEvents(input);
+    },
+
     async provisionProfile(input) {
       const reason = normalizeReason(input.reason);
       const previous = await profiles.findByAccountId(input.accountId);

--- a/auth/src/core/profileStore.ts
+++ b/auth/src/core/profileStore.ts
@@ -21,6 +21,10 @@ import {
   revokeBreakGlassAdmin,
   reviewBreakGlassAdmin,
   deactivateProfileWithAudit,
+  listAdminAuditEvents,
+  listOperatorAuthorityProfiles,
+  type AdminAuditEventRecord,
+  type OperatorProfileAuthoritySnapshot,
 } from '../database/queries';
 
 export interface ProfileStore {
@@ -29,6 +33,8 @@ export interface ProfileStore {
   findByWallet(walletAddress: string): Promise<UserProfile | null>;
   findByAccountId(accountId: string): Promise<UserProfile | null>;
   findById(id: string): Promise<UserProfile | null>;
+  listAuthorityProfiles(input?: { limit?: number }): Promise<OperatorProfileAuthoritySnapshot[]>;
+  listAuditEvents(input?: { accountId?: string; limit?: number }): Promise<AdminAuditEventRecord[]>;
   deactivate(id: string): Promise<void>;
   provision(input: {
     accountId: string;
@@ -83,6 +89,12 @@ export function createPostgresProfileStore(pool: Pool): ProfileStore {
     },
     findById(id) {
       return findProfileById(pool, id);
+    },
+    listAuthorityProfiles(input) {
+      return listOperatorAuthorityProfiles(pool, input);
+    },
+    listAuditEvents(input) {
+      return listAdminAuditEvents(pool, input);
     },
     deactivate(id) {
       return deactivateProfile(pool, id);

--- a/auth/src/database/queries.ts
+++ b/auth/src/database/queries.ts
@@ -707,6 +707,192 @@ export async function findProfileById(pool: Pool, id: string): Promise<UserProfi
   return result.rows[0] ?? null;
 }
 
+export interface AdminAuditEventRecord {
+  id: string;
+  accountId: string;
+  targetUserId: string | null;
+  action: AdminAuditAction;
+  actorType: AdminActor['type'];
+  actorId: string;
+  previousRole: string | null;
+  newRole: string | null;
+  reason: string;
+  breakGlassExpiresAt: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface OperatorSignerBindingRecord extends OperatorSignerAuthorization {
+  active: boolean;
+  revokedAt: string | null;
+  revokedBy: string | null;
+  revokedReason: string | null;
+}
+
+export interface OperatorProfileAuthoritySnapshot {
+  profile: UserProfile;
+  capabilities: OperatorCapability[];
+  signerBindings: OperatorSignerBindingRecord[];
+  recentAuditEvents: AdminAuditEventRecord[];
+}
+
+interface AdminAuditEventRow {
+  id: string;
+  accountId: string;
+  targetUserId: string | null;
+  action: AdminAuditAction;
+  actorType: AdminActor['type'];
+  actorId: string;
+  previousRole: string | null;
+  newRole: string | null;
+  reason: string;
+  breakGlassExpiresAt: Date | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+interface OperatorSignerBindingRow {
+  bindingId: string;
+  walletAddress: string;
+  actionClass: OperatorSignerActionClass;
+  environment: string;
+  active: boolean;
+  approvedAt: Date;
+  approvedBy: string;
+  ticketRef: string | null;
+  notes: string | null;
+  revokedAt: Date | null;
+  revokedBy: string | null;
+  revokedReason: string | null;
+}
+
+function mapAdminAuditEvent(row: AdminAuditEventRow): AdminAuditEventRecord {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    targetUserId: row.targetUserId,
+    action: row.action,
+    actorType: row.actorType,
+    actorId: row.actorId,
+    previousRole: row.previousRole,
+    newRole: row.newRole,
+    reason: row.reason,
+    breakGlassExpiresAt: row.breakGlassExpiresAt?.toISOString() ?? null,
+    metadata: row.metadata ?? {},
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function mapSignerBinding(row: OperatorSignerBindingRow): OperatorSignerBindingRecord {
+  return {
+    bindingId: row.bindingId,
+    walletAddress: row.walletAddress,
+    actionClass: row.actionClass,
+    environment: row.environment,
+    active: row.active,
+    approvedAt: row.approvedAt.toISOString(),
+    approvedBy: row.approvedBy,
+    ticketRef: row.ticketRef,
+    notes: row.notes,
+    revokedAt: row.revokedAt?.toISOString() ?? null,
+    revokedBy: row.revokedBy,
+    revokedReason: row.revokedReason,
+  };
+}
+
+export async function listAdminAuditEvents(
+  pool: Pool | PoolClient,
+  input: { accountId?: string; limit?: number } = {},
+): Promise<AdminAuditEventRecord[]> {
+  const limit = Math.min(Math.max(input.limit ?? 100, 1), 200);
+  const params: unknown[] = [];
+  const where: string[] = [];
+
+  if (input.accountId) {
+    params.push(input.accountId);
+    where.push(`account_id = $${params.length}`);
+  }
+
+  params.push(limit);
+  const result = await pool.query<AdminAuditEventRow>(
+    `SELECT id::text,
+            account_id AS "accountId",
+            target_user_id::text AS "targetUserId",
+            action,
+            actor_type AS "actorType",
+            actor_id AS "actorId",
+            previous_role AS "previousRole",
+            new_role AS "newRole",
+            reason,
+            break_glass_expires_at AS "breakGlassExpiresAt",
+            metadata,
+            created_at AS "createdAt"
+     FROM auth_admin_audit_events
+     ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+     ORDER BY created_at DESC, id DESC
+     LIMIT $${params.length}`,
+    params,
+  );
+
+  return result.rows.map(mapAdminAuditEvent);
+}
+
+async function listSignerBindingsByAccountId(
+  pool: Pool | PoolClient,
+  accountId: string,
+): Promise<OperatorSignerBindingRecord[]> {
+  const result = await pool.query<OperatorSignerBindingRow>(
+    `SELECT id::text AS "bindingId",
+            wallet_address AS "walletAddress",
+            action_class AS "actionClass",
+            environment,
+            active,
+            created_at AS "approvedAt",
+            provisioned_by AS "approvedBy",
+            provision_ticket_ref AS "ticketRef",
+            notes,
+            revoked_at AS "revokedAt",
+            revoked_by AS "revokedBy",
+            revoked_reason AS "revokedReason"
+     FROM operator_signer_bindings
+     WHERE account_id = $1
+     ORDER BY active DESC, created_at DESC, id DESC`,
+    [accountId],
+  );
+
+  return result.rows.map(mapSignerBinding);
+}
+
+export async function listOperatorAuthorityProfiles(
+  pool: Pool,
+  input: { limit?: number } = {},
+): Promise<OperatorProfileAuthoritySnapshot[]> {
+  const limit = Math.min(Math.max(input.limit ?? 100, 1), 200);
+  const result = await pool.query<UserProfile>(
+    `SELECT ${USER_PROFILE_FIELDS}
+     FROM user_profiles
+     WHERE role = 'admin'
+        OR break_glass_role IS NOT NULL
+        OR account_id IN (SELECT account_id FROM operator_capability_bindings)
+        OR account_id IN (SELECT account_id FROM operator_signer_bindings)
+     ORDER BY updated_at DESC, created_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return Promise.all(
+    result.rows.map(async (profile) => ({
+      profile,
+      capabilities: await listOperatorCapabilitiesByAccountId(pool, profile.accountId),
+      signerBindings: await listSignerBindingsByAccountId(pool, profile.accountId),
+      recentAuditEvents: await listAdminAuditEvents(pool, {
+        accountId: profile.accountId,
+        limit: 10,
+      }),
+    })),
+  );
+}
+
 export async function deactivateProfile(pool: Pool, id: string): Promise<void> {
   await pool.query(`UPDATE user_profiles SET active = FALSE, updated_at = NOW() WHERE id = $1`, [
     id,

--- a/auth/tests/routes.test.ts
+++ b/auth/tests/routes.test.ts
@@ -41,6 +41,8 @@ function createLegacyWalletController(): LegacyWalletAuthController {
 
 function createAdminController(): AdminController {
   return {
+    listAuthorityProfiles: jest.fn(),
+    listAuditEvents: jest.fn(),
     provision: jest.fn(),
     deactivate: jest.fn(),
     provisionSigner: jest.fn(),
@@ -78,6 +80,8 @@ describe('auth router', () => {
       adminControlMiddleware: jest.fn(),
     });
 
+    expect(listRoutes(router)).toContain('GET /admin/profiles');
+    expect(listRoutes(router)).toContain('GET /admin/audit-events');
     expect(listRoutes(router)).toContain('POST /admin/signers/provision');
     expect(listRoutes(router)).toContain('POST /admin/signers/revoke');
   });

--- a/auth/tests/sessionService.test.ts
+++ b/auth/tests/sessionService.test.ts
@@ -104,6 +104,8 @@ function makeStores(profile: UserProfile) {
     findByWallet: jest.fn(async (_w: string): Promise<UserProfile | null> => profile),
     findByAccountId: jest.fn(async (_accountId: string): Promise<UserProfile | null> => profile),
     findById: jest.fn(async (_id: string): Promise<UserProfile | null> => profile),
+    listAuthorityProfiles: jest.fn(async () => []),
+    listAuditEvents: jest.fn(async () => []),
     deactivate: jest.fn(async (_id: string): Promise<void> => undefined),
     provision: jest.fn(async (): Promise<UserProfile> => profile),
     grantBreakGlass: jest.fn(async (): Promise<UserProfile> => profile),

--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -778,6 +778,47 @@ paths:
           $ref: '#/components/responses/ConflictError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
+  /dashboard-settlement/gasless-executions/create-trade:
+    post:
+      tags: [Settlement]
+      summary: Submit a buyer-signed gasless create-trade package from the dashboard
+      description: |
+        Dashboard-authenticated submission boundary for Cotsel-Dash operator or integration
+        rehearsal flows. The browser submits only the buyer-signed gasless authorization package
+        created by the SDK. It must not include service-auth headers, service-auth API keys, or
+        service-auth secrets. The gateway validates the operator session, write posture,
+        idempotency, gasless readiness, and payload shape before dispatching to the existing
+        server-side gasless execution service.
+      operationId: submitDashboardGaslessCreateTradeExecution
+      security:
+        - sessionBearer: []
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettlementGaslessCreateTradeExecutionRequest'
+      responses:
+        '202':
+          description: Dashboard gasless create-trade package accepted for sponsored execution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettlementGaslessCreateTradeExecutionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '503':
+          $ref: '#/components/responses/UpstreamUnavailableError'
   /settlement/gasless-executions/user-action:
     post:
       tags: [Settlement]
@@ -940,6 +981,40 @@ paths:
         '403':
           $ref: '#/components/responses/ForbiddenError'
   /evidence/bundles:
+    get:
+      tags: [Evidence]
+      summary: List generated evidence bundle manifests
+      operationId: listEvidenceBundles
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/XCorrelationId'
+        - name: tradeId
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 128
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        '200':
+          description: Generated evidence bundle manifests visible to operators.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceBundleListResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
     post:
       tags: [Evidence]
       summary: Generate an evidence bundle manifest for a trade
@@ -5876,6 +5951,27 @@ components:
           const: true
         data:
           $ref: '#/components/schemas/EvidenceBundleManifest'
+        timestamp:
+          type: string
+          format: date-time
+    EvidenceBundleListResponse:
+      type: object
+      required: [success, data, timestamp]
+      properties:
+        success:
+          type: boolean
+          const: true
+        data:
+          type: object
+          required: [items, generatedAt]
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/EvidenceBundleManifest'
+            generatedAt:
+              type: string
+              format: date-time
         timestamp:
           type: string
           format: date-time

--- a/docs/runbooks/dashboard-api-gateway-boundary.md
+++ b/docs/runbooks/dashboard-api-gateway-boundary.md
@@ -41,6 +41,16 @@ Gateway responsibilities:
 - enforce idempotency, request tracing, and stable error shapes
 - own downstream HTTP orchestration policy for service-routed reads and probes through `gateway/src/core/serviceRegistry.ts` and `gateway/src/core/serviceOrchestrator.ts`
 
+Gasless create-trade boundary:
+
+- Cotsel-Dash may prepare the Ricardian artifact and collect the buyer signatures required for a gasless create-trade authorization package.
+- Cotsel-Dash must submit only the signed authorization package to a dashboard-authenticated gateway route.
+- The dashboard browser must never store settlement service-auth API keys, service-auth HMAC secrets, or service-auth headers.
+- The dashboard browser must never call `/settlement/gasless-executions/create-trade` directly because that route is the service-authenticated execution ingress.
+- The gateway must validate dashboard session authority, mutation/write posture, idempotency, gasless-execution readiness, and signed payload shape before dispatch.
+- The gateway remains the trusted server boundary that calls the existing gasless execution service and sponsors the privileged on-chain submission through the configured executor.
+- Execution evidence must distinguish buyer authorization, gateway submission, relayer broadcast, chain confirmation, callback delivery, and reconciliation. A signed authorization alone is not proof of escrow funding.
+
 Operations read surface:
 
 - `GET /operations/summary` provides service health and incident summary for operator operations pages.

--- a/gateway/src/core/evidenceBundleService.ts
+++ b/gateway/src/core/evidenceBundleService.ts
@@ -135,6 +135,7 @@ export interface EvidenceBundleGenerationInput {
 export interface EvidenceBundleService {
   generate(input: EvidenceBundleGenerationInput): Promise<EvidenceBundleManifest>;
   get(bundleId: string): Promise<EvidenceBundleManifest | null>;
+  list(input?: { tradeId?: string; limit?: number }): Promise<EvidenceBundleManifest[]>;
 }
 
 export class GatewayEvidenceBundleService implements EvidenceBundleService {
@@ -250,6 +251,11 @@ export class GatewayEvidenceBundleService implements EvidenceBundleService {
     }
 
     return stored.manifest as unknown as EvidenceBundleManifest;
+  }
+
+  async list(input: { tradeId?: string; limit?: number } = {}): Promise<EvidenceBundleManifest[]> {
+    const records = await this.store.list(input);
+    return records.map((record) => record.manifest as unknown as EvidenceBundleManifest);
   }
 
   private describeDegradedReason(error: unknown): string {

--- a/gateway/src/core/evidenceBundleStore.ts
+++ b/gateway/src/core/evidenceBundleStore.ts
@@ -22,6 +22,7 @@ export interface EvidenceBundleManifestRecord {
 export interface EvidenceBundleStore {
   save(record: EvidenceBundleManifestRecord): Promise<EvidenceBundleManifestRecord>;
   get(bundleId: string): Promise<EvidenceBundleManifestRecord | null>;
+  list(input?: { tradeId?: string; limit?: number }): Promise<EvidenceBundleManifestRecord[]>;
 }
 
 interface EvidenceBundleRow {
@@ -129,6 +130,27 @@ export function createPostgresEvidenceBundleStore(pool: Pool): EvidenceBundleSto
 
       return result.rows[0] ? mapRow(result.rows[0]) : null;
     },
+
+    async list(input = {}) {
+      const params: unknown[] = [];
+      const conditions: string[] = [];
+      if (input.tradeId) {
+        params.push(input.tradeId);
+        conditions.push(`trade_id = $${params.length}`);
+      }
+      params.push(Math.min(Math.max(input.limit ?? 50, 1), 100));
+      const limitParam = params.length;
+      const result = await pool.query<EvidenceBundleRow>(
+        `${selectColumns}
+         FROM evidence_bundles
+         ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+         ORDER BY generated_at DESC
+         LIMIT $${limitParam}`,
+        params,
+      );
+
+      return result.rows.map(mapRow);
+    },
   };
 }
 
@@ -148,6 +170,14 @@ export function createInMemoryEvidenceBundleStore(
     async get(bundleId) {
       const record = items.get(bundleId);
       return record ? cloneManifest(record) : null;
+    },
+
+    async list(input = {}) {
+      return [...items.values()]
+        .filter((record) => !input.tradeId || record.tradeId === input.tradeId)
+        .sort((left, right) => right.generatedAt.localeCompare(left.generatedAt))
+        .slice(0, Math.min(Math.max(input.limit ?? 50, 1), 100))
+        .map(cloneManifest);
     },
   };
 }

--- a/gateway/src/routes/dashboardSettlement.ts
+++ b/gateway/src/routes/dashboardSettlement.ts
@@ -1,0 +1,205 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Request, Router } from 'express';
+import { GatewayConfig } from '../config/env';
+import { AuthSessionClient } from '../core/authSessionClient';
+import {
+  GaslessCreateTradeExecutionInput,
+  GaslessSettlementExecutionService,
+} from '../core/gaslessSettlementExecutionService';
+import { IdempotencyStore } from '../core/idempotencyStore';
+import { GatewayError } from '../errors';
+import { createAuthenticationMiddleware, requireMutationWriteAccess } from '../middleware/auth';
+import { createIdempotencyMiddleware } from '../middleware/idempotency';
+import { type RequestContext } from '../middleware/requestContext';
+import { successResponse } from '../responses';
+
+export interface DashboardSettlementRouterOptions {
+  authSessionClient: AuthSessionClient;
+  config: GatewayConfig;
+  gaslessSettlementService?: GaslessSettlementExecutionService | null;
+  idempotencyStore: IdempotencyStore;
+}
+
+type MutationRequest = Request<Record<string, string | string[]>, unknown, Record<string, unknown>>;
+
+interface MutationContext {
+  requestContext: RequestContext;
+}
+
+function requireObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', `${field} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', `${field} must be a non-empty string`);
+  }
+
+  return value.trim();
+}
+
+function requireInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', `${field} must be an integer`);
+  }
+
+  return value;
+}
+
+function rejectUnexpectedFields(
+  value: Record<string, unknown>,
+  allowedFields: readonly string[],
+  field: string,
+): void {
+  const unexpectedFields = Object.keys(value).filter((key) => !allowedFields.includes(key));
+  if (unexpectedFields.length > 0) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', `${field} contains unsupported fields`, {
+      field,
+      unsupportedFields: unexpectedFields,
+    });
+  }
+}
+
+function getMutationContext(req: MutationRequest): MutationContext {
+  if (!req.gatewayPrincipal) {
+    throw new GatewayError(401, 'AUTH_REQUIRED', 'Authentication is required');
+  }
+
+  if (!req.requestContext) {
+    throw new GatewayError(500, 'INTERNAL_ERROR', 'Request context was not initialized');
+  }
+
+  if (!req.idempotencyState?.idempotencyKey) {
+    throw new GatewayError(500, 'INTERNAL_ERROR', 'Idempotency context was not initialized');
+  }
+
+  return {
+    requestContext: req.requestContext,
+  };
+}
+
+function parseCreateTradeExecutionRequest(
+  body: Record<string, unknown>,
+  context: MutationContext,
+): GaslessCreateTradeExecutionInput {
+  rejectUnexpectedFields(
+    body,
+    [
+      'action',
+      'handoffId',
+      'chainId',
+      'contractAddress',
+      'expiresAt',
+      'payloadHash',
+      'buyerAddress',
+      'supplierAddress',
+      'totalAmount',
+      'logisticsAmount',
+      'platformFeesAmount',
+      'supplierFirstTranche',
+      'supplierSecondTranche',
+      'ricardianHash',
+      'buyerAuthorization',
+      'usdcAuthorization',
+    ],
+    'body',
+  );
+
+  const buyerAuthorization = requireObject(body.buyerAuthorization, 'buyerAuthorization');
+  rejectUnexpectedFields(
+    buyerAuthorization,
+    ['nonce', 'deadline', 'signature'],
+    'buyerAuthorization',
+  );
+
+  const usdcAuthorization = requireObject(body.usdcAuthorization, 'usdcAuthorization');
+  rejectUnexpectedFields(
+    usdcAuthorization,
+    ['from', 'to', 'value', 'validAfter', 'validBefore', 'nonce', 'v', 'r', 's'],
+    'usdcAuthorization',
+  );
+
+  const action = requireString(body.action, 'action');
+  if (action !== 'create_trade') {
+    throw new GatewayError(400, 'VALIDATION_ERROR', 'action is not supported', {
+      allowed: ['create_trade'],
+    });
+  }
+
+  return {
+    action,
+    handoffId: requireString(body.handoffId, 'handoffId'),
+    chainId: requireInteger(body.chainId, 'chainId'),
+    contractAddress: requireString(body.contractAddress, 'contractAddress'),
+    expiresAt: requireString(body.expiresAt, 'expiresAt'),
+    payloadHash: requireString(body.payloadHash, 'payloadHash'),
+    buyerAddress: requireString(body.buyerAddress, 'buyerAddress'),
+    supplierAddress: requireString(body.supplierAddress, 'supplierAddress'),
+    totalAmount: requireString(body.totalAmount, 'totalAmount'),
+    logisticsAmount: requireString(body.logisticsAmount, 'logisticsAmount'),
+    platformFeesAmount: requireString(body.platformFeesAmount, 'platformFeesAmount'),
+    supplierFirstTranche: requireString(body.supplierFirstTranche, 'supplierFirstTranche'),
+    supplierSecondTranche: requireString(body.supplierSecondTranche, 'supplierSecondTranche'),
+    ricardianHash: requireString(body.ricardianHash, 'ricardianHash'),
+    buyerAuthorization: {
+      nonce: requireString(buyerAuthorization.nonce, 'buyerAuthorization.nonce'),
+      deadline: requireString(buyerAuthorization.deadline, 'buyerAuthorization.deadline'),
+      signature: requireString(buyerAuthorization.signature, 'buyerAuthorization.signature'),
+    },
+    usdcAuthorization: {
+      from: requireString(usdcAuthorization.from, 'usdcAuthorization.from'),
+      to: requireString(usdcAuthorization.to, 'usdcAuthorization.to'),
+      value: requireString(usdcAuthorization.value, 'usdcAuthorization.value'),
+      validAfter: requireString(usdcAuthorization.validAfter, 'usdcAuthorization.validAfter'),
+      validBefore: requireString(usdcAuthorization.validBefore, 'usdcAuthorization.validBefore'),
+      nonce: requireString(usdcAuthorization.nonce, 'usdcAuthorization.nonce'),
+      v: requireInteger(usdcAuthorization.v, 'usdcAuthorization.v'),
+      r: requireString(usdcAuthorization.r, 'usdcAuthorization.r'),
+      s: requireString(usdcAuthorization.s, 'usdcAuthorization.s'),
+    },
+    requestId: context.requestContext.requestId,
+    sourceApiKeyId: null,
+  };
+}
+
+export function createDashboardSettlementRouter(options: DashboardSettlementRouterOptions): Router {
+  const router = Router();
+  const authenticate = createAuthenticationMiddleware(options.authSessionClient, options.config);
+  const idempotency = createIdempotencyMiddleware(options.idempotencyStore);
+
+  router.use('/dashboard-settlement', authenticate);
+
+  router.post(
+    '/dashboard-settlement/gasless-executions/create-trade',
+    requireMutationWriteAccess(),
+    idempotency,
+    async (req: MutationRequest, res, next) => {
+      try {
+        if (!options.config.gaslessExecutionEnabled || !options.gaslessSettlementService) {
+          throw new GatewayError(503, 'UPSTREAM_UNAVAILABLE', 'Gasless execution is disabled', {
+            reason: 'gasless_execution_disabled',
+          });
+        }
+
+        const context = getMutationContext(req);
+        const executionRequest = parseCreateTradeExecutionRequest(
+          requireObject(req.body, 'body'),
+          context,
+        );
+        const result = await options.gaslessSettlementService.executeCreateTrade(executionRequest);
+
+        res.status(202).json(successResponse(result));
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/gateway/src/routes/evidenceBundles.ts
+++ b/gateway/src/routes/evidenceBundles.ts
@@ -53,6 +53,24 @@ function parseBundleId(value: unknown): string {
   return bundleId;
 }
 
+function parseOptionalTradeId(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return parseTradeId(value);
+}
+
+function parseLimit(value: unknown): number {
+  if (value === undefined) {
+    return 50;
+  }
+  const parsed = typeof value === 'string' ? Number.parseInt(value, 10) : NaN;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', 'limit must be an integer from 1 to 100');
+  }
+  return parsed;
+}
+
 function getMutationContext(req: MutationRequest): MutationContext {
   if (!req.gatewayPrincipal) {
     throw new GatewayError(401, 'AUTH_REQUIRED', 'Authentication is required');
@@ -78,6 +96,24 @@ export function createEvidenceBundleRouter(options: EvidenceBundleRouterOptions)
   const idempotency = createIdempotencyMiddleware(options.idempotencyStore);
 
   router.use('/evidence', authenticate);
+
+  router.get('/evidence/bundles', requireGatewayRole('operator:read'), async (req, res, next) => {
+    try {
+      const items = await options.evidenceBundleService.list({
+        tradeId: parseOptionalTradeId(req.query.tradeId),
+        limit: parseLimit(req.query.limit),
+      });
+
+      res.status(200).json(
+        successResponse({
+          items,
+          generatedAt: new Date().toISOString(),
+        }),
+      );
+    } catch (error) {
+      next(error);
+    }
+  });
 
   router.post(
     '/evidence/bundles',

--- a/gateway/src/routes/operations.ts
+++ b/gateway/src/routes/operations.ts
@@ -4,16 +4,87 @@
 import { NextFunction, Request, Response, Router } from 'express';
 import { GatewayConfig } from '../config/env';
 import { AuthSessionClient } from '../core/authSessionClient';
+import {
+  FailedOperationState,
+  FailedOperationStore,
+  type FailedOperationRecord,
+} from '../core/failedOperationStore';
+import { GatewayFailedOperationReplayer } from '../core/errorHandlerWorkflow';
 import type { GaslessSettlementExecutionService } from '../core/gaslessSettlementExecutionService';
 import { OperationsSummaryReader } from '../core/operationsSummaryService';
-import { createAuthenticationMiddleware, requireGatewayRole } from '../middleware/auth';
+import {
+  createAuthenticationMiddleware,
+  requireGatewayRole,
+  requireMutationWriteAccess,
+} from '../middleware/auth';
 import { successResponse } from '../responses';
+import { GatewayError } from '../errors';
 
 export interface OperationsRouterOptions {
   authSessionClient: AuthSessionClient;
   config: GatewayConfig;
   operationsSummaryService: OperationsSummaryReader;
   gaslessSettlementService?: GaslessSettlementExecutionService | null;
+  failedOperationStore?: FailedOperationStore | null;
+  failedOperationReplayer?: GatewayFailedOperationReplayer | null;
+}
+
+const FAILED_OPERATION_STATES: readonly FailedOperationState[] = [
+  'open',
+  'replayed',
+  'replay_failed',
+];
+
+function parseFailedOperationState(raw: unknown): FailedOperationState | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (typeof raw !== 'string' || !FAILED_OPERATION_STATES.includes(raw as FailedOperationState)) {
+    throw new GatewayError(400, 'VALIDATION_ERROR', "Query parameter 'failureState' is invalid", {
+      allowed: FAILED_OPERATION_STATES,
+    });
+  }
+  return raw as FailedOperationState;
+}
+
+function parseReplayEligible(raw: unknown): boolean | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  throw new GatewayError(
+    400,
+    'VALIDATION_ERROR',
+    "Query parameter 'replayEligible' must be true or false",
+  );
+}
+
+function requireFailedOperationStore(
+  store: FailedOperationStore | null | undefined,
+): FailedOperationStore {
+  if (!store) {
+    throw new GatewayError(503, 'UPSTREAM_UNAVAILABLE', 'Failed-operation queue is not configured');
+  }
+  return store;
+}
+
+function parseFailedOperationId(raw: string | string[] | undefined): string {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new GatewayError(400, 'VALIDATION_ERROR', 'Path parameter failedOperationId is required');
+  }
+  return raw.trim();
+}
+
+function sanitizeFailedOperation(record: FailedOperationRecord) {
+  return {
+    ...record,
+    requestPayload: null,
+  };
 }
 
 export function createOperationsRouter(options: OperationsRouterOptions): Router {
@@ -48,6 +119,61 @@ export function createOperationsRouter(options: OperationsRouterOptions): Router
 
     res.status(200).json(successResponse(options.gaslessSettlementService.getRelayerReadiness()));
   });
+
+  router.get('/operations/failed-operations', async (req, res, next) => {
+    try {
+      const records = await requireFailedOperationStore(options.failedOperationStore).list({
+        failureState: parseFailedOperationState(req.query.failureState),
+        replayEligible: parseReplayEligible(req.query.replayEligible),
+      });
+      res.status(200).json(
+        successResponse({
+          items: records.map(sanitizeFailedOperation),
+          generatedAt: new Date().toISOString(),
+        }),
+      );
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/operations/failed-operations/:failedOperationId', async (req, res, next) => {
+    try {
+      const failedOperationId = parseFailedOperationId(req.params.failedOperationId);
+      const record = await requireFailedOperationStore(options.failedOperationStore).get(
+        failedOperationId,
+      );
+      if (!record) {
+        throw new GatewayError(404, 'NOT_FOUND', 'Failed operation not found', {
+          failedOperationId,
+        });
+      }
+      res.status(200).json(successResponse(sanitizeFailedOperation(record)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post(
+    '/operations/failed-operations/:failedOperationId/replay',
+    requireMutationWriteAccess(),
+    async (req, res, next) => {
+      try {
+        const failedOperationId = parseFailedOperationId(req.params.failedOperationId);
+        if (!options.failedOperationReplayer) {
+          throw new GatewayError(
+            503,
+            'UPSTREAM_UNAVAILABLE',
+            'Failed-operation replay is not configured',
+          );
+        }
+        const replayed = await options.failedOperationReplayer.replay(failedOperationId);
+        res.status(202).json(successResponse(sanitizeFailedOperation(replayed)));
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
 
   return router;
 }

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -22,7 +22,10 @@ import { GatewayEvidenceBundleService } from './core/evidenceBundleService';
 import { createPostgresEvidenceBundleStore } from './core/evidenceBundleStore';
 import { createPostgresGovernanceActionStore } from './core/governanceStore';
 import { createPostgresGovernanceWriteStore } from './core/governanceWriteStore';
-import { GatewayErrorHandlerWorkflow } from './core/errorHandlerWorkflow';
+import {
+  GatewayErrorHandlerWorkflow,
+  GatewayFailedOperationReplayer,
+} from './core/errorHandlerWorkflow';
 import { createPostgresFailedOperationStore } from './core/failedOperationStore';
 import { createPostgresIdempotencyStore } from './core/idempotencyStore';
 import { OperatorSettingsReadService } from './core/operatorSettingsReadService';
@@ -60,6 +63,7 @@ import { createAccessLogRouter } from './routes/accessLogs';
 import { createApprovalWorkflowRouter } from './routes/approvals';
 import { createCapabilitiesRouter } from './routes/capabilities';
 import { createComplianceRouter } from './routes/compliance';
+import { createDashboardSettlementRouter } from './routes/dashboardSettlement';
 import { createEvidenceBundleRouter } from './routes/evidenceBundles';
 import { createGovernanceRouter } from './routes/governance';
 import { createGovernanceMutationRouter } from './routes/governanceMutations';
@@ -138,6 +142,12 @@ const governanceDirectSignMonitor = new GovernanceDirectSignMonitor(
   governanceWriteStore,
   auditLogStore,
   governanceTransactionVerifier,
+);
+const failedOperationReplayer = new GatewayFailedOperationReplayer(
+  failedOperationStore,
+  governanceMutationService,
+  complianceService,
+  settlementCallbackDispatcher,
 );
 const treasuryReadService = new TreasuryReadService(governanceStatusService, governanceActionStore);
 const reconciliationReadService = new ReconciliationReadService(settlementStore);
@@ -509,6 +519,14 @@ async function bootstrap(): Promise<void> {
     }),
   );
   extraRouter.use(
+    createDashboardSettlementRouter({
+      authSessionClient,
+      config,
+      gaslessSettlementService,
+      idempotencyStore,
+    }),
+  );
+  extraRouter.use(
     createSettlementRouter({
       config,
       settlementService,
@@ -532,6 +550,8 @@ async function bootstrap(): Promise<void> {
       config,
       operationsSummaryService,
       gaslessSettlementService,
+      failedOperationStore,
+      failedOperationReplayer,
     }),
   );
 

--- a/gateway/tests/dashboardSettlementRoutes.contract.test.ts
+++ b/gateway/tests/dashboardSettlementRoutes.contract.test.ts
@@ -1,0 +1,345 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Router } from 'express';
+import { createApp } from '../src/app';
+import type { GatewayConfig } from '../src/config/env';
+import type { AuthSession, AuthSessionClient } from '../src/core/authSessionClient';
+import type {
+  GaslessCreateTradeExecutionInput,
+  GaslessSettlementExecutionService,
+} from '../src/core/gaslessSettlementExecutionService';
+import { createInMemoryIdempotencyStore } from '../src/core/idempotencyStore';
+import type {
+  SettlementExecutionEventRecord,
+  SettlementHandoffRecord,
+} from '../src/core/settlementStore';
+import { loadOpenApiSpec } from '../src/openapi/spec';
+import { createSchemaValidator, hasOperation } from '../src/openapi/contract';
+import { createDashboardSettlementRouter } from '../src/routes/dashboardSettlement';
+import { sendInProcessRequest } from './support/inProcessHttp';
+
+const requestId = 'req-dashboard-create-trade';
+const isoNow = '2026-03-14T10:00:00.000Z';
+
+const baseConfig: GatewayConfig = {
+  port: 3600,
+  dbHost: 'localhost',
+  dbPort: 5432,
+  dbName: 'agroasys_gateway',
+  dbUser: 'postgres',
+  dbPassword: 'postgres',
+  authBaseUrl: 'http://127.0.0.1:3005',
+  authRequestTimeoutMs: 5000,
+  indexerGraphqlUrl: 'http://127.0.0.1:4350/graphql',
+  indexerRequestTimeoutMs: 5000,
+  rpcUrl: 'http://127.0.0.1:8545',
+  rpcFallbackUrls: [],
+  rpcReadTimeoutMs: 8000,
+  chainId: 84532,
+  escrowAddress: '0x00000000000000000000000000000000000000ee',
+  enableMutations: true,
+  writeAllowlist: ['uid-admin'],
+  governanceQueueTtlSeconds: 86400,
+  settlementIngressEnabled: false,
+  settlementServiceAuthApiKeysJson: '[]',
+  settlementServiceAuthMaxSkewSeconds: 300,
+  settlementServiceAuthNonceTtlSeconds: 600,
+  settlementCallbackEnabled: false,
+  settlementCallbackRequestTimeoutMs: 5000,
+  settlementCallbackPollIntervalMs: 5000,
+  settlementCallbackMaxAttempts: 8,
+  settlementCallbackInitialBackoffMs: 2000,
+  settlementCallbackMaxBackoffMs: 60000,
+  gaslessExecutionEnabled: true,
+  commitSha: 'abc1234',
+  buildTime: isoNow,
+  nodeEnv: 'test',
+  corsAllowedOrigins: [],
+  corsAllowNoOrigin: true,
+  rateLimitEnabled: true,
+  allowInsecureDownstreamAuth: true,
+};
+
+const handoff: SettlementHandoffRecord = {
+  handoffId: 'handoff-247',
+  platformId: 'agroasys',
+  platformHandoffId: 'platform-247',
+  tradeId: 'TRD-247',
+  phase: 'locked',
+  settlementChannel: 'cotsel_escrow',
+  displayCurrency: 'USDC',
+  displayAmount: 1200,
+  assetSymbol: 'USDC',
+  assetAmount: 1200,
+  ricardianHash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  externalReference: 'order-247',
+  metadata: {},
+  executionStatus: 'submitted',
+  reconciliationStatus: 'pending',
+  callbackStatus: 'pending',
+  providerStatus: 'gasless_broadcast_submitted',
+  txHash: '0xsettlement',
+  latestEventId: 'evt-submitted',
+  latestEventType: 'submitted',
+  latestEventDetail: 'Gasless create-trade transaction submitted by Cotsel.',
+  latestEventAt: isoNow,
+  callbackDeliveredAt: null,
+  requestId,
+  sourceApiKeyId: null,
+  createdAt: isoNow,
+  updatedAt: isoNow,
+};
+
+function event(eventId: string, eventType: SettlementExecutionEventRecord['eventType']) {
+  return {
+    eventId,
+    handoffId: handoff.handoffId,
+    eventType,
+    executionStatus:
+      eventType === 'accepted' ? 'accepted' : eventType === 'submitted' ? 'submitted' : 'queued',
+    reconciliationStatus: 'pending',
+    providerStatus: `gasless_${eventType}`,
+    txHash: eventType === 'submitted' ? '0xsettlement' : null,
+    detail: `Event ${eventType}`,
+    metadata: {},
+    observedAt: isoNow,
+    requestId,
+    sourceApiKeyId: null,
+    createdAt: isoNow,
+  } satisfies SettlementExecutionEventRecord;
+}
+
+const executionResult = {
+  handoff,
+  acceptedEvent: event('evt-accepted', 'accepted'),
+  queuedEvent: event('evt-queued', 'queued'),
+  simulationEvent: event('evt-simulation', 'simulation_completed'),
+  submittedEvent: event('evt-submitted', 'submitted'),
+  txHash: '0xsettlement',
+};
+
+const validPayload: Omit<GaslessCreateTradeExecutionInput, 'requestId' | 'sourceApiKeyId'> = {
+  action: 'create_trade',
+  handoffId: 'handoff-247',
+  chainId: 84532,
+  contractAddress: '0x00000000000000000000000000000000000000ee',
+  expiresAt: '2026-03-14T10:15:00.000Z',
+  payloadHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  buyerAddress: '0x00000000000000000000000000000000000000b1',
+  supplierAddress: '0x00000000000000000000000000000000000000c1',
+  totalAmount: '1200000000',
+  logisticsAmount: '35000000',
+  platformFeesAmount: '16000000',
+  supplierFirstTranche: '574500000',
+  supplierSecondTranche: '574500000',
+  ricardianHash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  buyerAuthorization: {
+    nonce: '1',
+    deadline: '1773492000',
+    signature: `0x${'11'.repeat(65)}`,
+  },
+  usdcAuthorization: {
+    from: '0x00000000000000000000000000000000000000b1',
+    to: '0x00000000000000000000000000000000000000ee',
+    value: '1200000000',
+    validAfter: '0',
+    validBefore: '1773492000',
+    nonce: '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+    v: 27,
+    r: '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+    s: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  },
+};
+
+function buildSession(role: AuthSession['role'], userId: string): AuthSession {
+  return {
+    userId,
+    walletAddress: '0x00000000000000000000000000000000000000aa',
+    role,
+    capabilities: [],
+    signerAuthorizations: [],
+    issuedAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  };
+}
+
+async function startServer(
+  input: {
+    session?: AuthSession | null;
+    config?: Partial<GatewayConfig>;
+    service?: Partial<GaslessSettlementExecutionService> | null;
+  } = {},
+) {
+  const config: GatewayConfig = {
+    ...baseConfig,
+    ...input.config,
+  };
+  const authSessionClient: AuthSessionClient = {
+    resolveSession: jest
+      .fn()
+      .mockResolvedValue(input.session ?? buildSession('admin', 'uid-admin')),
+    checkReadiness: jest.fn(),
+  };
+  const gaslessSettlementService =
+    input.service === null
+      ? null
+      : ({
+          executeCreateTrade: jest.fn().mockResolvedValue(executionResult),
+          ...input.service,
+        } as unknown as GaslessSettlementExecutionService);
+  const router = Router();
+  router.use(
+    createDashboardSettlementRouter({
+      authSessionClient,
+      config,
+      gaslessSettlementService,
+      idempotencyStore: createInMemoryIdempotencyStore(),
+    }),
+  );
+  const app = createApp(config, {
+    version: '1.0.0-test',
+    commitSha: config.commitSha,
+    buildTime: config.buildTime,
+    readinessCheck: jest.fn().mockResolvedValue([]),
+    extraRouter: router,
+  });
+
+  return { app, authSessionClient, gaslessSettlementService };
+}
+
+async function postCreateTrade(
+  app: ReturnType<typeof createApp>,
+  input: {
+    token?: string;
+    idempotencyKey?: string;
+    body?: unknown;
+  } = {},
+) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'x-request-id': requestId,
+  };
+  if (input.token !== undefined) {
+    headers.authorization = `Bearer ${input.token}`;
+  }
+  if (input.idempotencyKey !== undefined) {
+    headers['idempotency-key'] = input.idempotencyKey;
+  }
+
+  return sendInProcessRequest(app, {
+    method: 'POST',
+    path: '/api/dashboard-gateway/v1/dashboard-settlement/gasless-executions/create-trade',
+    headers,
+    body: JSON.stringify(input.body ?? validPayload),
+  });
+}
+
+describe('dashboard gasless create-trade route contract', () => {
+  test('OpenAPI spec exposes the dashboard-authenticated gasless create-trade route', () => {
+    const spec = loadOpenApiSpec();
+
+    expect(
+      hasOperation(spec, 'post', '/dashboard-settlement/gasless-executions/create-trade'),
+    ).toBe(true);
+  });
+
+  test('rejects unauthenticated dashboard submissions', async () => {
+    const { app, gaslessSettlementService } = await startServer({ session: null });
+    const response = await postCreateTrade(app, {
+      idempotencyKey: 'idem-unauthenticated',
+    });
+
+    expect(response.status).toBe(401);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-operator sessions before execution', async () => {
+    const { app, gaslessSettlementService } = await startServer({
+      session: buildSession('buyer', 'uid-buyer'),
+    });
+    const response = await postCreateTrade(app, {
+      token: 'sess-buyer',
+      idempotencyKey: 'idem-buyer',
+    });
+
+    expect(response.status).toBe(403);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('rejects admin sessions when mutation write posture is disabled or not allowlisted', async () => {
+    const { app, gaslessSettlementService } = await startServer({
+      config: { writeAllowlist: [] },
+    });
+    const response = await postCreateTrade(app, {
+      token: 'sess-admin',
+      idempotencyKey: 'idem-not-allowlisted',
+    });
+
+    expect(response.status).toBe(403);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('requires an idempotency key for dashboard create-trade submissions', async () => {
+    const { app, gaslessSettlementService } = await startServer();
+    const response = await postCreateTrade(app, {
+      token: 'sess-admin',
+    });
+
+    expect(response.status).toBe(400);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when gasless execution is disabled', async () => {
+    const { app, gaslessSettlementService } = await startServer({
+      config: { gaslessExecutionEnabled: false },
+    });
+    const response = await postCreateTrade(app, {
+      token: 'sess-admin',
+      idempotencyKey: 'idem-gasless-disabled',
+    });
+
+    expect(response.status).toBe(503);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('rejects malformed signed package payloads before execution', async () => {
+    const { app, gaslessSettlementService } = await startServer();
+    const response = await postCreateTrade(app, {
+      token: 'sess-admin',
+      idempotencyKey: 'idem-malformed',
+      body: {
+        ...validPayload,
+        buyerAuthorization: {
+          ...validPayload.buyerAuthorization,
+          unexpected: 'not-allowed',
+        },
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(gaslessSettlementService?.executeCreateTrade).not.toHaveBeenCalled();
+  });
+
+  test('accepts a valid dashboard package and passes it to the existing execution service', async () => {
+    const spec = loadOpenApiSpec();
+    const validateResponse = createSchemaValidator(
+      spec,
+      '#/components/schemas/SettlementGaslessCreateTradeExecutionResponse',
+    );
+    const { app, gaslessSettlementService } = await startServer();
+    const response = await postCreateTrade(app, {
+      token: 'sess-admin',
+      idempotencyKey: 'idem-valid-create-trade',
+    });
+    const payload = response.json<Record<string, unknown>>();
+
+    expect(response.status).toBe(202);
+    expect(validateResponse(payload)).toBe(true);
+    expect(gaslessSettlementService?.executeCreateTrade).toHaveBeenCalledWith({
+      ...validPayload,
+      requestId,
+      sourceApiKeyId: null,
+    } satisfies GaslessCreateTradeExecutionInput);
+  });
+});

--- a/gateway/tests/evidenceBundleRoutes.contract.test.ts
+++ b/gateway/tests/evidenceBundleRoutes.contract.test.ts
@@ -238,8 +238,13 @@ describe('gateway evidence bundle routes contract', () => {
     spec,
     '#/components/schemas/EvidenceBundleResponse',
   );
+  const validateBundleListResponse = createSchemaValidator(
+    spec,
+    '#/components/schemas/EvidenceBundleListResponse',
+  );
 
   test('OpenAPI spec exposes evidence bundle generation and retrieval routes', () => {
+    expect(hasOperation(spec, 'get', '/evidence/bundles')).toBe(true);
     expect(hasOperation(spec, 'post', '/evidence/bundles')).toBe(true);
     expect(hasOperation(spec, 'get', '/evidence/bundles/{bundleId}')).toBe(true);
     expect(hasOperation(spec, 'get', '/evidence/bundles/{bundleId}/download')).toBe(true);
@@ -281,6 +286,24 @@ describe('gateway evidence bundle routes contract', () => {
     expect((getPayload as { data: { bundleId: string } }).data.bundleId).toBe(
       (createPayload as { data: { bundleId: string } }).data.bundleId,
     );
+
+    const listResponse = await sendInProcessRequest(app, {
+      method: 'GET',
+      path: `/api/dashboard-gateway/v1/evidence/bundles?tradeId=${trade.id}&limit=10`,
+      headers: {
+        authorization: 'Bearer sess-admin',
+        'x-request-id': 'req-evidence-list',
+      },
+    });
+    const listPayload = listResponse.json<Record<string, unknown>>();
+
+    expect(listResponse.status).toBe(200);
+    expect(validateBundleListResponse(listPayload)).toBe(true);
+    expect((listPayload as { data: { items: Array<{ bundleId: string }> } }).data.items).toEqual([
+      expect.objectContaining({
+        bundleId: (createPayload as { data: { bundleId: string } }).data.bundleId,
+      }),
+    ]);
   });
 
   test('GET /evidence/bundles/{bundleId}/download returns a JSON attachment', async () => {

--- a/gateway/tests/operationsRoutes.contract.test.ts
+++ b/gateway/tests/operationsRoutes.contract.test.ts
@@ -14,6 +14,7 @@ import type {
   OperationsSummaryReader,
   OperationsSummarySnapshot,
 } from '../src/core/operationsSummaryService';
+import type { FailedOperationRecord, FailedOperationStore } from '../src/core/failedOperationStore';
 
 const config: GatewayConfig = {
   port: 3600,
@@ -156,6 +157,7 @@ async function startServer(
   role: 'admin' | 'buyer' | null,
   fixture: OperationsSummarySnapshot = operationsFixture,
   gaslessSettlementService?: GaslessSettlementExecutionService | null,
+  failedOperationStore?: FailedOperationStore | null,
 ) {
   const authSessionClient: AuthSessionClient = {
     resolveSession: jest.fn().mockImplementation(async () => {
@@ -185,6 +187,7 @@ async function startServer(
       config,
       operationsSummaryService,
       gaslessSettlementService,
+      failedOperationStore,
     }),
   );
 
@@ -344,6 +347,78 @@ describe('gateway operations summary route contract', () => {
       expect(payload.data.controls.maxFeePerGasWei).toBe('50000000000');
       expect(payload.data.alerts[0].code).toBe('gasless_broadcast_paused');
       expect(payload.data.alerts[1].code).toBe('gasless_low_executor_balance');
+    } finally {
+      server.close();
+    }
+  });
+
+  test('GET /operations/failed-operations returns sanitized replay queue records', async () => {
+    const failedRecord: FailedOperationRecord = {
+      failedOperationId: 'failed-op-1',
+      operationType: 'settlement-callback',
+      operationKey: 'callback-1',
+      targetService: 'agroasys-backend',
+      route: '/settlement/callbacks',
+      method: 'POST',
+      payloadHash: 'hash-1',
+      requestPayload: { secret: 'redacted-by-route' },
+      requestId: 'req-failed-1',
+      correlationId: null,
+      idempotencyKey: 'idem-1',
+      actionKey: null,
+      actorId: null,
+      actorUserId: 'admin-1',
+      actorWalletAddress: null,
+      actorRole: 'admin',
+      sessionReference: 'session-1',
+      replayEligible: true,
+      failureState: 'open',
+      firstFailedAt: '2026-03-12T00:00:00.000Z',
+      lastFailedAt: '2026-03-12T00:05:00.000Z',
+      retryCount: 3,
+      terminalErrorClass: 'infrastructure',
+      terminalErrorCode: 'CALLBACK_503',
+      terminalErrorMessage: 'Callback service unavailable',
+      metadata: { source: 'test' },
+      lastReplayedAt: null,
+      createdAt: '2026-03-12T00:00:00.000Z',
+      updatedAt: '2026-03-12T00:05:00.000Z',
+    };
+    const failedOperationStore = {
+      list: jest.fn().mockResolvedValue([failedRecord]),
+      get: jest.fn(),
+      recordFailure: jest.fn(),
+      markReplayed: jest.fn(),
+      markReplayFailed: jest.fn(),
+    } as unknown as FailedOperationStore;
+    const { server, baseUrl } = await startServer(
+      'admin',
+      operationsFixture,
+      null,
+      failedOperationStore,
+    );
+
+    try {
+      const response = await fetch(
+        `${baseUrl}/operations/failed-operations?failureState=open&replayEligible=true`,
+        { headers: { Authorization: 'Bearer sess-admin' } },
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(failedOperationStore.list).toHaveBeenCalledWith({
+        failureState: 'open',
+        replayEligible: true,
+      });
+      expect(payload.data.items).toHaveLength(1);
+      expect(payload.data.items[0]).toEqual(
+        expect.objectContaining({
+          failedOperationId: 'failed-op-1',
+          replayEligible: true,
+          failureState: 'open',
+          requestPayload: null,
+        }),
+      );
     } finally {
       server.close();
     }

--- a/oracle/src/api/controller.ts
+++ b/oracle/src/api/controller.ts
@@ -18,7 +18,8 @@ import {
   RejectRequest,
   ReleaseStage1Request,
 } from '../types';
-import { TriggerType } from '../types/trigger';
+import { Trigger, TriggerStatus, TriggerType } from '../types/trigger';
+import { listTriggers } from '../database/queries';
 import { ValidationError } from '../utils/errors';
 
 type TriggerRequestBody = {
@@ -30,6 +31,11 @@ type RedriveRequestBody = TriggerRequestBody & {
   triggerType?: TriggerType;
 };
 type RouteParams = Record<string, string | string[]>;
+type TriggerListQuery = {
+  status?: string;
+  tradeId?: string;
+  limit?: string;
+};
 
 type TriggerExecutionResult = {
   idempotencyKey: string;
@@ -41,6 +47,7 @@ type TriggerExecutionResult = {
 };
 
 const ORACLE_TRIGGER_TYPES = Object.values(TriggerType);
+const ORACLE_TRIGGER_STATUSES: readonly string[] = Object.values(TriggerStatus);
 
 function buildOracleSuccess(result: TriggerExecutionResult): OracleResponse {
   return {
@@ -115,6 +122,65 @@ function parseApprovalBody(body: unknown): { idempotencyKey: string; actor: stri
   };
 }
 
+function parseTriggerListQuery(query: TriggerListQuery): {
+  status?: TriggerStatus;
+  tradeId?: string;
+  limit: number;
+} {
+  const limit =
+    query.limit === undefined
+      ? 100
+      : /^\d+$/.test(query.limit)
+        ? Number.parseInt(query.limit, 10)
+        : Number.NaN;
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new HttpError(400, 'BadRequest', 'limit must be between 1 and 200');
+  }
+
+  if (query.status !== undefined && !ORACLE_TRIGGER_STATUSES.includes(query.status)) {
+    throw new HttpError(400, 'BadRequest', 'status is invalid');
+  }
+
+  return {
+    status: query.status as TriggerStatus | undefined,
+    tradeId: query.tradeId?.trim() || undefined,
+    limit,
+  };
+}
+
+function serializeTrigger(trigger: Trigger) {
+  return {
+    id: trigger.id,
+    actionKey: trigger.action_key,
+    requestId: trigger.request_id,
+    idempotencyKey: trigger.idempotency_key,
+    tradeId: trigger.trade_id,
+    triggerType: trigger.trigger_type,
+    attemptCount: trigger.attempt_count,
+    status: trigger.status,
+    txHash: trigger.tx_hash,
+    blockNumber: trigger.block_number ? Number(trigger.block_number) : null,
+    confirmationStage: trigger.confirmation_stage,
+    confirmationStageAt: trigger.confirmation_stage_at?.toISOString() ?? null,
+    indexerConfirmed: trigger.indexer_confirmed,
+    indexerConfirmedAt: trigger.indexer_confirmed_at?.toISOString() ?? null,
+    indexerEventId: trigger.indexer_event_id,
+    lastError: trigger.last_error,
+    errorType: trigger.error_type,
+    onChainVerified: trigger.on_chain_verified,
+    onChainVerifiedAt: trigger.on_chain_verified_at?.toISOString() ?? null,
+    createdAt: trigger.created_at.toISOString(),
+    submittedAt: trigger.submitted_at?.toISOString() ?? null,
+    confirmedAt: trigger.confirmed_at?.toISOString() ?? null,
+    updatedAt: trigger.updated_at.toISOString(),
+    approvedBy: trigger.approved_by,
+    approvedAt: trigger.approved_at?.toISOString() ?? null,
+    rejectedBy: trigger.rejected_by,
+    rejectedAt: trigger.rejected_at?.toISOString() ?? null,
+  };
+}
+
 function parseRejectBody(body: unknown): {
   idempotencyKey: string;
   actor: string;
@@ -131,6 +197,27 @@ function parseRejectBody(body: unknown): {
 
 export class OracleController {
   constructor(private triggerManager: TriggerManager) {}
+
+  async listTriggers(
+    req: Request<RouteParams, unknown, unknown, TriggerListQuery>,
+    res: Response<OracleResponse | ErrorResponse>,
+  ): Promise<void> {
+    try {
+      const query = parseTriggerListQuery(req.query);
+      const triggers = await listTriggers(query);
+      res.status(200).json({
+        success: true,
+        data: {
+          items: triggers.map(serializeTrigger),
+          generatedAt: timestamp(),
+        },
+        timestamp: timestamp(),
+      } as unknown as OracleResponse);
+    } catch (error: unknown) {
+      Logger.error('Controller error in listTriggers', error);
+      res.status(resolveStatusCode(error)).json(buildOracleErrorResponse(error));
+    }
+  }
 
   async releaseStage1(
     req: Request<RouteParams, unknown, ReleaseStage1Request>,

--- a/oracle/src/api/routes.ts
+++ b/oracle/src/api/routes.ts
@@ -46,6 +46,13 @@ export function createRouter(
     }
   });
 
+  router.get(
+    '/triggers',
+    authMiddleware,
+    hmacMiddleware,
+    asyncHandler((req, res) => controller.listTriggers(req, res)),
+  );
+
   router.post(
     '/release-stage1',
     authMiddleware,

--- a/oracle/src/database/queries.ts
+++ b/oracle/src/database/queries.ts
@@ -89,6 +89,36 @@ export async function getTriggersByStatus(
   return result.rows;
 }
 
+export async function listTriggers(input: {
+  status?: TriggerStatus;
+  tradeId?: string;
+  limit?: number;
+}): Promise<Trigger[]> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (input.status) {
+    params.push(input.status);
+    conditions.push(`status = $${params.length}`);
+  }
+
+  if (input.tradeId) {
+    params.push(input.tradeId);
+    conditions.push(`trade_id = $${params.length}`);
+  }
+
+  params.push(Math.min(Math.max(input.limit ?? 100, 1), 200));
+  const result = await pool.query(
+    `SELECT *
+     FROM oracle_triggers
+     ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+     ORDER BY updated_at DESC, created_at DESC
+     LIMIT $${params.length}`,
+    params,
+  );
+  return result.rows;
+}
+
 export async function getExhaustedTriggersForRedrive(limit: number = 50): Promise<Trigger[]> {
   const result = await pool.query(
     `SELECT * FROM oracle_triggers

--- a/oracle/src/middleware/middleware.ts
+++ b/oracle/src/middleware/middleware.ts
@@ -58,7 +58,7 @@ export async function hmacMiddleware(
   }
 
   try {
-    const body = JSON.stringify(req.body);
+    const body = JSON.stringify(req.body ?? {});
     verifyRequestSignature(timestamp, body, signature, config.hmacSecret);
     const nonce = providedNonce || deriveRequestNonce(timestamp, body, signature);
 

--- a/oracle/tests/authenticated-routes.test.ts
+++ b/oracle/tests/authenticated-routes.test.ts
@@ -74,6 +74,9 @@ describe('oracle authenticated routes', () => {
     rejectTrigger: async (_req: Request, res: Response) => {
       res.status(200).json({ success: true });
     },
+    listTriggers: async (req: Request, res: Response) => {
+      res.status(200).json({ success: true, status: req.query.status ?? null });
+    },
   };
 
   beforeEach(async () => {
@@ -209,5 +212,22 @@ describe('oracle authenticated routes', () => {
         message: 'Authentication nonce store unavailable',
       }),
     );
+  });
+
+  test('valid signed GET reaches protected trigger queue route', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+
+    const response = await fetch(`${baseUrl}/api/oracle/triggers?status=pending_approval`, {
+      headers: createSignedHeaders({}, { nonce: 'oracle-trigger-list' }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        status: 'pending_approval',
+      }),
+    );
+    expect(mockConsumeHmacNonce).toHaveBeenCalledWith('test-api-key', 'oracle-trigger-list', 600);
   });
 });

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@agroasys/sdk",
   "version": "1.0.0",
+  "publishConfig": {
+    "access": "restricted",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agroasys/Cotsel.git",
+    "directory": "sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- adds a dashboard-authenticated gasless create-trade submission route that keeps service-auth and privileged execution server-side
- documents the browser/gateway boundary and publishes an SDK package workflow for GitHub Packages
- adds route contract coverage for auth, write posture, idempotency, gasless readiness, payload validation, and execution dispatch
- includes the linked operations/evidence/auth/oracle hardening surfaces needed by the current launch-readiness workstream

## Validation
- pnpm --filter gateway test -- tests/dashboardSettlementRoutes.contract.test.ts tests/operationsRoutes.contract.test.ts tests/evidenceBundleRoutes.contract.test.ts
- pnpm --filter gateway run typecheck
- pnpm --filter auth test -- tests/routes.test.ts
- pnpm --filter auth run typecheck
- pnpm --filter oracle test -- tests/authenticated-routes.test.ts
- pnpm --filter oracle run typecheck
- git diff --check

## Notes
- Browser clients must call /dashboard-settlement/gasless-executions/create-trade with a dashboard session and an Idempotency-Key.
- Browser clients must not call /settlement/gasless-executions/create-trade directly or hold service-auth secrets.
- After this lands on main, run the SDK Publish workflow for @agroasys/sdk@1.0.0 before adding the dependency to Cotsel-Dash.