### PR TITLE
ci: checkout canonical Cotsel.dash repo

### DIFF
--- a/.github/workflows/dashboard-live-parity.yml
+++ b/.github/workflows/dashboard-live-parity.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.cotsel_ref != '' && inputs.cotsel_ref || github.ref }}
 
-      - name: Checkout Cotsel-Dash
+      - name: Checkout Cotsel.dash
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          repository: Agroasys/Cotsel-Dash
+          repository: Agroasys/Cotsel.dash
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.dash_ref != '' && inputs.dash_ref || 'main' }}
           path: cotsel-dash
           token: ${{ secrets.COTSEL_DASH_CHECKOUT_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- update dashboard live parity checkout to use the canonical Agroasys/Cotsel.dash repository name
- keep the checkout path and dash ref behavior unchanged

## Validation
- git diff --check