### PR TITLE
Harden gasless relayer balance alert config

### DIFF
--- a/gateway/src/config/env.ts
+++ b/gateway/src/config/env.ts
@@ -476,11 +476,13 @@ export function loadConfig(): GatewayConfig {
       envBigInt('GATEWAY_GASLESS_MAX_NATIVE_COST_WEI', 100_000_000_000_000_000n) > 0n,
       'GATEWAY_GASLESS_MAX_NATIVE_COST_WEI must be > 0 when gasless execution is enabled',
     );
+    const gaslessLowBalanceAlertWei = envBigInt('GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI', 0n);
+    const gaslessMinExecutorBalanceWei = envBigInt('GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI', 0n);
     assert(
-      envBigInt('GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI', 0n) <=
-        envBigInt('GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI', 0n) ||
-        envBigInt('GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI', 0n) === 0n,
-      'GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI must be <= GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI when both are set',
+      gaslessLowBalanceAlertWei === 0n ||
+        gaslessMinExecutorBalanceWei === 0n ||
+        gaslessLowBalanceAlertWei >= gaslessMinExecutorBalanceWei,
+      'GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI must be >= GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI when both are set',
     );
     assert(
       envNumber('GATEWAY_GASLESS_STUCK_QUEUE_THRESHOLD_MS', 300000) >= 1000,

--- a/gateway/tests/configEnv.test.ts
+++ b/gateway/tests/configEnv.test.ts
@@ -167,8 +167,8 @@ describe('gateway runtime env config', () => {
         GATEWAY_GASLESS_SIGNER_CUSTODY_MODE: 'raw_private_key',
         GATEWAY_GASLESS_MAX_FEE_PER_GAS_WEI: '1000000000',
         GATEWAY_GASLESS_MAX_NATIVE_COST_WEI: '100000000000000',
-        GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI: '1',
-        GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI: '2',
+        GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI: '2',
+        GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI: '1',
         GATEWAY_GASLESS_STUCK_QUEUE_THRESHOLD_MS: '5000',
         GATEWAY_GASLESS_REPEATED_FAILURE_ALERT_THRESHOLD: '2',
       },
@@ -181,10 +181,32 @@ describe('gateway runtime env config', () => {
         expect(config.rpcFallbackUrls).toEqual(['https://fallback.example.test']);
         expect(config.gaslessMaxFeePerGasWei).toBe(1000000000n);
         expect(config.gaslessMaxNativeCostWei).toBe(100000000000000n);
-        expect(config.gaslessLowBalanceAlertWei).toBe(1n);
-        expect(config.gaslessMinExecutorBalanceWei).toBe(2n);
+        expect(config.gaslessLowBalanceAlertWei).toBe(2n);
+        expect(config.gaslessMinExecutorBalanceWei).toBe(1n);
         expect(config.gaslessStuckQueueThresholdMs).toBe(5000);
         expect(config.gaslessRepeatedFailureAlertThreshold).toBe(2);
+      },
+    );
+  });
+
+  test('gasless relayer low-balance alert threshold must protect the minimum executor balance floor', () => {
+    withEnv(
+      {
+        GATEWAY_SETTLEMENT_RUNTIME: 'base-sepolia',
+        GATEWAY_RPC_URL: undefined,
+        GATEWAY_RPC_FALLBACK_URLS: 'https://fallback.example.test',
+        GATEWAY_CHAIN_ID: undefined,
+        GATEWAY_GASLESS_EXECUTION_ENABLED: 'true',
+        GATEWAY_GASLESS_EXECUTOR_PRIVATE_KEY:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI: '1',
+        GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI: '2',
+      },
+      () => {
+        const { loadConfig } = loadConfigModule();
+        expect(() => loadConfig()).toThrow(
+          'GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI must be >= GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI when both are set',
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary

This PR patches one Cotsel-side gasless hardening gap found during the #525 closeout audit: the gateway env validation allowed `GATEWAY_GASLESS_LOW_BALANCE_ALERT_WEI` to be lower than `GATEWAY_GASLESS_MIN_EXECUTOR_BALANCE_WEI`, while the relayer rehearsal script correctly treats that posture as unsafe.

The new behavior is fail-closed: when both values are set, the low-balance alert threshold must be greater than or equal to the hard minimum executor balance floor, so operators get an alert before the relayer reaches the no-broadcast floor.

## Metadata

Related issues: #525, #519

This PR is not sufficient for the gasless evidence-dependent parent issues by itself. The remaining closeout blocker is live operational evidence: approved production signer custody or KMS/MPC proof, failover/dropped-tx/low-balance/stuck-queue rehearsal evidence, and external alert-routing smoke evidence.

## Validation

- `pnpm --dir gateway test -- configEnv.test.ts`
- `node --test scripts/tests/gasless-relayer-capacity-rehearsal.test.mjs`
- `pnpm --dir gateway test -- operationsRoutes.contract.test.ts settlementRoutes.contract.test.ts configEnv.test.ts`
- `pnpm --dir gateway run typecheck`
- `pnpm --dir gateway run lint`
- `pnpm format:check -- gateway/src/config/env.ts gateway/tests/configEnv.test.ts`
- `git diff --check`
