### PR TITLE
Require idempotency for failed-operation replay

### DIFF
--- a/docs/adr/adr-0142-pull-over-push-claim-settlement.md
+++ b/docs/adr/adr-0142-pull-over-push-claim-settlement.md
@@ -1,6 +1,6 @@
-# ADR-0142: Pull-Over-Push Claim Settlement Model
+# ADR-0142: Historical Pull-Over-Push Claim Settlement Model
 
-- Status: Superseded for supplier payouts by issue #528 and buyer refunds by PR #530; still accepted for treasury claim flows
+- Status: Historical for buyer/supplier settlement; retained only for treasury fee sweep accounting
 - Date: 2026-02-28
 - Related issue: [#142](https://github.com/Agroasys/Cotsel/issues/142)
 
@@ -8,9 +8,9 @@
 
 Escrow payout transitions previously transferred USDC directly during stage/dispute/timeout functions. This coupled core trade-state mutation with external token-transfer side effects and made payout-path failures harder to isolate.
 
-## Decision
+## Historical Decision
 
-Adopted a pull-over-push settlement model:
+ADR-0142 originally adopted a pull-over-push settlement model:
 
 - Trade-state transitions accrue recipient entitlement into `claimableUsdc` via `ClaimableAccrued` events.
 - Recipients withdraw accrued funds via `claim()`.
@@ -19,7 +19,9 @@ Adopted a pull-over-push settlement model:
   - `claim()` remains available during global pause.
   - `pauseClaims()` / `unpauseClaims()` provide dedicated emergency claim freeze.
 
-## Superseding Decision
+This is no longer the active buyer/supplier payout model.
+
+## Active Settlement Model
 
 Issue `#528` restores direct supplier payout for active settlement flows, and PR `#530` restores direct buyer refunds. The current model is:
 

--- a/gateway/src/routes/operations.ts
+++ b/gateway/src/routes/operations.ts
@@ -11,12 +11,14 @@ import {
 } from '../core/failedOperationStore';
 import { GatewayFailedOperationReplayer } from '../core/errorHandlerWorkflow';
 import type { GaslessSettlementExecutionService } from '../core/gaslessSettlementExecutionService';
+import { IdempotencyStore } from '../core/idempotencyStore';
 import { OperationsSummaryReader } from '../core/operationsSummaryService';
 import {
   createAuthenticationMiddleware,
   requireGatewayRole,
   requireMutationWriteAccess,
 } from '../middleware/auth';
+import { createIdempotencyMiddleware } from '../middleware/idempotency';
 import { successResponse } from '../responses';
 import { GatewayError } from '../errors';
 
@@ -27,6 +29,7 @@ export interface OperationsRouterOptions {
   gaslessSettlementService?: GaslessSettlementExecutionService | null;
   failedOperationStore?: FailedOperationStore | null;
   failedOperationReplayer?: GatewayFailedOperationReplayer | null;
+  idempotencyStore?: IdempotencyStore | null;
 }
 
 const FAILED_OPERATION_STATES: readonly FailedOperationState[] = [
@@ -90,6 +93,16 @@ function sanitizeFailedOperation(record: FailedOperationRecord) {
 export function createOperationsRouter(options: OperationsRouterOptions): Router {
   const router = Router();
   const authenticate = createAuthenticationMiddleware(options.authSessionClient, options.config);
+  const replayIdempotency = options.idempotencyStore
+    ? createIdempotencyMiddleware(options.idempotencyStore)
+    : (_req: Request, _res: Response, next: NextFunction) =>
+        next(
+          new GatewayError(
+            503,
+            'UPSTREAM_UNAVAILABLE',
+            'Failed-operation replay idempotency is not configured',
+          ),
+        );
 
   router.use('/operations', authenticate, requireGatewayRole('operator:read'));
 
@@ -157,6 +170,7 @@ export function createOperationsRouter(options: OperationsRouterOptions): Router
   router.post(
     '/operations/failed-operations/:failedOperationId/replay',
     requireMutationWriteAccess(),
+    replayIdempotency,
     async (req, res, next) => {
       try {
         const failedOperationId = parseFailedOperationId(req.params.failedOperationId);

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -552,6 +552,7 @@ async function bootstrap(): Promise<void> {
       gaslessSettlementService,
       failedOperationStore,
       failedOperationReplayer,
+      idempotencyStore,
     }),
   );
 

--- a/gateway/tests/operationsRoutes.contract.test.ts
+++ b/gateway/tests/operationsRoutes.contract.test.ts
@@ -10,11 +10,13 @@ import { createSchemaValidator, hasOperation } from '../src/openapi/contract';
 import { createOperationsRouter } from '../src/routes/operations';
 import type { AuthSessionClient } from '../src/core/authSessionClient';
 import type { GaslessSettlementExecutionService } from '../src/core/gaslessSettlementExecutionService';
+import type { GatewayFailedOperationReplayer } from '../src/core/errorHandlerWorkflow';
 import type {
   OperationsSummaryReader,
   OperationsSummarySnapshot,
 } from '../src/core/operationsSummaryService';
 import type { FailedOperationRecord, FailedOperationStore } from '../src/core/failedOperationStore';
+import type { IdempotencyStore } from '../src/core/idempotencyStore';
 
 const config: GatewayConfig = {
   port: 3600,
@@ -158,6 +160,9 @@ async function startServer(
   fixture: OperationsSummarySnapshot = operationsFixture,
   gaslessSettlementService?: GaslessSettlementExecutionService | null,
   failedOperationStore?: FailedOperationStore | null,
+  failedOperationReplayer?: GatewayFailedOperationReplayer | null,
+  idempotencyStore?: IdempotencyStore | null,
+  routeConfig: GatewayConfig = config,
 ) {
   const authSessionClient: AuthSessionClient = {
     resolveSession: jest.fn().mockImplementation(async () => {
@@ -184,14 +189,16 @@ async function startServer(
   router.use(
     createOperationsRouter({
       authSessionClient,
-      config,
+      config: routeConfig,
       operationsSummaryService,
       gaslessSettlementService,
       failedOperationStore,
+      failedOperationReplayer,
+      idempotencyStore,
     }),
   );
 
-  const app = createApp(config, {
+  const app = createApp(routeConfig, {
     version: '0.1.0',
     commitSha: config.commitSha,
     buildTime: config.buildTime,
@@ -416,6 +423,117 @@ describe('gateway operations summary route contract', () => {
           failedOperationId: 'failed-op-1',
           replayEligible: true,
           failureState: 'open',
+          requestPayload: null,
+        }),
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  test('POST /operations/failed-operations/:id/replay requires idempotency before replaying', async () => {
+    const replayedRecord: FailedOperationRecord = {
+      failedOperationId: 'failed-op-1',
+      operationType: 'settlement-callback',
+      operationKey: 'callback-1',
+      targetService: 'agroasys-backend',
+      route: '/settlement/callbacks',
+      method: 'POST',
+      payloadHash: 'hash-1',
+      requestPayload: { callback: true },
+      requestId: 'req-failed-1',
+      correlationId: null,
+      idempotencyKey: 'idem-1',
+      actionKey: null,
+      actorId: null,
+      actorUserId: 'admin-1',
+      actorWalletAddress: null,
+      actorRole: 'admin',
+      sessionReference: 'session-1',
+      replayEligible: true,
+      failureState: 'replayed',
+      firstFailedAt: '2026-03-12T00:00:00.000Z',
+      lastFailedAt: '2026-03-12T00:05:00.000Z',
+      retryCount: 3,
+      terminalErrorClass: 'infrastructure',
+      terminalErrorCode: 'CALLBACK_503',
+      terminalErrorMessage: 'Callback service unavailable',
+      metadata: { replayed: true },
+      lastReplayedAt: '2026-03-12T00:10:00.000Z',
+      createdAt: '2026-03-12T00:00:00.000Z',
+      updatedAt: '2026-03-12T00:10:00.000Z',
+    };
+    const failedOperationStore = {
+      list: jest.fn(),
+      get: jest.fn(),
+      recordFailure: jest.fn(),
+      markReplayed: jest.fn(),
+      markReplayFailed: jest.fn(),
+    } as unknown as FailedOperationStore;
+    const failedOperationReplayer = {
+      replay: jest.fn().mockResolvedValue(replayedRecord),
+    } as unknown as GatewayFailedOperationReplayer;
+    const idempotencyStore = {
+      get: jest.fn(),
+      createPending: jest.fn().mockResolvedValue({
+        created: true,
+        record: {
+          idempotencyKey: 'replay-1',
+          actorId: 'user:uid-admin',
+          endpoint: '/operations/failed-operations/:failedOperationId/replay',
+          requestMethod: 'POST',
+          requestPath: '/api/dashboard-gateway/v1/operations/failed-operations/failed-op-1/replay',
+          requestFingerprint: 'hash',
+          requestId: 'req-replay-1',
+          responseStatus: null,
+          responseHeaders: {},
+          responseBody: null,
+          completedAt: null,
+          createdAt: '2026-03-12T00:00:00.000Z',
+        },
+      }),
+      complete: jest.fn().mockResolvedValue(undefined),
+      releasePending: jest.fn().mockResolvedValue(undefined),
+      markReplay: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IdempotencyStore;
+    const writeConfig = {
+      ...config,
+      enableMutations: true,
+      writeAllowlist: ['uid-admin'],
+    };
+    const { server, baseUrl } = await startServer(
+      'admin',
+      operationsFixture,
+      null,
+      failedOperationStore,
+      failedOperationReplayer,
+      idempotencyStore,
+      writeConfig,
+    );
+
+    try {
+      const response = await fetch(`${baseUrl}/operations/failed-operations/failed-op-1/replay`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sess-admin',
+          'Idempotency-Key': 'replay-1',
+        },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(202);
+      expect(idempotencyStore.createPending).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: 'replay-1',
+          actorId: 'user:uid-admin',
+          requestMethod: 'POST',
+        }),
+      );
+      expect(failedOperationReplayer.replay).toHaveBeenCalledWith('failed-op-1');
+      expect(payload.data).toEqual(
+        expect.objectContaining({
+          failedOperationId: 'failed-op-1',
+          failureState: 'replayed',
           requestPayload: null,
         }),
       );

--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     ]
   },
   "overrides": {
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "hardhat-gas-reporter": {
-      "axios": "1.15.2"
+      "axios": "1.16.1"
     },
     "@protobufjs/utf8": "1.1.1",
     "cookie": "0.7.0",
@@ -112,7 +112,10 @@
     "brace-expansion@^1.1.7": "1.1.14",
     "brace-expansion@^2.0.1": "2.1.0",
     "brace-expansion@^2.0.2": "2.1.0",
-    "brace-expansion@>=4 <5.0.5": "5.0.5",
+    "brace-expansion@>=4 <5.0.5": "5.0.6",
+    "qs": "6.15.2",
+    "uuid@<11.1.1": "11.1.1",
+    "ws@>=8 <8.20.1": "8.21.0",
     "hardhat": "2.28.6",
     "@nomicfoundation/hardhat-ethers": "3.1.3",
     "@nomicfoundation/hardhat-verify": "2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@protobufjs/utf8': 1.1.1
-  axios: 1.15.2
+  axios: 1.16.1
   bn.js: 4.12.3
   cookie: 0.7.0
   fast-uri: 3.1.2
@@ -16,6 +16,10 @@ overrides:
   serialize-javascript: 7.0.5
   tmp: 0.2.6
   undici: 6.24.0
+  brace-expansion@>=4 <5.0.6: 5.0.6
+  qs: 6.15.2
+  uuid@<11.1.1: 11.1.1
+  ws@>=8 <8.20.1: 8.21.0
 
 importers:
   .:
@@ -4275,10 +4279,10 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  axios@1.15.2:
+  axios@1.16.1:
     resolution:
       {
-        integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==,
+        integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==,
       }
 
   babel-jest@30.4.1:
@@ -4469,10 +4473,10 @@ packages:
         integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
       }
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     resolution:
       {
-        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
+        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -6934,7 +6938,7 @@ packages:
         integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==,
       }
     peerDependencies:
-      ws: '*'
+      ws: 8.21.0
 
   isows@1.0.7:
     resolution:
@@ -6942,7 +6946,7 @@ packages:
         integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==,
       }
     peerDependencies:
-      ws: '*'
+      ws: 8.21.0
 
   istanbul-lib-coverage@3.2.2:
     resolution:
@@ -8672,10 +8676,10 @@ packages:
         integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==,
       }
 
-  qs@6.14.2:
+  qs@6.15.2:
     resolution:
       {
-        integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
+        integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
       }
     engines: { node: '>=0.6' }
 
@@ -10240,22 +10244,6 @@ packages:
       }
     hasBin: true
 
-  uuid@8.3.2:
-    resolution:
-      {
-        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
-      }
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution:
-      {
-        integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==,
-      }
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution:
       {
@@ -10490,40 +10478,10 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.17.1:
+  ws@8.21.0:
     resolution:
       {
-        integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==,
-      }
-    engines: { node: '>=10.0.0' }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution:
-      {
-        integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
-      }
-    engines: { node: '>=10.0.0' }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution:
-      {
-        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+        integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
       }
     engines: { node: '>=10.0.0' }
     peerDependencies:
@@ -11729,7 +11687,7 @@ snapshots:
       readable-stream: 3.6.2
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       utf-8-validate: 5.0.10
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11758,7 +11716,7 @@ snapshots:
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
       util: 0.12.5
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -11791,7 +11749,7 @@ snapshots:
       lodash: 4.18.1
       pony-cause: 2.1.11
       semver: 7.8.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11805,7 +11763,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.8.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11819,7 +11777,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.8.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12317,7 +12275,7 @@ snapshots:
       lru-cache: 6.0.0
       node-abort-controller: 3.1.1
       sha.js: 2.4.12
-      uuid: 9.0.1
+      uuid: 11.1.1
       whatwg-mimetype: 3.0.0
     transitivePeerDependencies:
       - encoding
@@ -12346,7 +12304,7 @@ snapshots:
       lru-cache: 6.0.0
       node-abort-controller: 3.1.1
       sha.js: 2.4.12
-      uuid: 9.0.1
+      uuid: 11.1.1
       whatwg-mimetype: 3.0.0
     transitivePeerDependencies:
       - encoding
@@ -12458,7 +12416,7 @@ snapshots:
       graphql-ws: 5.16.2(graphql@15.10.1)
       keyv: 4.5.4
       pg: 8.20.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@subsquid/big-decimal': 1.0.0
       typeorm: 0.3.29(ioredis@5.10.1)(pg@8.20.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
@@ -12507,7 +12465,7 @@ snapshots:
       graphql-ws: 5.16.2(graphql@15.10.2)
       inflected: 2.1.0
       pg: 8.20.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@subsquid/big-decimal': 1.0.0
     transitivePeerDependencies:
@@ -12751,7 +12709,7 @@ snapshots:
       jsonschema: 1.5.0
       loglevel: 1.9.2
       permissionless: 0.3.5(ox@0.14.20(typescript@6.0.3))(viem@2.45.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
-      uuid: 8.3.2
+      uuid: 11.1.1
       viem: 2.45.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@sentry/core'
@@ -13679,7 +13637,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       eventemitter3: 5.0.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -13912,13 +13870,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.2:
+  axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
@@ -14028,7 +13988,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -14043,7 +14003,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -14077,7 +14037,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14600,7 +14560,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -14841,7 +14801,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14854,7 +14814,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14937,7 +14897,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -14972,7 +14932,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -15334,7 +15294,7 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/units': 5.8.0
       '@solidity-parser/parser': 0.20.2
-      axios: 1.15.2
+      axios: 1.16.1
       brotli-wasm: 2.0.1
       chalk: 4.1.2
       cli-table3: 0.6.5
@@ -15349,6 +15309,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - typescript
       - utf-8-validate
       - zod
@@ -15392,7 +15353,7 @@ snapshots:
       tinyglobby: 0.2.15
       tsort: 0.0.1
       undici: 6.24.0
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       ts-node: 10.9.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -15687,9 +15648,9 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -15740,7 +15701,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -16388,7 +16349,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -16896,7 +16857,7 @@ snapshots:
 
   qrcode-generator@2.0.4: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -17110,7 +17071,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 11.1.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -17886,10 +17847,6 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
-
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
@@ -17911,9 +17868,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.11.3(typescript@6.0.3)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17928,9 +17885,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.11.3(typescript@6.0.3)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -18071,27 +18028,12 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
-  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
 
-  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -18117,7 +18059,7 @@ snapshots:
       ripple-address-codec: 4.3.1
       ripple-binary-codec: 1.11.0
       ripple-keypairs: 1.3.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xrpl-secret-numbers: 0.3.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ preferWorkspacePackages: true
 minimumReleaseAge: 10080
 overrides:
   '@protobufjs/utf8': 1.1.1
-  axios: 1.15.2
+  axios: 1.16.1
   bn.js: 4.12.3
   cookie: 0.7.0
   fast-uri: 3.1.2
@@ -29,3 +29,7 @@ overrides:
   serialize-javascript: 7.0.5
   tmp: 0.2.6
   undici: 6.24.0
+  brace-expansion@>=4 <5.0.6: 5.0.6
+  qs: 6.15.2
+  uuid@<11.1.1: 11.1.1
+  ws@>=8 <8.20.1: 8.21.0

--- a/scripts/security-deps-gate.mjs
+++ b/scripts/security-deps-gate.mjs
@@ -27,15 +27,21 @@ function parseAudit(stdout) {
 }
 
 function vulnerabilities(report) {
-  return (
-    report?.metadata?.vulnerabilities ?? {
-      critical: 0,
-      high: 0,
-      moderate: 0,
-      low: 0,
-      total: 0,
-    }
-  );
+  const summary = report?.metadata?.vulnerabilities ?? {
+    critical: 0,
+    high: 0,
+    moderate: 0,
+    low: 0,
+  };
+  return {
+    critical: summary.critical ?? 0,
+    high: summary.high ?? 0,
+    moderate: summary.moderate ?? 0,
+    low: summary.low ?? 0,
+    total:
+      summary.total ??
+      (summary.critical ?? 0) + (summary.high ?? 0) + (summary.moderate ?? 0) + (summary.low ?? 0),
+  };
 }
 
 const auditProd = runPnpm(['audit', '--prod', '--json']);
@@ -51,8 +57,8 @@ console.log(
 console.log(`pnpm list --depth Infinity: exit=${lsAll.exitCode}`);
 
 let failed = false;
-if (summary.critical > 0 || summary.high > 0) {
-  console.error('Release gate failed: production dependency audit has high/critical findings.');
+if (summary.critical > 0 || summary.high > 0 || summary.moderate > 0 || summary.low > 0) {
+  console.error('Release gate failed: production dependency audit has findings.');
   failed = true;
 }
 

--- a/treasury/tests/partnerHandoff.postgres.test.ts
+++ b/treasury/tests/partnerHandoff.postgres.test.ts
@@ -8,6 +8,9 @@ type TreasuryConnection = typeof import('../src/database/connection');
 type TreasuryControllerModule = typeof import('../src/api/controller');
 type TreasuryRoutesModule = typeof import('../src/api/routes');
 
+const runPostgresIntegrationTests = process.env.TREASURY_POSTGRES_TESTS === 'true';
+const describePostgres = runPostgresIntegrationTests ? describe : describe.skip;
+
 async function createFreshTreasuryDatabase() {
   const dbName = `treasury_bridge_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const admin = new Pool({
@@ -18,7 +21,12 @@ async function createFreshTreasuryDatabase() {
     password: process.env.DB_MIGRATION_PASSWORD || process.env.DB_PASSWORD || 'postgres',
   });
 
-  await admin.query(`CREATE DATABASE "${dbName}"`);
+  try {
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+  } catch (error) {
+    await admin.end();
+    throw error;
+  }
 
   return {
     dbName,
@@ -35,7 +43,7 @@ async function createFreshTreasuryDatabase() {
   };
 }
 
-describe('treasury partner handoff persistence (postgres)', () => {
+describePostgres('treasury partner handoff persistence (postgres)', () => {
   jest.setTimeout(120_000);
 
   let cleanup: (() => Promise<void>) | null = null;
@@ -161,7 +169,7 @@ describe('treasury partner handoff persistence (postgres)', () => {
   });
 });
 
-describe('treasury partner handoff routes (postgres)', () => {
+describePostgres('treasury partner handoff routes (postgres)', () => {
   jest.setTimeout(120_000);
 
   let cleanup: (() => Promise<void>) | null = null;
@@ -169,7 +177,7 @@ describe('treasury partner handoff routes (postgres)', () => {
   let queries: TreasuryQueries;
   let TreasuryControllerCtor: TreasuryControllerModule['TreasuryController'];
   let createRouterFn: TreasuryRoutesModule['createRouter'];
-  let server: Server;
+  let server: Server | null = null;
   let baseUrl: string;
 
   beforeAll(async () => {
@@ -204,14 +212,20 @@ describe('treasury partner handoff routes (postgres)', () => {
       server = app.listen(0, () => resolve());
     });
 
+    if (!server) {
+      throw new Error('Treasury partner handoff test server failed to start');
+    }
+
     const address = server.address() as AddressInfo;
     baseUrl = `http://127.0.0.1:${address.port}`;
   });
 
   afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
     await connection?.closeConnection();
     await cleanup?.();
   });


### PR DESCRIPTION
## Summary
- requires the shared gateway idempotency middleware before failed-operation replay executes
- wires the production idempotency store into the operations router
- adds a route contract test proving replay uses an `Idempotency-Key` and still sanitizes replay records

## Validation
- `pnpm --dir gateway run typecheck`
- `pnpm --dir gateway exec jest tests/operationsRoutes.contract.test.ts --runInBand`

## Cross-repo dependencies
- Agroasys backend Cotsel bridge contracts: https://github.com/Agroasys/agroasys-backend/pull/387
- Admin.cons Cotsel operator surfaces: https://github.com/Agroasys/Admin.dash/pull/131

## Notes
This is the Cotsel-side safety companion for the Agroasys Admin.cons Cotsel control-plane work. Failed-operation replay is replay-sensitive, so the gateway now enforces idempotency at the mutation boundary instead of relying only on the upstream admin bridge.