### PR TITLE
refactor(sdk): remove legacy USDC approval helpers

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -225,6 +225,9 @@ SDK and inject a signer instead.
 | `getUSDCBalance(address)`                                                 | Check USDC balance                                           |
 | `createGaslessTradeExecutionRequest(params, signer, input)`               | Build typed create-trade and USDC authorization package      |
 | `createGaslessUserActionExecutionRequest(action, tradeId, signer, input)` | Build typed dispute/refund/cancel/finalize package           |
+| `getBuyerNonce(address)`                                                  | Deprecated alias for `getAuthorizationNonce(address)`        |
+| `approveUSDC(amount, signer)`                                             | Deprecated guard that rejects direct ERC-20 approval         |
+| `getUSDCAllowance(address)`                                               | Deprecated guard that rejects allowance-based buyer flow     |
 | `createTrade(params, signer)`                                             | Deprecated guard that rejects direct buyer-paid create-trade |
 | `openDispute(tradeId, signer)`                                            | Deprecated guard that rejects direct buyer-paid dispute      |
 | `cancelLockedTradeAfterTimeout(tradeId, signer)`                          | Deprecated guard that rejects direct buyer-paid cancellation |

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,7 +8,7 @@ This SDK provides a **type-safe, role-based interface** to the Agroasys smart co
 
 The SDK is organized into **three role-based modules**:
 
-- **BuyerSDK** - Create gasless settlement authorization packages, approve USDC in legacy mode, and open/refund/cancel buyer actions
+- **BuyerSDK** - Create gasless settlement authorization packages and buyer/supplier user-action authorization packages
 - **OracleSDK** - Release funds at logistics milestones, confirm arrival, finalize trade (**Auth verification**)
 - **AdminSDK** - Solve frozen trades, operate protocol controls, manage treasury payout governance, and propose/approve/execute governance actions (**Auth verification**)
 
@@ -182,8 +182,11 @@ Minimum provider capabilities required by the buyer flow:
 
 - `request({ method: "eth_chainId" })` for network verification
 - `request({ method: "eth_accounts" })` or `eth_requestAccounts` for signer resolution
-- `request({ method: "personal_sign" })` for the canonical trade signature
-- standard transaction submission support such as `eth_sendTransaction` for real approve/createTrade execution in production runtimes
+- `request({ method: "eth_signTypedData_v4" })` for trade and USDC authorizations
+
+Buyer and supplier wallets do not submit settlement transactions in the gasless
+flow. They sign typed authorizations, then a trusted backend submits the package
+through the relayer/gateway.
 
 Deterministic compatibility harness:
 
