### PR TITLE
Add signer coverage guard and break-glass review evidence

### DIFF
--- a/auth/src/api/adminController.ts
+++ b/auth/src/api/adminController.ts
@@ -15,12 +15,12 @@ import {
   ApiSuccessResponse,
   OPERATOR_CAPABILITIES,
   OPERATOR_SIGNER_ACTION_CLASSES,
-  BreakGlassReviewStatus,
   OperatorCapability,
   OperatorSignerActionClass,
   UserProfile,
   UserRole,
 } from '../types';
+import { resolveBreakGlassReviewStatus } from '../core/breakGlassReviewStatus';
 import { assertWalletAddress, handleControllerError, requireAuthRole } from './controllerSupport';
 
 const VALID_BREAK_GLASS_BASE_ROLES: Exclude<UserRole, 'admin'>[] = ['buyer', 'supplier', 'oracle'];
@@ -218,29 +218,6 @@ function profilePayload(profile: UserProfile) {
       }),
     },
   };
-}
-
-function resolveBreakGlassReviewStatus(input: {
-  active: boolean;
-  role: 'admin' | null;
-  expiresAt: string | null;
-  grantedAt: string | null;
-  revokedAt: string | null;
-  reviewedAt: string | null;
-}): BreakGlassReviewStatus {
-  if (input.reviewedAt) {
-    return 'reviewed';
-  }
-  if (!input.role && !input.grantedAt && !input.expiresAt && !input.revokedAt) {
-    return 'none';
-  }
-  if (input.revokedAt) {
-    return 'revoked_unreviewed';
-  }
-  if (input.active) {
-    return 'active_unreviewed';
-  }
-  return 'expired_unreviewed';
 }
 
 function statusForAdminError(error: unknown): number {

--- a/auth/src/api/adminController.ts
+++ b/auth/src/api/adminController.ts
@@ -15,6 +15,7 @@ import {
   ApiSuccessResponse,
   OPERATOR_CAPABILITIES,
   OPERATOR_SIGNER_ACTION_CLASSES,
+  BreakGlassReviewStatus,
   OperatorCapability,
   OperatorSignerActionClass,
   UserProfile,
@@ -182,6 +183,11 @@ function optionalAccountId(value: unknown): string | undefined {
 }
 
 function profilePayload(profile: UserProfile) {
+  const breakGlassActive =
+    profile.breakGlassRole === 'admin' &&
+    profile.breakGlassExpiresAt !== null &&
+    profile.breakGlassExpiresAt.getTime() > Date.now() &&
+    profile.breakGlassRevokedAt === null;
   return {
     userId: profile.id,
     accountId: profile.accountId,
@@ -192,11 +198,7 @@ function profilePayload(profile: UserProfile) {
     orgId: profile.orgId,
     active: profile.active,
     breakGlass: {
-      active:
-        profile.breakGlassRole === 'admin' &&
-        profile.breakGlassExpiresAt !== null &&
-        profile.breakGlassExpiresAt.getTime() > Date.now() &&
-        profile.breakGlassRevokedAt === null,
+      active: breakGlassActive,
       role: profile.breakGlassRole,
       expiresAt: profile.breakGlassExpiresAt?.toISOString() ?? null,
       grantedAt: profile.breakGlassGrantedAt?.toISOString() ?? null,
@@ -206,8 +208,39 @@ function profilePayload(profile: UserProfile) {
       revokedBy: profile.breakGlassRevokedBy,
       reviewedAt: profile.breakGlassReviewedAt?.toISOString() ?? null,
       reviewedBy: profile.breakGlassReviewedBy,
+      reviewStatus: resolveBreakGlassReviewStatus({
+        active: breakGlassActive,
+        role: profile.breakGlassRole,
+        expiresAt: profile.breakGlassExpiresAt?.toISOString() ?? null,
+        grantedAt: profile.breakGlassGrantedAt?.toISOString() ?? null,
+        revokedAt: profile.breakGlassRevokedAt?.toISOString() ?? null,
+        reviewedAt: profile.breakGlassReviewedAt?.toISOString() ?? null,
+      }),
     },
   };
+}
+
+function resolveBreakGlassReviewStatus(input: {
+  active: boolean;
+  role: 'admin' | null;
+  expiresAt: string | null;
+  grantedAt: string | null;
+  revokedAt: string | null;
+  reviewedAt: string | null;
+}): BreakGlassReviewStatus {
+  if (input.reviewedAt) {
+    return 'reviewed';
+  }
+  if (!input.role && !input.grantedAt && !input.expiresAt && !input.revokedAt) {
+    return 'none';
+  }
+  if (input.revokedAt) {
+    return 'revoked_unreviewed';
+  }
+  if (input.active) {
+    return 'active_unreviewed';
+  }
+  return 'expired_unreviewed';
 }
 
 function statusForAdminError(error: unknown): number {

--- a/auth/src/api/sessionController.ts
+++ b/auth/src/api/sessionController.ts
@@ -31,6 +31,7 @@ const INACTIVE_BREAK_GLASS_CONTEXT = {
   revokedBy: null,
   reviewedAt: null,
   reviewedBy: null,
+  reviewStatus: 'none',
 } as const;
 
 interface TrustedSessionExchangeBody {

--- a/auth/src/core/breakGlassReviewStatus.ts
+++ b/auth/src/core/breakGlassReviewStatus.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { BreakGlassReviewStatus } from '../types';
+
+export interface BreakGlassReviewStatusInput {
+  active: boolean;
+  role: 'admin' | null;
+  expiresAt: string | null;
+  grantedAt: string | null;
+  revokedAt: string | null;
+  reviewedAt: string | null;
+}
+
+export function resolveBreakGlassReviewStatus(
+  input: BreakGlassReviewStatusInput,
+): BreakGlassReviewStatus {
+  if (input.reviewedAt) {
+    return 'reviewed';
+  }
+  if (!input.role && !input.grantedAt && !input.expiresAt && !input.revokedAt) {
+    return 'none';
+  }
+  if (input.revokedAt) {
+    return 'revoked_unreviewed';
+  }
+  if (input.active) {
+    return 'active_unreviewed';
+  }
+  return 'expired_unreviewed';
+}

--- a/auth/src/database/queries.ts
+++ b/auth/src/database/queries.ts
@@ -5,7 +5,6 @@ import { Pool, PoolClient } from 'pg';
 import {
   AdminActor,
   AdminAuditAction,
-  BreakGlassReviewStatus,
   BreakGlassSessionContext,
   OPERATOR_CAPABILITIES,
   OPERATOR_SIGNER_ACTION_CLASSES,
@@ -16,6 +15,7 @@ import {
   UserSession,
   UserRole,
 } from '../types';
+import { resolveBreakGlassReviewStatus } from '../core/breakGlassReviewStatus';
 
 type SessionRow = Omit<
   UserSession,
@@ -169,29 +169,6 @@ function normalizeBreakGlassContext(row: SessionRow): BreakGlassSessionContext {
       reviewedAt,
     }),
   };
-}
-
-function resolveBreakGlassReviewStatus(input: {
-  active: boolean;
-  role: 'admin' | null;
-  expiresAt: string | null;
-  grantedAt: string | null;
-  revokedAt: string | null;
-  reviewedAt: string | null;
-}): BreakGlassReviewStatus {
-  if (input.reviewedAt) {
-    return 'reviewed';
-  }
-  if (!input.role && !input.grantedAt && !input.expiresAt && !input.revokedAt) {
-    return 'none';
-  }
-  if (input.revokedAt) {
-    return 'revoked_unreviewed';
-  }
-  if (input.active) {
-    return 'active_unreviewed';
-  }
-  return 'expired_unreviewed';
 }
 
 export function normalizeSessionRow(row: SessionRow): UserSession {

--- a/auth/src/database/queries.ts
+++ b/auth/src/database/queries.ts
@@ -5,6 +5,7 @@ import { Pool, PoolClient } from 'pg';
 import {
   AdminActor,
   AdminAuditAction,
+  BreakGlassReviewStatus,
   BreakGlassSessionContext,
   OPERATOR_CAPABILITIES,
   OPERATOR_SIGNER_ACTION_CLASSES,
@@ -140,6 +141,8 @@ function timestampIsoOrNull(value: Date | string | null | undefined): string | n
 function normalizeBreakGlassContext(row: SessionRow): BreakGlassSessionContext {
   const expiresAt = timestampIsoOrNull(row.breakGlassExpiresAt);
   const revokedAt = timestampIsoOrNull(row.breakGlassRevokedAt);
+  const reviewedAt = timestampIsoOrNull(row.breakGlassReviewedAt);
+  const grantedAt = timestampIsoOrNull(row.breakGlassGrantedAt);
   const active =
     row.breakGlassRole === 'admin' &&
     expiresAt !== null &&
@@ -150,14 +153,45 @@ function normalizeBreakGlassContext(row: SessionRow): BreakGlassSessionContext {
     active,
     role: row.breakGlassRole ?? null,
     expiresAt,
-    grantedAt: timestampIsoOrNull(row.breakGlassGrantedAt),
+    grantedAt,
     grantedBy: row.breakGlassGrantedBy ?? null,
     reason: row.breakGlassReason ?? null,
     revokedAt,
     revokedBy: row.breakGlassRevokedBy ?? null,
-    reviewedAt: timestampIsoOrNull(row.breakGlassReviewedAt),
+    reviewedAt,
     reviewedBy: row.breakGlassReviewedBy ?? null,
+    reviewStatus: resolveBreakGlassReviewStatus({
+      active,
+      role: row.breakGlassRole ?? null,
+      expiresAt,
+      grantedAt,
+      revokedAt,
+      reviewedAt,
+    }),
   };
+}
+
+function resolveBreakGlassReviewStatus(input: {
+  active: boolean;
+  role: 'admin' | null;
+  expiresAt: string | null;
+  grantedAt: string | null;
+  revokedAt: string | null;
+  reviewedAt: string | null;
+}): BreakGlassReviewStatus {
+  if (input.reviewedAt) {
+    return 'reviewed';
+  }
+  if (!input.role && !input.grantedAt && !input.expiresAt && !input.revokedAt) {
+    return 'none';
+  }
+  if (input.revokedAt) {
+    return 'revoked_unreviewed';
+  }
+  if (input.active) {
+    return 'active_unreviewed';
+  }
+  return 'expired_unreviewed';
 }
 
 export function normalizeSessionRow(row: SessionRow): UserSession {

--- a/auth/src/types.ts
+++ b/auth/src/types.ts
@@ -74,6 +74,13 @@ export interface UserSession {
   revokedAt: number | null;
 }
 
+export type BreakGlassReviewStatus =
+  | 'none'
+  | 'active_unreviewed'
+  | 'revoked_unreviewed'
+  | 'expired_unreviewed'
+  | 'reviewed';
+
 export interface BreakGlassSessionContext {
   active: boolean;
   role: 'admin' | null;
@@ -85,6 +92,7 @@ export interface BreakGlassSessionContext {
   revokedBy: string | null;
   reviewedAt: string | null;
   reviewedBy: string | null;
+  reviewStatus: BreakGlassReviewStatus;
 }
 
 export interface OperatorSignerAuthorization {

--- a/auth/tests/adminController.test.ts
+++ b/auth/tests/adminController.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Request, Response } from 'express';
+import { AdminController } from '../src/api/adminController';
+import type { AdminService } from '../src/core/adminService';
+import type { UserProfile } from '../src/types';
+
+function buildProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    id: 'uid-admin',
+    accountId: 'acct-admin',
+    walletAddress: '0x00000000000000000000000000000000000000aa',
+    email: 'admin@agroasys.example',
+    role: 'buyer',
+    baseRole: 'buyer',
+    orgId: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    active: true,
+    breakGlassRole: null,
+    breakGlassExpiresAt: null,
+    breakGlassGrantedAt: null,
+    breakGlassGrantedBy: null,
+    breakGlassReason: null,
+    breakGlassRevokedAt: null,
+    breakGlassRevokedBy: null,
+    breakGlassReviewedAt: null,
+    breakGlassReviewedBy: null,
+    ...overrides,
+  };
+}
+
+function mockRequest<TBody extends Record<string, unknown>>(
+  body: TBody,
+): Request<Record<string, never>, unknown, TBody> {
+  return {
+    body,
+    serviceAuth: {
+      apiKeyId: 'admin-control-key',
+    },
+  } as unknown as Request<Record<string, never>, unknown, TBody>;
+}
+
+function mockResponse(): Response {
+  const response = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return response as unknown as Response;
+}
+
+describe('AdminController break-glass review status payloads', () => {
+  test('returns active_unreviewed after granting break-glass authority', async () => {
+    const service = {
+      grantBreakGlass: jest.fn().mockResolvedValue(
+        buildProfile({
+          role: 'admin',
+          breakGlassRole: 'admin',
+          breakGlassGrantedAt: new Date('2026-06-01T00:00:00.000Z'),
+          breakGlassGrantedBy: 'incident-commander',
+          breakGlassReason: 'INC-548 controlled grant',
+          breakGlassExpiresAt: new Date(Date.now() + 300_000),
+        }),
+      ),
+    } as unknown as AdminService;
+    const controller = new AdminController(service);
+    const response = mockResponse();
+
+    await controller.grantBreakGlass(
+      mockRequest({
+        accountId: 'acct-admin',
+        ttlSeconds: 300,
+        baseRole: 'buyer' as const,
+        reason: 'INC-548 controlled grant',
+      }),
+      response,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          breakGlass: expect.objectContaining({
+            active: true,
+            reviewStatus: 'active_unreviewed',
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('returns revoked_unreviewed after revoking break-glass authority', async () => {
+    const service = {
+      revokeBreakGlass: jest.fn().mockResolvedValue(
+        buildProfile({
+          breakGlassRole: 'admin',
+          breakGlassGrantedAt: new Date('2026-06-01T00:00:00.000Z'),
+          breakGlassGrantedBy: 'incident-commander',
+          breakGlassExpiresAt: new Date('2026-06-01T00:30:00.000Z'),
+          breakGlassRevokedAt: new Date('2026-06-01T00:10:00.000Z'),
+          breakGlassRevokedBy: 'security-owner',
+        }),
+      ),
+    } as unknown as AdminService;
+    const controller = new AdminController(service);
+    const response = mockResponse();
+
+    await controller.revokeBreakGlass(
+      mockRequest({
+        accountId: 'acct-admin',
+        reason: 'INC-548 incident contained',
+      }),
+      response,
+    );
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          breakGlass: expect.objectContaining({
+            active: false,
+            reviewStatus: 'revoked_unreviewed',
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('returns reviewed after post-incident review is recorded', async () => {
+    const service = {
+      reviewBreakGlass: jest.fn().mockResolvedValue(
+        buildProfile({
+          breakGlassRole: 'admin',
+          breakGlassGrantedAt: new Date('2026-06-01T00:00:00.000Z'),
+          breakGlassGrantedBy: 'incident-commander',
+          breakGlassExpiresAt: new Date('2026-06-01T00:30:00.000Z'),
+          breakGlassRevokedAt: new Date('2026-06-01T00:10:00.000Z'),
+          breakGlassRevokedBy: 'security-owner',
+          breakGlassReviewedAt: new Date('2026-06-01T01:00:00.000Z'),
+          breakGlassReviewedBy: 'security-owner',
+        }),
+      ),
+    } as unknown as AdminService;
+    const controller = new AdminController(service);
+    const response = mockResponse();
+
+    await controller.reviewBreakGlass(
+      mockRequest({
+        accountId: 'acct-admin',
+        reason: 'INC-548 post-incident review completed',
+      }),
+      response,
+    );
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          breakGlass: expect.objectContaining({
+            active: false,
+            reviewStatus: 'reviewed',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/auth/tests/breakGlassReviewStatus.test.ts
+++ b/auth/tests/breakGlassReviewStatus.test.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { resolveBreakGlassReviewStatus } from '../src/core/breakGlassReviewStatus';
+
+describe('resolveBreakGlassReviewStatus', () => {
+  test.each([
+    [
+      'none',
+      {
+        active: false,
+        role: null,
+        expiresAt: null,
+        grantedAt: null,
+        revokedAt: null,
+        reviewedAt: null,
+      },
+    ],
+    [
+      'active_unreviewed',
+      {
+        active: true,
+        role: 'admin' as const,
+        expiresAt: '2026-06-02T00:00:00.000Z',
+        grantedAt: '2026-06-01T00:00:00.000Z',
+        revokedAt: null,
+        reviewedAt: null,
+      },
+    ],
+    [
+      'revoked_unreviewed',
+      {
+        active: false,
+        role: 'admin' as const,
+        expiresAt: '2026-06-02T00:00:00.000Z',
+        grantedAt: '2026-06-01T00:00:00.000Z',
+        revokedAt: '2026-06-01T01:00:00.000Z',
+        reviewedAt: null,
+      },
+    ],
+    [
+      'expired_unreviewed',
+      {
+        active: false,
+        role: 'admin' as const,
+        expiresAt: '2026-06-01T00:00:00.000Z',
+        grantedAt: '2026-06-01T00:00:00.000Z',
+        revokedAt: null,
+        reviewedAt: null,
+      },
+    ],
+    [
+      'reviewed',
+      {
+        active: false,
+        role: 'admin' as const,
+        expiresAt: '2026-06-01T00:00:00.000Z',
+        grantedAt: '2026-06-01T00:00:00.000Z',
+        revokedAt: null,
+        reviewedAt: '2026-06-01T02:00:00.000Z',
+      },
+    ],
+  ] as const)('returns %s', (expected, input) => {
+    expect(resolveBreakGlassReviewStatus(input)).toBe(expected);
+  });
+});

--- a/auth/tests/controller.test.ts
+++ b/auth/tests/controller.test.ts
@@ -381,6 +381,10 @@ describe('AuthController.getSession', () => {
           walletAddress: WALLET,
           email: 'admin@example.com',
           role: 'buyer',
+          breakGlass: expect.objectContaining({
+            active: false,
+            reviewStatus: 'none',
+          }),
         }),
       }),
     );

--- a/auth/tests/queries.test.ts
+++ b/auth/tests/queries.test.ts
@@ -83,6 +83,61 @@ describe('normalizeSessionRow', () => {
       }),
     ).toThrow('Invalid issuedAt session timestamp returned from database');
   });
+
+  test('derives break-glass post-incident review status from session rows', () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const baseRow = {
+      sessionId: 'sess-review',
+      accountId: 'acct-review',
+      userId: 'user-review',
+      walletAddress: null,
+      email: 'ops@example.com',
+      role: 'admin' as const,
+      capabilities: null,
+      signerAuthorizations: null,
+      issuedAt: '1772916944',
+      expiresAt: '1772920544',
+      revokedAt: null,
+      breakGlassRole: 'admin' as const,
+      breakGlassGrantedAt: past,
+      breakGlassGrantedBy: 'incident-commander',
+      breakGlassReason: 'INC-548 review status proof',
+      breakGlassRevokedAt: null,
+      breakGlassRevokedBy: null,
+      breakGlassReviewedAt: null,
+      breakGlassReviewedBy: null,
+    };
+
+    expect(
+      normalizeSessionRow({
+        ...baseRow,
+        breakGlassExpiresAt: future,
+      }).breakGlass,
+    ).toEqual(expect.objectContaining({ active: true, reviewStatus: 'active_unreviewed' }));
+    expect(
+      normalizeSessionRow({
+        ...baseRow,
+        breakGlassExpiresAt: past,
+      }).breakGlass,
+    ).toEqual(expect.objectContaining({ active: false, reviewStatus: 'expired_unreviewed' }));
+    expect(
+      normalizeSessionRow({
+        ...baseRow,
+        breakGlassExpiresAt: future,
+        breakGlassRevokedAt: past,
+        breakGlassRevokedBy: 'security-owner',
+      }).breakGlass,
+    ).toEqual(expect.objectContaining({ active: false, reviewStatus: 'revoked_unreviewed' }));
+    expect(
+      normalizeSessionRow({
+        ...baseRow,
+        breakGlassExpiresAt: past,
+        breakGlassReviewedAt: future,
+        breakGlassReviewedBy: 'security-owner',
+      }).breakGlass,
+    ).toEqual(expect.objectContaining({ active: false, reviewStatus: 'reviewed' }));
+  });
 });
 
 describe('upsertTrustedProfile', () => {

--- a/docs/runbooks/auth-break-glass.md
+++ b/docs/runbooks/auth-break-glass.md
@@ -89,9 +89,11 @@ operator routes:
 
 Rejected signer attempts return `SIGNER_POLICY_RESTRICTED` with the action
 class, signer environment, and break-glass evidence fields. Successful
-privileged audit records include `breakGlassActive`, `breakGlassReason`, and
-`breakGlassExpiresAt` so reviewers can separate normal signer use from
-incident authority.
+privileged audit records include `breakGlassActive`, `breakGlassReason`,
+`breakGlassExpiresAt`, `breakGlassReviewedAt`, `breakGlassReviewedBy`, and
+`breakGlassReviewStatus` so reviewers can separate normal signer use from
+incident authority and see whether emergency access still needs post-incident
+closure.
 
 ## Expiry
 
@@ -151,6 +153,8 @@ The reviewer must confirm:
   binding and incident approval
 - privileged actions during the window match the incident scope
 - the audit trail exists in `auth_admin_audit_events`
+- the profile/session break-glass context has `reviewStatus: reviewed` after
+  review is complete
 
 ## Required Alerts
 

--- a/docs/runbooks/auth-break-glass.md
+++ b/docs/runbooks/auth-break-glass.md
@@ -95,6 +95,10 @@ privileged audit records include `breakGlassActive`, `breakGlassReason`,
 incident authority and see whether emergency access still needs post-incident
 closure.
 
+Gateway session validation treats the break-glass review status as required
+evidence. If auth omits `breakGlass.reviewStatus` or emits an unknown value, the
+gateway fails closed instead of accepting an ambiguous emergency posture.
+
 ## Expiry
 
 Break-glass expires at `break_glass_expires_at`. Expired elevation is not

--- a/docs/runbooks/operator-signer-authority-program.md
+++ b/docs/runbooks/operator-signer-authority-program.md
@@ -108,6 +108,7 @@ Relevant runtime surfaces:
 - `gateway/src/routes/governanceMutations.ts`
 - `gateway/src/core/governanceMutationService.ts`
 - `gateway/src/core/governanceStore.ts`
+- `gateway/tests/signerPolicyCoverage.test.ts`
 
 ### 4. Treasury has an explicit session-only vs signer-required policy
 
@@ -124,7 +125,14 @@ Relevant runtime surfaces:
 
 - `gateway/src/routes/treasury.ts`
 - `gateway/src/core/treasuryWorkflowService.ts`
+- `gateway/tests/signerPolicyCoverage.test.ts`
 - `docs/adr/adr-0412-treasury-revenue-controls-boundary.md`
+
+Future governance, treasury, or emergency signer-required route additions must
+extend the centralized signer policy path and update
+`gateway/tests/signerPolicyCoverage.test.ts`. A privileged route that bypasses
+`requireAuthorizedSignerBinding` is a security regression, even if it still has
+operator session or write-allowlist checks.
 
 ### 5. Break-glass admin posture is not ordinary signer posture
 
@@ -150,9 +158,9 @@ Allowed under break-glass only by explicit backend policy:
 
 Runtime evidence for privileged actions must mark whether break-glass was
 active, why it was active, when it expires, which signer policy result was
-applied, and which approved binding was used. A reviewer should never need to
-infer whether a privileged signer action came from normal durable admin posture
-or incident posture.
+applied, which review status applies, and which approved binding was used. A
+reviewer should never need to infer whether a privileged signer action came from
+normal durable admin posture or incident posture.
 
 ## Historical Baseline Before Signer Hardening
 

--- a/docs/runbooks/operator-signer-authority-program.md
+++ b/docs/runbooks/operator-signer-authority-program.md
@@ -162,6 +162,10 @@ applied, which review status applies, and which approved binding was used. A
 reviewer should never need to infer whether a privileged signer action came from
 normal durable admin posture or incident posture.
 
+Gateway-auth contracts require the review status to be present on every
+break-glass session context. Missing or unknown review status is treated as an
+invalid upstream auth payload and is rejected fail-closed.
+
 ## Historical Baseline Before Signer Hardening
 
 ### 1. Historical authoritative session model

--- a/gateway/src/core/authSessionClient.ts
+++ b/gateway/src/core/authSessionClient.ts
@@ -50,7 +50,7 @@ export interface BreakGlassSessionContext {
   revokedBy: string | null;
   reviewedAt: string | null;
   reviewedBy: string | null;
-  reviewStatus?: BreakGlassReviewStatus;
+  reviewStatus: BreakGlassReviewStatus;
 }
 
 export interface AuthSession {
@@ -153,8 +153,7 @@ function isBreakGlassSessionContext(value: unknown): value is BreakGlassSessionC
     isStringOrNull(candidate.revokedBy) &&
     isStringOrNull(candidate.reviewedAt) &&
     isStringOrNull(candidate.reviewedBy) &&
-    (candidate.reviewStatus === undefined ||
-      isKnownValue(BREAK_GLASS_REVIEW_STATUSES, candidate.reviewStatus))
+    isKnownValue(BREAK_GLASS_REVIEW_STATUSES, candidate.reviewStatus)
   );
 }
 

--- a/gateway/src/core/authSessionClient.ts
+++ b/gateway/src/core/authSessionClient.ts
@@ -21,6 +21,12 @@ export type SignerActionClass =
   | 'treasury_close'
   | 'compliance_sensitive'
   | 'emergency_admin';
+export type BreakGlassReviewStatus =
+  | 'none'
+  | 'active_unreviewed'
+  | 'revoked_unreviewed'
+  | 'expired_unreviewed'
+  | 'reviewed';
 
 export interface SignerAuthorization {
   bindingId: string;
@@ -44,6 +50,7 @@ export interface BreakGlassSessionContext {
   revokedBy: string | null;
   reviewedAt: string | null;
   reviewedBy: string | null;
+  reviewStatus?: BreakGlassReviewStatus;
 }
 
 export interface AuthSession {
@@ -86,6 +93,13 @@ const SIGNER_ACTION_CLASSES: SignerActionClass[] = [
   'treasury_close',
   'compliance_sensitive',
   'emergency_admin',
+];
+const BREAK_GLASS_REVIEW_STATUSES: BreakGlassReviewStatus[] = [
+  'none',
+  'active_unreviewed',
+  'revoked_unreviewed',
+  'expired_unreviewed',
+  'reviewed',
 ];
 
 function buildUrl(baseUrl: string, pathname: string): string {
@@ -138,7 +152,9 @@ function isBreakGlassSessionContext(value: unknown): value is BreakGlassSessionC
     isStringOrNull(candidate.revokedAt) &&
     isStringOrNull(candidate.revokedBy) &&
     isStringOrNull(candidate.reviewedAt) &&
-    isStringOrNull(candidate.reviewedBy)
+    isStringOrNull(candidate.reviewedBy) &&
+    (candidate.reviewStatus === undefined ||
+      isKnownValue(BREAK_GLASS_REVIEW_STATUSES, candidate.reviewStatus))
   );
 }
 

--- a/gateway/src/core/governanceMutationService.ts
+++ b/gateway/src/core/governanceMutationService.ts
@@ -345,6 +345,9 @@ function buildAuditRecord(
     breakGlassActive: principal.session.breakGlass?.active ?? false,
     breakGlassReason: principal.session.breakGlass?.reason ?? null,
     breakGlassExpiresAt: principal.session.breakGlass?.expiresAt ?? null,
+    breakGlassReviewedAt: principal.session.breakGlass?.reviewedAt ?? null,
+    breakGlassReviewedBy: principal.session.breakGlass?.reviewedBy ?? null,
+    breakGlassReviewStatus: principal.session.breakGlass?.reviewStatus ?? null,
   };
 }
 
@@ -803,6 +806,9 @@ export class GovernanceMutationService {
         breakGlassActive: input.principal.session.breakGlass?.active ?? false,
         breakGlassReason: input.principal.session.breakGlass?.reason ?? null,
         breakGlassExpiresAt: input.principal.session.breakGlass?.expiresAt ?? null,
+        breakGlassReviewedAt: input.principal.session.breakGlass?.reviewedAt ?? null,
+        breakGlassReviewedBy: input.principal.session.breakGlass?.reviewedBy ?? null,
+        breakGlassReviewStatus: input.principal.session.breakGlass?.reviewStatus ?? null,
         idempotencyKey: input.idempotencyKey,
       },
     };
@@ -1151,6 +1157,9 @@ export class GovernanceMutationService {
         breakGlassActive: input.principal.session.breakGlass?.active ?? false,
         breakGlassReason: input.principal.session.breakGlass?.reason ?? null,
         breakGlassExpiresAt: input.principal.session.breakGlass?.expiresAt ?? null,
+        breakGlassReviewedAt: input.principal.session.breakGlass?.reviewedAt ?? null,
+        breakGlassReviewedBy: input.principal.session.breakGlass?.reviewedBy ?? null,
+        breakGlassReviewStatus: input.principal.session.breakGlass?.reviewStatus ?? null,
       },
     };
 

--- a/gateway/src/core/governanceStore.ts
+++ b/gateway/src/core/governanceStore.ts
@@ -127,6 +127,9 @@ export interface GovernanceActionAuditRecord {
   breakGlassActive?: boolean;
   breakGlassReason?: string | null;
   breakGlassExpiresAt?: string | null;
+  breakGlassReviewedAt?: string | null;
+  breakGlassReviewedBy?: string | null;
+  breakGlassReviewStatus?: string | null;
   finalSignerWallet?: string | null;
   finalSignerVerifiedAt?: string | null;
 }

--- a/gateway/src/core/governanceWriteStore.ts
+++ b/gateway/src/core/governanceWriteStore.ts
@@ -68,6 +68,9 @@ function governanceActionParams(action: GovernanceActionRecord): unknown[] {
       breakGlassActive: action.audit.breakGlassActive ?? false,
       breakGlassReason: action.audit.breakGlassReason ?? null,
       breakGlassExpiresAt: action.audit.breakGlassExpiresAt ?? null,
+      breakGlassReviewedAt: action.audit.breakGlassReviewedAt ?? null,
+      breakGlassReviewedBy: action.audit.breakGlassReviewedBy ?? null,
+      breakGlassReviewStatus: action.audit.breakGlassReviewStatus ?? null,
     }),
     action.finalSignerWallet ?? null,
     action.verificationState ??

--- a/gateway/src/core/treasuryWorkflowService.ts
+++ b/gateway/src/core/treasuryWorkflowService.ts
@@ -188,6 +188,9 @@ function breakGlassEvidence(session: AuthSession) {
     active: session.breakGlass?.active ?? false,
     reason: session.breakGlass?.reason ?? null,
     expiresAt: session.breakGlass?.expiresAt ?? null,
+    reviewedAt: session.breakGlass?.reviewedAt ?? null,
+    reviewedBy: session.breakGlass?.reviewedBy ?? null,
+    reviewStatus: session.breakGlass?.reviewStatus ?? null,
   };
 }
 
@@ -661,6 +664,9 @@ export class TreasuryWorkflowService implements TreasuryWorkflowClient {
       breakGlassActive: breakGlass.active,
       breakGlassReason: breakGlass.reason,
       breakGlassExpiresAt: breakGlass.expiresAt,
+      breakGlassReviewedAt: breakGlass.reviewedAt,
+      breakGlassReviewedBy: breakGlass.reviewedBy,
+      breakGlassReviewStatus: breakGlass.reviewStatus,
       auditReason: context.audit.reason,
       auditTicketRef: context.audit.ticketRef,
       auditEvidenceReferences: context.audit.evidenceReferences ?? [],
@@ -731,6 +737,9 @@ export class TreasuryWorkflowService implements TreasuryWorkflowClient {
           breakGlassActive: complianceMetadata.breakGlassActive,
           breakGlassReason: complianceMetadata.breakGlassReason,
           breakGlassExpiresAt: complianceMetadata.breakGlassExpiresAt,
+          breakGlassReviewedAt: complianceMetadata.breakGlassReviewedAt,
+          breakGlassReviewedBy: complianceMetadata.breakGlassReviewedBy,
+          breakGlassReviewStatus: complianceMetadata.breakGlassReviewStatus,
           signerPolicy: context.signerPolicy ?? { required: false, result: 'not_required' },
           result: dataRecord,
         },

--- a/gateway/src/middleware/auth.ts
+++ b/gateway/src/middleware/auth.ts
@@ -46,6 +46,7 @@ const INACTIVE_BREAK_GLASS_CONTEXT: BreakGlassSessionContext = {
   revokedBy: null,
   reviewedAt: null,
   reviewedBy: null,
+  reviewStatus: 'none',
 };
 
 export interface GatewayPrincipal {
@@ -68,6 +69,9 @@ export interface SignerPolicyEvaluation {
   breakGlassActive: boolean;
   breakGlassReason: string | null;
   breakGlassExpiresAt: string | null;
+  breakGlassReviewedAt?: string | null;
+  breakGlassReviewedBy?: string | null;
+  breakGlassReviewStatus?: BreakGlassSessionContext['reviewStatus'] | null;
 }
 
 export interface AuthorizedSignerBinding extends SignerAuthorization {
@@ -360,6 +364,9 @@ export function requireAuthorizedSignerBinding(
       breakGlassActive: policy.breakGlassActive,
       breakGlassReason: policy.breakGlassReason,
       breakGlassExpiresAt: policy.breakGlassExpiresAt,
+      breakGlassReviewedAt: policy.breakGlassReviewedAt ?? null,
+      breakGlassReviewedBy: policy.breakGlassReviewedBy ?? null,
+      breakGlassReviewStatus: policy.breakGlassReviewStatus ?? null,
     });
   }
 
@@ -404,6 +411,9 @@ export function evaluateSignerPolicy(
       breakGlassActive: false,
       breakGlassReason: null,
       breakGlassExpiresAt: null,
+      breakGlassReviewedAt: breakGlassContext.reviewedAt ?? null,
+      breakGlassReviewedBy: breakGlassContext.reviewedBy ?? null,
+      breakGlassReviewStatus: breakGlassContext.reviewStatus ?? null,
     };
   }
 
@@ -417,6 +427,9 @@ export function evaluateSignerPolicy(
       breakGlassActive: true,
       breakGlassReason: breakGlassContext.reason,
       breakGlassExpiresAt: breakGlassContext.expiresAt,
+      breakGlassReviewedAt: breakGlassContext.reviewedAt ?? null,
+      breakGlassReviewedBy: breakGlassContext.reviewedBy ?? null,
+      breakGlassReviewStatus: breakGlassContext.reviewStatus ?? null,
     };
   }
 
@@ -429,5 +442,8 @@ export function evaluateSignerPolicy(
     breakGlassActive: breakGlassContext.active,
     breakGlassReason: breakGlassContext.reason,
     breakGlassExpiresAt: breakGlassContext.expiresAt,
+    breakGlassReviewedAt: breakGlassContext.reviewedAt ?? null,
+    breakGlassReviewedBy: breakGlassContext.reviewedBy ?? null,
+    breakGlassReviewStatus: breakGlassContext.reviewStatus ?? null,
   };
 }

--- a/gateway/tests/authMiddleware.test.ts
+++ b/gateway/tests/authMiddleware.test.ts
@@ -77,6 +77,7 @@ function buildSession(overrides: Partial<AuthSession> = {}): AuthSession {
       revokedBy: null,
       reviewedAt: null,
       reviewedBy: null,
+      reviewStatus: 'none',
     },
     email: 'admin@agroasys.io',
     issuedAt: 1,
@@ -416,6 +417,7 @@ describe('signer authorization enforcement', () => {
               revokedBy: null,
               reviewedAt: null,
               reviewedBy: null,
+              reviewStatus: 'active_unreviewed',
             },
             signerAuthorizations: [
               buildSignerAuthorization({
@@ -452,6 +454,7 @@ describe('signer authorization enforcement', () => {
             revokedBy: null,
             reviewedAt: null,
             reviewedBy: null,
+            reviewStatus: 'active_unreviewed',
           },
           signerAuthorizations: [
             buildSignerAuthorization({

--- a/gateway/tests/authSessionClient.test.ts
+++ b/gateway/tests/authSessionClient.test.ts
@@ -73,6 +73,7 @@ function buildAuthSession(overrides: Record<string, unknown> = {}) {
       revokedBy: null,
       reviewedAt: null,
       reviewedBy: null,
+      reviewStatus: 'none',
     },
     issuedAt: 1777353600,
     expiresAt: 1777357200,

--- a/gateway/tests/authSessionClient.test.ts
+++ b/gateway/tests/authSessionClient.test.ts
@@ -162,4 +162,33 @@ describe('AuthSessionClient contract validation', () => {
       code: 'UPSTREAM_UNAVAILABLE',
     });
   });
+
+  test('fails closed when auth omits break-glass review evidence status', async () => {
+    const breakGlassWithoutReviewStatus = {
+      active: false,
+      role: null,
+      expiresAt: null,
+      grantedAt: null,
+      grantedBy: null,
+      reason: null,
+      revokedAt: null,
+      revokedBy: null,
+      reviewedAt: null,
+      reviewedBy: null,
+    };
+    const malformedSession = buildAuthSession({ breakGlass: breakGlassWithoutReviewStatus });
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: malformedSession }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const client = createAuthSessionClient(baseConfig);
+    await expect(client.resolveSession('sess-1', 'req-1')).rejects.toMatchObject({
+      statusCode: 503,
+      code: 'UPSTREAM_UNAVAILABLE',
+      message: 'Auth service returned an invalid session payload',
+    });
+  });
 });

--- a/gateway/tests/governanceMutations.contract.test.ts
+++ b/gateway/tests/governanceMutations.contract.test.ts
@@ -594,6 +594,7 @@ describe('gateway governance mutation routes contract', () => {
             revokedBy: null,
             reviewedAt: null,
             reviewedBy: null,
+            reviewStatus: 'active_unreviewed',
           },
           issuedAt: Date.now(),
           expiresAt: Date.now() + 60_000,

--- a/gateway/tests/signerPolicyCoverage.test.ts
+++ b/gateway/tests/signerPolicyCoverage.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function readGatewaySource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, '..', relativePath), 'utf8');
+}
+
+function routeBlock(source: string, route: string): string {
+  const marker = `'${route}'`;
+  const start = source.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const nextRoute = source.indexOf('router.post(', start + marker.length);
+  return source.slice(start, nextRoute === -1 ? undefined : nextRoute);
+}
+
+describe('privileged signer route coverage', () => {
+  test('governance direct-sign route support uses centralized signer policy', () => {
+    const source = readGatewaySource('src/routes/governanceMutationRouteSupport.ts');
+
+    expect(source).toContain('requireAuthorizedSignerBinding');
+    expect(source).toContain('requireSignerWalletAddress');
+    expect(source).toMatch(
+      /requireAuthorizedSignerBinding\(\s*req\.gatewayPrincipal,\s*config,\s*'governance'/,
+    );
+    expect(source).toContain('prepareAndRespond');
+    expect(source).toContain('confirmAndRespond');
+  });
+
+  test('treasury signer-required routes call the centralized signer policy helper', () => {
+    const source = readGatewaySource('src/routes/treasury.ts');
+    const directSignerRoutes = [
+      '/treasury/accounting-periods/:periodId/request-close',
+      '/treasury/accounting-periods/:periodId/close',
+      '/treasury/sweep-batches/:batchId/request-approval',
+      '/treasury/sweep-batches/:batchId/approve',
+      '/treasury/sweep-batches/:batchId/match-execution',
+      '/treasury/sweep-batches/:batchId/close',
+      '/treasury/entries/:entryId/realizations',
+    ];
+    const sharedHandoffRoutes = [
+      '/treasury/sweep-batches/:batchId/external-handoff',
+      '/treasury/sweep-batches/:batchId/partner-handoff',
+    ];
+
+    expect(source).toContain('const assertAuthorizedTreasurySigner');
+    expect(source).toMatch(
+      /return requireAuthorizedSignerBinding\(\s*req\.gatewayPrincipal,\s*options\.config,\s*actionClass/,
+    );
+
+    for (const route of directSignerRoutes) {
+      const block = routeBlock(source, route);
+      expect(block).toContain('signerPolicy: {');
+      expect(block).toContain('required: true');
+      expect(block).toContain('binding: assertAuthorizedTreasurySigner(');
+    }
+
+    const sharedHandler = source.slice(
+      source.indexOf('const recordExternalHandoff'),
+      source.indexOf("router.post(\n    '/treasury/sweep-batches/:batchId/external-handoff'"),
+    );
+    expect(sharedHandler).toContain('signerPolicy: {');
+    expect(sharedHandler).toContain('required: true');
+    expect(sharedHandler).toContain("actionClass: 'treasury_execute'");
+    expect(sharedHandler).toContain('binding: assertAuthorizedTreasurySigner(');
+
+    for (const route of sharedHandoffRoutes) {
+      const block = routeBlock(source, route);
+      expect(block).toContain('...requireTreasuryExecuteMatch');
+      expect(block).toContain('recordExternalHandoff');
+    }
+  });
+});

--- a/gateway/tests/signerPolicyCoverage.test.ts
+++ b/gateway/tests/signerPolicyCoverage.test.ts
@@ -16,6 +16,30 @@ function routeBlock(source: string, route: string): string {
   return source.slice(start, nextRoute === -1 ? undefined : nextRoute);
 }
 
+function routerPostBlocks(source: string): Array<{ route: string; block: string }> {
+  const blocks: Array<{ route: string; block: string }> = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const start = source.indexOf('router.post(', cursor);
+    if (start === -1) {
+      break;
+    }
+
+    const routeMatch = source.slice(start).match(/router\.post\(\s*['"]([^'"]+)['"]/);
+    expect(routeMatch).not.toBeNull();
+
+    const nextRoute = source.indexOf('router.post(', start + 'router.post('.length);
+    blocks.push({
+      route: routeMatch?.[1] ?? '',
+      block: source.slice(start, nextRoute === -1 ? undefined : nextRoute),
+    });
+    cursor = start + 'router.post('.length;
+  }
+
+  return blocks;
+}
+
 describe('privileged signer route coverage', () => {
   test('governance direct-sign route support uses centralized signer policy', () => {
     const source = readGatewaySource('src/routes/governanceMutationRouteSupport.ts');
@@ -27,6 +51,24 @@ describe('privileged signer route coverage', () => {
     );
     expect(source).toContain('prepareAndRespond');
     expect(source).toContain('confirmAndRespond');
+  });
+
+  test('governance direct-sign route handlers only enter through signer-policy wrappers', () => {
+    const source = readGatewaySource('src/routes/governanceDirectSignMutations.ts');
+    const blocks = routerPostBlocks(source);
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const { route, block } of blocks) {
+      if (route.endsWith('/prepare')) {
+        expect(block).toContain('prepareAndRespond(');
+        expect(block).not.toContain('confirmAndRespond(');
+        continue;
+      }
+
+      expect(route).toBe('/governance/actions/:actionId/confirm');
+      expect(block).toContain('confirmAndRespond(');
+      expect(block).not.toContain('prepareAndRespond(');
+    }
   });
 
   test('treasury signer-required routes call the centralized signer policy helper', () => {


### PR DESCRIPTION
## Summary
- adds a gateway signer-policy coverage guard for governance and treasury privileged routes
- adds explicit break-glass review status to auth session/profile output and gateway audit evidence
- updates break-glass and signer-authority runbooks for future route additions and post-incident closure

## Issue Metadata
Resolves #547
Resolves #548

## Stack
- Stacked on #545 / `closeout/signer-tail-483`; review this after the signer closeout branch.
- Because this is intentionally stacked on a non-default base branch, GitHub may not show auto-closing issue references until it is retargeted or the stack lands.
- This does not merge anything and does not change gasless operational issue closure status.

## Validation
- `pnpm --dir auth test -- queries.test.ts controller.test.ts sessionService.test.ts`
- `pnpm --dir gateway test -- signerPolicyCoverage.test.ts authSessionClient.test.ts authMiddleware.test.ts governanceMutations.contract.test.ts treasuryWorkflowService.test.ts treasuryRoutes.contract.test.ts`
- `pnpm --dir auth run typecheck`
- `pnpm --dir gateway run typecheck`
- `pnpm --dir auth run lint`
- `pnpm --dir gateway run lint`
- `pnpm format:check ...`
- `git diff --check`