### PR TITLE
refactor(oracle): remove dead code and simplify indexer timeout config

### DIFF
--- a/oracle/package.json
+++ b/oracle/package.json
@@ -25,8 +25,7 @@
     "ethers": "^6.4.0",
     "pg": "^8.20.0",
     "@agroasys/sdk": "^1.0.0",
-    "@agroasys/notifications": "^1.0.0",
-    "reflect-metadata": "^0.2.2"
+    "@agroasys/notifications": "^1.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/oracle/src/blockchain/sdk-client.ts
+++ b/oracle/src/blockchain/sdk-client.ts
@@ -3,7 +3,6 @@ import { OracleSDK, Trade } from '@agroasys/sdk';
 import { createManagedRpcProvider } from '@agroasys/sdk/rpc/failoverProvider';
 import type { SettlementConfirmationHeads } from '@agroasys/sdk';
 import { Logger } from '../utils/logger';
-import { IndexerClient, IndexerTrade } from './indexer-client';
 
 export interface BlockchainResult {
   txHash: string;
@@ -14,7 +13,6 @@ export class SDKClient {
   private sdk: OracleSDK;
   private provider: ethers.AbstractProvider;
   private signer: ethers.Wallet;
-  private indexer: IndexerClient;
 
   constructor(
     rpcUrl: string,
@@ -23,7 +21,6 @@ export class SDKClient {
     escrowAddress: string,
     usdcAddress: string,
     chainId: number,
-    indexer: IndexerClient,
   ) {
     const provider = createManagedRpcProvider(rpcUrl, rpcFallbackUrls, { chainId });
     this.provider = provider;
@@ -36,8 +33,6 @@ export class SDKClient {
       escrowAddress,
       usdcAddress,
     });
-
-    this.indexer = indexer;
 
     Logger.info('SDKClient initialized', {
       oracleAddress: this.signer.address,
@@ -88,23 +83,6 @@ export class SDKClient {
     }
 
     return trade;
-  }
-
-  private mapIndexerTradeToSDK(indexerTrade: IndexerTrade): Trade {
-    return {
-      tradeId: indexerTrade.tradeId,
-      buyer: indexerTrade.buyer,
-      supplier: indexerTrade.supplier,
-      status: indexerTrade.status,
-      totalAmountLocked: indexerTrade.totalAmountLocked,
-      logisticsAmount: indexerTrade.logisticsAmount,
-      platformFeesAmount: indexerTrade.platformFeesAmount,
-      supplierFirstTranche: indexerTrade.supplierFirstTranche,
-      supplierSecondTranche: indexerTrade.supplierSecondTranche,
-      ricardianHash: indexerTrade.ricardianHash,
-      createdAt: indexerTrade.createdAt,
-      arrivalTimestamp: indexerTrade.arrivalTimestamp ?? undefined,
-    };
   }
 
   async releaseFundsStage1(tradeId: string): Promise<BlockchainResult> {

--- a/oracle/src/config.test.ts
+++ b/oracle/src/config.test.ts
@@ -57,6 +57,24 @@ function loadConfigModule(): typeof import('./config') {
   return loaded;
 }
 
+describe('INDEXER_GQL_TIMEOUT_MS validation', () => {
+  test('rejects value below 1000', () => {
+    withEnv({ INDEXER_GQL_TIMEOUT_MS: '999' }, () => {
+      expect(() => loadConfigModule()).toThrow(
+        'INDEXER_GQL_TIMEOUT_MS must be between 1000 and 60000',
+      );
+    });
+  });
+
+  test('rejects value above 60000', () => {
+    withEnv({ INDEXER_GQL_TIMEOUT_MS: '60001' }, () => {
+      expect(() => loadConfigModule()).toThrow(
+        'INDEXER_GQL_TIMEOUT_MS must be between 1000 and 60000',
+      );
+    });
+  });
+});
+
 describe('oracle runtime config', () => {
   test('resolves base-sepolia defaults from settlement runtime key', () => {
     withEnv(

--- a/oracle/src/config.ts
+++ b/oracle/src/config.ts
@@ -78,8 +78,6 @@ export function loadConfig(): OracleConfig {
     const nodeEnv = process.env.NODE_ENV || 'development';
     const notificationsEnabled = validateEnvBool('NOTIFICATIONS_ENABLED', false);
     const notificationsWebhookUrl = process.env.NOTIFICATIONS_WEBHOOK_URL;
-    const indexerGraphqlTimeoutMinMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MIN_MS', 1000);
-    const indexerGraphqlTimeoutMaxMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MAX_MS', 60000);
     const indexerGraphqlRequestTimeoutMs = validateEnvNumber('INDEXER_GQL_TIMEOUT_MS', 10000);
     const retryAttempts = validateEnvNumber('RETRY_ATTEMPTS', 3);
     const retryDelay = validateEnvNumber('RETRY_DELAY', 1000);
@@ -99,16 +97,9 @@ export function loadConfig(): OracleConfig {
       'DB_MIGRATION_USER and DB_MIGRATION_PASSWORD must be set together',
     );
 
-    assert(indexerGraphqlTimeoutMinMs >= 1000, 'INDEXER_GQL_TIMEOUT_MIN_MS must be >= 1000');
-    assert(indexerGraphqlTimeoutMaxMs <= 60000, 'INDEXER_GQL_TIMEOUT_MAX_MS must be <= 60000');
     assert(
-      indexerGraphqlTimeoutMinMs <= indexerGraphqlTimeoutMaxMs,
-      'INDEXER_GQL_TIMEOUT_MIN_MS must be <= INDEXER_GQL_TIMEOUT_MAX_MS',
-    );
-    assert(
-      indexerGraphqlRequestTimeoutMs >= indexerGraphqlTimeoutMinMs &&
-        indexerGraphqlRequestTimeoutMs <= indexerGraphqlTimeoutMaxMs,
-      `INDEXER_GQL_TIMEOUT_MS must be between ${indexerGraphqlTimeoutMinMs} and ${indexerGraphqlTimeoutMaxMs}`,
+      indexerGraphqlRequestTimeoutMs >= 1000 && indexerGraphqlRequestTimeoutMs <= 60000,
+      'INDEXER_GQL_TIMEOUT_MS must be between 1000 and 60000',
     );
 
     const runtime = resolveSettlementRuntime({

--- a/oracle/src/database/queries.ts
+++ b/oracle/src/database/queries.ts
@@ -54,28 +54,12 @@ export async function getTriggerByIdempotencyKey(idempotencyKey: string): Promis
   return result.rows[0] || null;
 }
 
-export async function getTriggersByActionKey(actionKey: string): Promise<Trigger[]> {
-  const result = await pool.query(
-    'SELECT * FROM oracle_triggers WHERE action_key = $1 ORDER BY created_at DESC',
-    [actionKey],
-  );
-  return result.rows;
-}
-
 export async function getLatestTriggerByActionKey(actionKey: string): Promise<Trigger | null> {
   const result = await pool.query(
     'SELECT * FROM oracle_triggers WHERE action_key = $1 ORDER BY created_at DESC LIMIT 1',
     [actionKey],
   );
   return result.rows[0] || null;
-}
-
-export async function getTriggersByTradeId(tradeId: string): Promise<Trigger[]> {
-  const result = await pool.query(
-    'SELECT * FROM oracle_triggers WHERE trade_id = $1 ORDER BY created_at DESC',
-    [tradeId],
-  );
-  return result.rows;
 }
 
 export async function getTriggersByStatus(
@@ -115,17 +99,6 @@ export async function listTriggers(input: {
      ORDER BY updated_at DESC, created_at DESC
      LIMIT $${params.length}`,
     params,
-  );
-  return result.rows;
-}
-
-export async function getExhaustedTriggersForRedrive(limit: number = 50): Promise<Trigger[]> {
-  const result = await pool.query(
-    `SELECT * FROM oracle_triggers
-         WHERE status = $1
-         ORDER BY updated_at ASC
-         LIMIT $2`,
-    [TriggerStatus.EXHAUSTED_NEEDS_REDRIVE, limit],
   );
   return result.rows;
 }

--- a/oracle/src/server.ts
+++ b/oracle/src/server.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -75,7 +74,6 @@ async function bootstrap() {
       config.escrowAddress,
       config.usdcAddress,
       config.chainId,
-      indexerClient,
     );
 
     const triggerManager = new TriggerManager(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,9 +373,6 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17


### PR DESCRIPTION
 -  queries.ts: 3 dead exported functions:
    - getTriggersByActionKey never imported anywhere
    - getTriggersByTradeId never imported anywhere
    - getExhaustedTriggersForRedrive never imported anywhere (redrive is always operator-triggered via the /redrive endpoint, not auto-queued)

 -  sdk-client.ts dead IndexerClient coupling:
    - Constructor parameter indexer: IndexerClient stored as this.indexer but never read
    - private indexer: IndexerClient field
    - mapIndexerTradeToSDK() private method that was never called
    - IndexerClient / IndexerTrade imports

 - The IndexerClient is used only by ConfirmationWorker directly, which is correct, SDKClient is a pure RPC wrapper.

  - server.ts: import 'reflect-metadata' decorator-metadata shim with zero decorators in this service.

  - config.ts: INDEXER_GQL_TIMEOUT_MIN_MS / INDEXER_GQL_TIMEOUT_MAX_MS: two undocumented env vars that existed only to cross-validate INDEXER_GQL_TIMEOUT_MS. Replaced with a direct bounds assertion (1000–60000ms).

 - package.json: reflect-metadata runtime dependency removed.
