### PR TITLE
fix(indexer): persist UnpauseApproved counts, extract TTL constant, drop dead graphqlPort config

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -2,7 +2,7 @@
   "name": "indexer",
   "private": true,
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "build": "rm -rf lib && tsc",

--- a/indexer/src/config.ts
+++ b/indexer/src/config.ts
@@ -27,9 +27,6 @@ export interface IndexerConfig {
 
   // contract
   contractAddress: string;
-
-  // graphql
-  graphqlPort: number;
 }
 
 function validateEnv(name: string): string {
@@ -92,7 +89,6 @@ export function loadConfig(): IndexerConfig {
       finalityConfirmationBlocks: validateEnvNumber('FINALITY_CONFIRMATION_BLOCKS'),
       prometheusPort: optionalEnvNumber('PROMETHEUS_PORT'),
       contractAddress: validateEnv('CONTRACT_ADDRESS').toLowerCase(),
-      graphqlPort: validateEnvNumber('GRAPHQL_PORT'),
     };
 
     return config;

--- a/indexer/src/main.ts
+++ b/indexer/src/main.ts
@@ -33,6 +33,7 @@ type IndexerBlock = BlockData<Fields>;
 type DecodedEscrowLog = NonNullable<ReturnType<typeof contractInterface.parseLog>>;
 
 const SETTLEMENT_SUPPORT_FEE_BASE_UNITS = 4_000_000n;
+const PROPOSAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 function splitPlatformFeeComponents(platformFeesAmount: bigint): {
   platformFeeNetAmount: bigint;
@@ -1442,9 +1443,7 @@ async function handleDisputeSolutionProposed(
 
   const disputeStatusEnum = disputeStatus === 0n ? DisputeStatus.REFUND : DisputeStatus.RESOLVE;
 
-  // Calculate expiration (7 days TTL)
-  const DISPUTE_PROPOSAL_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
-  const expiresAt = new Date(timestamp.getTime() + DISPUTE_PROPOSAL_TTL);
+  const expiresAt = new Date(timestamp.getTime() + PROPOSAL_TTL_MS);
 
   const proposal = new DisputeProposal({
     id: proposalId.toString(),
@@ -1695,9 +1694,7 @@ async function handleOracleUpdateProposed(
 ) {
   const [proposalId, proposer, newOracle, eta, emergencyFastTrack] = log.args;
 
-  // Calculate expiration (7 days TTL)
-  const GOVERNANCE_PROPOSAL_TTL = 7 * 24 * 60 * 60 * 1000;
-  const expiresAt = new Date(timestamp.getTime() + GOVERNANCE_PROPOSAL_TTL);
+  const expiresAt = new Date(timestamp.getTime() + PROPOSAL_TTL_MS);
 
   const proposal = new OracleUpdateProposal({
     id: proposalId.toString(),
@@ -1906,9 +1903,7 @@ async function handleAdminAddProposed(
 ) {
   const [proposalId, proposer, newAdmin, eta] = log.args;
 
-  // Calculate expiration (7 days TTL)
-  const GOVERNANCE_PROPOSAL_TTL = 7 * 24 * 60 * 60 * 1000;
-  const expiresAt = new Date(timestamp.getTime() + GOVERNANCE_PROPOSAL_TTL);
+  const expiresAt = new Date(timestamp.getTime() + PROPOSAL_TTL_MS);
 
   const proposal = new AdminAddProposal({
     id: proposalId.toString(),
@@ -2147,6 +2142,8 @@ async function handleUnpauseApproved(
       logIndex,
       transactionIndex,
       triggeredBy: triggeredBy.toLowerCase(),
+      approvalCount: Number(approvalCount),
+      requiredApprovals: Number(requiredApprovals),
     }),
   );
 

--- a/indexer/tests/systemEventApprovalFields.test.mjs
+++ b/indexer/tests/systemEventApprovalFields.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('UnpauseApproved SystemEvent persists approvalCount and requiredApprovals', () => {
+  const source = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+
+  const systemEventBlocks = [...source.matchAll(/new SystemEvent\(\{([\s\S]*?)\n\s*\}\)/g)].map(
+    (match) => match[1],
+  );
+
+  assert.ok(systemEventBlocks.length > 0, 'expected SystemEvent blocks in indexer/src/main.ts');
+
+  const unpauseApprovedBlock = systemEventBlocks.find((block) =>
+    block.includes("eventName: 'UnpauseApproved'"),
+  );
+
+  assert.ok(
+    unpauseApprovedBlock,
+    'expected a SystemEvent block with eventName UnpauseApproved in indexer/src/main.ts',
+  );
+  assert.match(
+    unpauseApprovedBlock,
+    /\bapprovalCount\b/,
+    'UnpauseApproved SystemEvent must persist approvalCount',
+  );
+  assert.match(
+    unpauseApprovedBlock,
+    /\brequiredApprovals\b/,
+    'UnpauseApproved SystemEvent must persist requiredApprovals',
+  );
+});


### PR DESCRIPTION
 - Bug fixed:  handleUnpauseApproved: approvalCount and requiredApprovals were decoded from the log and even logged, but never persisted to the SystemEvent record. Every other *Approved handler stores these fields; now UnpauseApproved does too.

  - Cleanup: Inline TTL constant defined 3× under 2 different names (DISPUTE_PROPOSAL_TTL, GOVERNANCE_PROPOSAL_TTL) all with the same value 7 * 24 * 60 * 60 * 1000. Replaced with a single module-level PROPOSAL_TTL_MS.

  - Cleanup: graphqlPort in config.ts validated GRAPHQL_PORT from env and stored it in IndexerConfig, but the indexer process never reads it. The squid-graphql-server container gets GQL_PORT directly from compose.

  - Minor:  package.json engine >=16 bumped to >=20