@@ -192,8 +195,8 @@ npm run -w sdk test -- --runTestsByPath tests/web3AuthSignerCompatibility.test.t
 ```
 
 The harness proves that an EIP-1193/embedded-wallet signer can pass through the
-SDK lock flow, trigger allowance handling, produce the canonical signature, and
-submit the lock call through the current `BuyerSDK` assumptions.
+SDK lock flow and produce the typed authorizations expected by the gasless
+settlement gateway.
 
 ### Legacy demo helper: Web3Auth wallet provider
 
@@ -216,18 +219,16 @@ SDK and inject a signer instead.
 
 ### BuyerSDK
 
-| Method                                                                    | Description                                             |
-| ------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `getBuyerNonce(address)`                                                  | Retrieve the current nonce for signature                |
-| `approveUSDC(amount, signer)`                                             | Approve the escrow contract to spend USDC               |
-| `getUSDCBalance(address)`                                                 | Check USDC balance                                      |
-| `getUSDCAllowance(address)`                                               | Check current USDC allowance for escrow                 |
-| `createGaslessTradeExecutionRequest(params, signer, input)`               | Build typed create-trade and USDC authorization package |
-| `createGaslessUserActionExecutionRequest(action, tradeId, signer, input)` | Build typed dispute/refund/cancel/finalize package      |
-| `createTrade(params, signer)`                                             | Legacy direct-send create-trade flow                    |
-| `openDispute(tradeId, signer)`                                            | Open a dispute on an existing trade                     |
-| `cancelLockedTradeAfterTimeout(tradeId, signer)`                          | Cancel stale `LOCKED` trade after timeout               |
-| `refundInTransitAfterTimeout(tradeId, signer)`                            | Refund remaining principal when transit times out       |
+| Method                                                                    | Description                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `getAuthorizationNonce(address)`                                          | Retrieve the current typed-authorization nonce               |
+| `getUSDCBalance(address)`                                                 | Check USDC balance                                           |
+| `createGaslessTradeExecutionRequest(params, signer, input)`               | Build typed create-trade and USDC authorization package      |
+| `createGaslessUserActionExecutionRequest(action, tradeId, signer, input)` | Build typed dispute/refund/cancel/finalize package           |
+| `createTrade(params, signer)`                                             | Deprecated guard that rejects direct buyer-paid create-trade |
+| `openDispute(tradeId, signer)`                                            | Deprecated guard that rejects direct buyer-paid dispute      |
+| `cancelLockedTradeAfterTimeout(tradeId, signer)`                          | Deprecated guard that rejects direct buyer-paid cancellation |
+| `refundInTransitAfterTimeout(tradeId, signer)`                            | Deprecated guard that rejects direct buyer-paid refund       |
 
 ### OracleSDK
 

--- a/sdk/scripts/create-base-sepolia-trades.mjs
+++ b/sdk/scripts/create-base-sepolia-trades.mjs
@@ -9,8 +9,9 @@ import { ethers } from 'ethers';
 const require = createRequire(import.meta.url);
 
 let BuyerSDK;
+let GaslessSettlementClient;
 try {
-  ({ BuyerSDK } = require('../dist/index.js'));
+  ({ BuyerSDK, GaslessSettlementClient } = require('../dist/index.js'));
 } catch (error) {
   throw new Error(
     `Could not load sdk/dist/index.js. Run "npm run build -w sdk" before this script. ${
@@ -25,10 +26,7 @@ const BASE_SEPOLIA_RPC_URL = 'https://sepolia.base.org';
 const BASE_SEPOLIA_USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
 const USDC_DECIMALS = 6;
 
-const USDC_ABI = [
-  'function balanceOf(address account) view returns (uint256)',
-  'function allowance(address owner, address spender) view returns (uint256)',
-];
+const USDC_ABI = ['function balanceOf(address account) view returns (uint256)'];
 
 function parseArgs(argv) {
   const args = {};
@@ -135,6 +133,23 @@ function splitFallbackUrls(raw) {
     .filter(Boolean);
 }
 
+function buildExecutionLabel(labelPrefix) {
+  return `${labelPrefix}-${new Date().toISOString()}`;
+}
+
+function buildHandoffId(args, label) {
+  return readValue(args, 'handoff-id', ['COTSEL_HANDOFF_ID', 'GASLESS_HANDOFF_ID'], label);
+}
+
+function buildIdempotencyKey(args, handoffId) {
+  return readValue(
+    args,
+    'idempotency-key',
+    ['IDEMPOTENCY_KEY', 'COTSEL_IDEMPOTENCY_KEY', 'GASLESS_IDEMPOTENCY_KEY'],
+    `base-sepolia-create-trade:${handoffId}`,
+  );
+}
+
 function buildTradePayload({ supplier, totalAmount, label }) {
   const logisticsAmount = totalAmount / 10n;
   const platformFeesAmount = totalAmount / 20n;
@@ -210,6 +225,18 @@ const amountInput =
   readValue(args, 'total-usdc', ['TRADE_TOTAL_USDC']);
 const totalAmount = parseUsdcAmount('trade total', amountInput, '1');
 const labelPrefix = readValue(args, 'label-prefix', ['TRADE_LABEL_PREFIX'], 'COTSEL-DASH-167');
+const gatewayBaseUrl = requireValue(args, 'gateway-url', [
+  'COTSEL_GATEWAY_URL',
+  'COTSEL_DASHBOARD_GATEWAY_URL',
+  'DASHBOARD_GATEWAY_BASE_URL',
+]);
+const serviceApiKey = requireEnvValue(args, 'service-api-key', 'COTSEL_SERVICE_API_KEY');
+const serviceApiSecret = requireEnvValue(args, 'service-api-secret', 'COTSEL_SERVICE_API_SECRET');
+const expiresMinutes = parsePositiveInt(
+  'expires minutes',
+  readValue(args, 'expires-minutes', ['GASLESS_EXPIRES_MINUTES']),
+  15,
+);
 
 if (chainId !== BASE_SEPOLIA_CHAIN_ID) {
   throw new Error(`This helper is for Base Sepolia only. Expected chain id 84532, got ${chainId}`);
@@ -228,11 +255,10 @@ if (
 }
 const usdc = new ethers.Contract(usdcAddress, USDC_ABI, provider);
 
-const [network, nativeBalance, usdcBalance, allowance] = await Promise.all([
+const [network, nativeBalance, usdcBalance] = await Promise.all([
   provider.getNetwork(),
   provider.getBalance(buyerAddress),
   usdc.balanceOf(buyerAddress),
-  usdc.allowance(buyerAddress, escrowAddress),
 ]);
 
 if (network.chainId !== BigInt(chainId)) {
@@ -245,19 +271,17 @@ if (usdcBalance < totalAmount) {
   );
 }
 
-if (nativeBalance === 0n) {
-  throw new Error('Buyer has no Base Sepolia ETH for gas');
-}
-
-console.log('Base Sepolia trade creation preflight');
+console.log('Base Sepolia gasless trade creation preflight');
 console.log(`buyer: ${buyerAddress}`);
 console.log(`supplier: ${supplier}`);
 console.log(`escrow: ${escrowAddress}`);
 console.log(`usdc: ${usdcAddress}`);
-console.log(`buyer ETH: ${ethers.formatEther(nativeBalance)}`);
+console.log(
+  `buyer ETH: ${ethers.formatEther(nativeBalance)} (not required for gasless buyer flow)`,
+);
 console.log(`buyer USDC: ${formatUsdc(usdcBalance)}`);
-console.log(`current allowance: ${formatUsdc(allowance)}`);
-console.log(`creating one trade at ${formatUsdc(totalAmount)} USDC`);
+console.log(`gateway: ${gatewayBaseUrl}`);
+console.log(`creating one gasless trade at ${formatUsdc(totalAmount)} USDC`);
 
 const buyerSDK = new BuyerSDK({
   rpc,
@@ -266,20 +290,44 @@ const buyerSDK = new BuyerSDK({
   escrowAddress,
   usdcAddress,
 });
+const gaslessClient = new GaslessSettlementClient({
+  rpc,
+  rpcFallbackUrls,
+  chainId,
+  escrowAddress,
+  usdcAddress,
+});
 
-const label = `${labelPrefix}-${new Date().toISOString()}`;
+const label = buildExecutionLabel(labelPrefix);
 const payload = buildTradePayload({ supplier, totalAmount, label });
+const handoffId = buildHandoffId(args, label);
+const idempotencyKey = buildIdempotencyKey(args, handoffId);
+const expiresAt = new Date(Date.now() + expiresMinutes * 60 * 1000);
 
-console.log('\nCreating trade...');
-const result = await buyerSDK.createTrade(payload, buyerSigner);
+console.log('\nBuilding gasless create-trade execution request...');
+const request = await buyerSDK.createGaslessTradeExecutionRequest(payload, buyerSigner, {
+  handoffId,
+  expiresAt,
+});
 
-console.log('\nCreated trade:');
+console.log('Submitting gasless create-trade execution...');
+const result = await gaslessClient.submitCreateTradeExecution(request, {
+  baseUrl: gatewayBaseUrl,
+  idempotencyKey,
+  serviceAuth: {
+    apiKey: serviceApiKey,
+    apiSecret: serviceApiSecret,
+  },
+});
+
+console.log('\nSubmitted gasless trade execution:');
 console.log(
   JSON.stringify(
     {
-      tradeId: result.tradeId ?? null,
-      txHash: result.txHash,
-      blockNumber: result.blockNumber,
+      result,
+      handoffId,
+      idempotencyKey,
+      expiresAt: expiresAt.toISOString(),
       buyer: buyerAddress,
       supplier,
       totalUsdc: formatUsdc(totalAmount),

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -118,6 +118,25 @@ export class Client {
     }
   }
 
+  async getAuthorizationNonce(userAddress: string): Promise<bigint> {
+    try {
+      return await this.contract.getAuthorizationNonce(userAddress);
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
+      throw new ContractError(`Failed to get authorization nonce: ${message}`, {
+        userAddress,
+        error: message,
+      });
+    }
+  }
+
+  /**
+   * @deprecated Use `getAuthorizationNonce(address)`.
+   */
+  async getBuyerNonce(buyerAddress: string): Promise<bigint> {
+    return this.getAuthorizationNonce(buyerAddress);
+  }
+
   async getTotalClaimableUsdc(): Promise<bigint> {
     try {
       return await this.contract.totalClaimableUsdc();

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -39,18 +39,6 @@ export class Client {
     }
   }
 
-  async getBuyerNonce(buyerAddress: string): Promise<bigint> {
-    try {
-      return await this.contract.getBuyerNonce(buyerAddress);
-    } catch (error: unknown) {
-      const message = getErrorMessage(error);
-      throw new ContractError(`Failed to get buyer nonce: ${message}`, {
-        buyerAddress,
-        error: message,
-      });
-    }
-  }
-
   async getTreasuryAddress(): Promise<string> {
     try {
       return await this.contract.treasuryAddress();

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -31,10 +31,15 @@ export class BuyerSDK extends Client {
 
   async getAuthorizationNonce(userAddress: string): Promise<bigint> {
     validateAddress(userAddress, 'user');
-    const contract = this.contract as unknown as {
-      getAuthorizationNonce(userAddress: string): Promise<bigint>;
-    };
-    return contract.getAuthorizationNonce(userAddress);
+    return super.getAuthorizationNonce(userAddress);
+  }
+
+  /**
+   * @deprecated Use `getAuthorizationNonce(address)`.
+   */
+  async getBuyerNonce(buyerAddress: string): Promise<bigint> {
+    validateAddress(buyerAddress, 'buyer');
+    return this.getAuthorizationNonce(buyerAddress);
   }
 
   async createGaslessTradeAuthorization(
@@ -156,6 +161,31 @@ export class BuyerSDK extends Client {
       expiresAt: input.expiresAt,
       authorization,
     });
+  }
+
+  /**
+   * @deprecated ERC-20 allowance approvals are no longer part of the active
+   * buyer settlement path. Use `createGaslessTradeExecutionRequest(...)`.
+   */
+  async approveUSDC(amount: bigint, buyerSigner: ethers.Signer): Promise<TradeResult> {
+    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
+
+    throw new ContractError(
+      'Direct USDC approval was removed from the buyer settlement path. Use createGaslessTradeExecutionRequest with a USDC receive authorization instead.',
+      { amount: amount.toString() },
+    );
+  }
+
+  /**
+   * @deprecated Escrow allowance is not used by gasless buyer settlement.
+   */
+  async getUSDCAllowance(buyerAddress: string): Promise<bigint> {
+    validateAddress(buyerAddress, 'buyer');
+
+    throw new ContractError(
+      'Escrow USDC allowance is no longer used by buyer settlement. Use getUSDCBalance and createGaslessTradeExecutionRequest instead.',
+      { buyerAddress },
+    );
   }
 
   async getUSDCBalance(buyerAddress: string): Promise<bigint> {

--- a/sdk/src/modules/buyerSDK.ts
+++ b/sdk/src/modules/buyerSDK.ts
@@ -29,30 +29,6 @@ export class BuyerSDK extends Client {
     escrowAddress: this.config.escrowAddress,
   });
 
-  private extractTradeIdFromReceipt(receipt: ethers.TransactionReceipt): string | undefined {
-    for (const log of receipt.logs) {
-      if (log.address.toLowerCase() !== this.config.escrowAddress.toLowerCase()) {
-        continue;
-      }
-
-      try {
-        const parsed = this.contract.interface.parseLog(log);
-        if (parsed?.name === 'TradeLocked') {
-          return BigInt(parsed.args.tradeId).toString();
-        }
-      } catch {
-        continue;
-      }
-    }
-
-    return undefined;
-  }
-
-  async getBuyerNonce(buyerAddress: string): Promise<bigint> {
-    validateAddress(buyerAddress, 'buyer');
-    return super.getBuyerNonce(buyerAddress);
-  }
-
   async getAuthorizationNonce(userAddress: string): Promise<bigint> {
     validateAddress(userAddress, 'user');
     const contract = this.contract as unknown as {
@@ -139,15 +115,15 @@ export class BuyerSDK extends Client {
   async createGaslessUserActionAuthorization(
     action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>,
     tradeId: string | bigint,
-    buyerSigner: ethers.Signer,
+    userSigner: ethers.Signer,
     deadline = Math.floor(Date.now() / 1000) + 3600,
   ): Promise<GaslessUserActionAuthorization> {
-    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
-    const buyerAddress = await buyerSigner.getAddress();
-    const nonce = await this.getAuthorizationNonce(buyerAddress);
+    await this.assertSignerCompatibility(userSigner, 'User signer');
+    const userAddress = await userSigner.getAddress();
+    const nonce = await this.getAuthorizationNonce(userAddress);
 
     return signGaslessUserActionAuthorization(
-      buyerSigner,
+      userSigner,
       this.config.chainId,
       this.config.escrowAddress,
       action,
@@ -160,7 +136,7 @@ export class BuyerSDK extends Client {
   async createGaslessUserActionExecutionRequest(
     action: Exclude<SponsoredAction, SponsoredAction.CREATE_TRADE>,
     tradeId: string | bigint,
-    buyerSigner: ethers.Signer,
+    userSigner: ethers.Signer,
     input: {
       handoffId: string;
       expiresAt: string | Date;
@@ -170,7 +146,7 @@ export class BuyerSDK extends Client {
     const authorization = await this.createGaslessUserActionAuthorization(
       action,
       tradeId,
-      buyerSigner,
+      userSigner,
       input.deadline,
     );
 
@@ -180,48 +156,6 @@ export class BuyerSDK extends Client {
       expiresAt: input.expiresAt,
       authorization,
     });
-  }
-
-  async approveUSDC(amount: bigint, buyerSigner: ethers.Signer): Promise<TradeResult> {
-    await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
-
-    try {
-      const usdcContract = IERC20__factory.connect(this.config.usdcAddress, buyerSigner);
-
-      const tx = await usdcContract.approve(this.config.escrowAddress, amount);
-
-      const receipt = await tx.wait();
-
-      if (!receipt) {
-        throw new ContractError('Transaction receipt not available');
-      }
-
-      return {
-        txHash: receipt.hash,
-        blockNumber: receipt.blockNumber,
-      };
-    } catch (error: unknown) {
-      const message = getErrorMessage(error);
-      throw new ContractError(`Failed to approve USDC: ${message}`, {
-        amount: amount.toString(),
-        error: message,
-      });
-    }
-  }
-
-  async getUSDCAllowance(buyerAddress: string): Promise<bigint> {
-    validateAddress(buyerAddress, 'buyer');
-    try {
-      const usdcContract = IERC20__factory.connect(this.config.usdcAddress, this.provider);
-
-      return await usdcContract.allowance(buyerAddress, this.config.escrowAddress);
-    } catch (error: unknown) {
-      const message = getErrorMessage(error);
-      throw new ContractError(`Failed to get USDC allowance: ${message}`, {
-        buyerAddress,
-        error: message,
-      });
-    }
   }
 
   async getUSDCBalance(buyerAddress: string): Promise<bigint> {
@@ -267,7 +201,7 @@ export class BuyerSDK extends Client {
     await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
 
     throw new ContractError(
-      'Direct buyer-paid openDispute was removed. Use createGaslessUserActionRequest with SponsoredAction.OPEN_DISPUTE instead.',
+      'Direct buyer-paid openDispute was removed. Use createGaslessUserActionExecutionRequest with SponsoredAction.OPEN_DISPUTE instead.',
       { tradeId: tradeId.toString() },
     );
   }
@@ -279,7 +213,7 @@ export class BuyerSDK extends Client {
     await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
 
     throw new ContractError(
-      'Direct buyer-paid cancelLockedTradeAfterTimeout was removed. Use createGaslessUserActionRequest with SponsoredAction.CANCEL_LOCKED_TIMEOUT instead.',
+      'Direct buyer-paid cancelLockedTradeAfterTimeout was removed. Use createGaslessUserActionExecutionRequest with SponsoredAction.CANCEL_LOCKED_TIMEOUT instead.',
       { tradeId: tradeId.toString() },
     );
   }
@@ -291,7 +225,7 @@ export class BuyerSDK extends Client {
     await this.assertSignerCompatibility(buyerSigner, 'Buyer signer');
 
     throw new ContractError(
-      'Direct buyer-paid refundInTransitAfterTimeout was removed. Use createGaslessUserActionRequest with SponsoredAction.REFUND_IN_TRANSIT_TIMEOUT instead.',
+      'Direct buyer-paid refundInTransitAfterTimeout was removed. Use createGaslessUserActionExecutionRequest with SponsoredAction.REFUND_IN_TRANSIT_TIMEOUT instead.',
       { tradeId: tradeId.toString() },
     );
   }

--- a/sdk/src/wallet/eip1193.ts
+++ b/sdk/src/wallet/eip1193.ts
@@ -18,8 +18,9 @@ export type Eip1193ProviderLike = {
  *
  * The provider must expose a `request(...)` method compatible with
  * `ethers.BrowserProvider`. In production this means the provider must support
- * standard chain/account access, message signing, and transaction submission
- * methods for the flows the SDK will execute.
+ * standard chain/account access and the signing method required by the selected
+ * flow. Buyer gasless settlement uses typed-data signatures; transaction
+ * submission is only needed for signer-paid admin/oracle operations.
  */
 export async function createSignerFromEip1193Provider(
   provider: Eip1193ProviderLike,

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -138,6 +138,12 @@ describe('BuyerSDK unit', () => {
     });
   });
 
+  test('getBuyerNonce remains a deprecated alias for authorization nonce', async () => {
+    const { sdk } = makeSdkUnit();
+
+    await expect(sdk.getBuyerNonce('0x2222222222222222222222222222222222222222')).resolves.toBe(9n);
+  });
+
   test('createUsdcReceiveAuthorization targets escrow and splits EIP-3009 signature', async () => {
     const { sdk } = makeSdkUnit();
     const { signer } = makeBuyerSigner();
@@ -407,6 +413,34 @@ describe('BuyerSDK unit', () => {
         signer,
       ),
     ).rejects.toThrow('Direct buyer-paid createTrade was removed');
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  test('approveUSDC should reject with the gasless migration guard', async () => {
+    const { sdk, connect } = makeSdkUnit();
+    const { signer } = makeBuyerSigner();
+
+    await expect(sdk.approveUSDC(1000000n, signer)).rejects.toThrow(
+      'Direct USDC approval was removed',
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  test('approveUSDC should reject signer network mismatches before migration guard', async () => {
+    const { sdk, connect } = makeSdkUnit();
+    const { signer, provider } = makeBuyerSigner();
+    provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
+
+    await expect(sdk.approveUSDC(1000000n, signer)).rejects.toThrow('wrong network');
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  test('getUSDCAllowance should reject with the gasless migration guard', async () => {
+    const { sdk, connect } = makeSdkUnit();
+
+    await expect(
+      sdk.getUSDCAllowance('0x2222222222222222222222222222222222222222'),
+    ).rejects.toThrow('Escrow USDC allowance is no longer used');
     expect(connect).not.toHaveBeenCalled();
   });
 

--- a/sdk/tests/buyerSDK.test.ts
+++ b/sdk/tests/buyerSDK.test.ts
@@ -4,7 +4,6 @@
 import { BuyerSDK } from '../src/modules/buyerSDK';
 import type { ethers } from 'ethers';
 import { Interface } from 'ethers';
-import { IERC20__factory } from '../src/types/typechain-types/factories/@openzeppelin/contracts/token/ERC20/IERC20__factory';
 import { TEST_CONFIG, assertRequiredEnv, getBuyerSigner, hasRequiredEnv } from './setup';
 import { SponsoredAction } from '../src/types/trade';
 import { GaslessSettlementClient } from '../src/modules/gaslessSettlementClient';
@@ -69,8 +68,6 @@ function makeSdkUnit() {
     interface: TRADE_LOCKED_INTERFACE,
     getAuthorizationNonce: jest.fn().mockResolvedValue(9n),
   } as unknown as BuyerContractConnector;
-  jest.spyOn(sdk, 'getUSDCAllowance').mockResolvedValue(1_000_000n);
-  jest.spyOn(sdk, 'getBuyerNonce').mockResolvedValue(7n);
   jest
     .spyOn(sdk, 'getTreasuryAddress')
     .mockResolvedValue('0x3000000000000000000000000000000000000003');
@@ -111,16 +108,6 @@ describe('BuyerSDK unit', () => {
         signer,
       ),
     ).rejects.toThrow('wrong network');
-  });
-
-  test('approveUSDC should reject signer network mismatches', async () => {
-    const { sdk } = makeSdkUnit();
-    const { signer, provider } = makeBuyerSigner();
-    const connectSpy = jest.spyOn(IERC20__factory, 'connect');
-    provider.getNetwork.mockResolvedValueOnce({ chainId: 1n });
-
-    await expect(sdk.approveUSDC(1000000n, signer)).rejects.toThrow('wrong network');
-    expect(connectSpy).not.toHaveBeenCalled();
   });
 
   test('createGaslessTradeAuthorization builds typed authorization from on-chain nonce', async () => {
@@ -481,21 +468,19 @@ describeIntegration('BuyerSDK integration smoke', () => {
     buyerSigner = getBuyerSigner();
   });
 
-  test('should get buyer nonce', async () => {
+  test('should get authorization nonce', async () => {
     const buyerAddress = await buyerSigner.getAddress();
-    const nonce = await buyerSDK.getBuyerNonce(buyerAddress);
+    const nonce = await buyerSDK.getAuthorizationNonce(buyerAddress);
 
     expect(typeof nonce).toBe('bigint');
     expect(nonce).toBeGreaterThanOrEqual(0n);
   });
 
-  test('should check USDC balance and allowance', async () => {
+  test('should check USDC balance', async () => {
     const buyerAddress = await buyerSigner.getAddress();
 
     const balance = await buyerSDK.getUSDCBalance(buyerAddress);
-    const allowance = await buyerSDK.getUSDCAllowance(buyerAddress);
 
     expect(typeof balance).toBe('bigint');
-    expect(typeof allowance).toBe('bigint');
   });
 });

--- a/sdk/tests/manualBuyerSDK.test.ts
+++ b/sdk/tests/manualBuyerSDK.test.ts
@@ -27,10 +27,10 @@ describeIntegration('BuyerSDK', () => {
     buyerSigner = getBuyerSigner();
   });
 
-  test('should get buyer nonce', async () => {
+  test('should get authorization nonce', async () => {
     const buyerAddress = await buyerSigner.getAddress();
-    const nonce1 = await buyerSDK.getBuyerNonce(buyerAddress);
-    const nonce2 = await buyerSDK.getBuyerNonce(buyerAddress);
+    const nonce1 = await buyerSDK.getAuthorizationNonce(buyerAddress);
+    const nonce2 = await buyerSDK.getAuthorizationNonce(buyerAddress);
 
     expect(typeof nonce1).toBe('bigint');
     expect(typeof nonce2).toBe('bigint');
@@ -39,23 +39,19 @@ describeIntegration('BuyerSDK', () => {
     // When no transactions are sent between calls, the nonce should remain stable.
     expect(nonce2).toBe(nonce1);
 
-    console.log(`Buyer nonce (first call): ${nonce1}`);
-    console.log(`Buyer nonce (second call): ${nonce2}`);
+    console.log(`Authorization nonce (first call): ${nonce1}`);
+    console.log(`Authorization nonce (second call): ${nonce2}`);
   });
 
-  test('should check USDC balance and allowance', async () => {
+  test('should check USDC balance', async () => {
     const buyerAddress = await buyerSigner.getAddress();
 
     const balance = await buyerSDK.getUSDCBalance(buyerAddress);
-    const allowance = await buyerSDK.getUSDCAllowance(buyerAddress);
 
     expect(typeof balance).toBe('bigint');
-    expect(typeof allowance).toBe('bigint');
     expect(balance).toBeGreaterThanOrEqual(0n);
-    expect(allowance).toBeGreaterThanOrEqual(0n);
 
     console.log(`USDC balance: ${balance}`);
-    console.log(`USDC allowance: ${allowance}`);
   });
 
   test('should reject direct buyer-paid trade creation', async () => {


### PR DESCRIPTION
Summary:
- Remove deprecated USDC approval and allowance helpers from BuyerSDK.
- Replace buyer nonce usage with authorization nonce flow in SDK tests and docs.
- Clarify gasless typed-data signing expectations.