### PR TITLE
Harden admin bridge route safety

### DIFF
--- a/auth/src/database/schema.sql
+++ b/auth/src/database/schema.sql
@@ -127,6 +127,7 @@ CREATE TABLE IF NOT EXISTS operator_capability_bindings (
     capability    TEXT NOT NULL CHECK (capability IN (
         'governance:write',
         'compliance:write',
+        'operations:replay',
         'treasury:read',
         'treasury:prepare',
         'treasury:approve',

--- a/auth/src/types.ts
+++ b/auth/src/types.ts
@@ -7,6 +7,7 @@ export type AdminActorType = 'service_auth' | 'system';
 export const OPERATOR_CAPABILITIES = [
   'governance:write',
   'compliance:write',
+  'operations:replay',
   'treasury:read',
   'treasury:prepare',
   'treasury:approve',

--- a/auth/tests/adminControls.integration.test.ts
+++ b/auth/tests/adminControls.integration.test.ts
@@ -581,7 +581,7 @@ describe('admin controls persistence integration', () => {
             accountId: 'agroasys-user:signer-1',
             role: 'admin',
             email: 'signer@example.com',
-            capabilities: ['governance:write', 'compliance:write'],
+            capabilities: ['governance:write', 'compliance:write', 'operations:replay'],
             capabilityTicketRef: 'SEC-1100',
             reason: 'SEC-1100 durable admin provisioning for signer binding proof',
           });
@@ -607,6 +607,7 @@ describe('admin controls persistence integration', () => {
           expect(resolvedBeforeSigner?.capabilities).toEqual([
             'compliance:write',
             'governance:write',
+            'operations:replay',
           ]);
           expect(resolvedBeforeSigner?.signerAuthorizations).toEqual([]);
 
@@ -640,6 +641,7 @@ describe('admin controls persistence integration', () => {
           const resolved = await app.sessionService.resolve(session.sessionId);
           expect(resolved?.capabilities).toContain('governance:write');
           expect(resolved?.capabilities).toContain('compliance:write');
+          expect(resolved?.capabilities).toContain('operations:replay');
           expect(resolved?.signerAuthorizations).toEqual(
             expect.arrayContaining([
               expect.objectContaining({

--- a/auth/tests/routes.test.ts
+++ b/auth/tests/routes.test.ts
@@ -75,5 +75,8 @@ describe('auth router', () => {
     expect(listRoutes(router)).toContain('GET /admin/audit-events');
     expect(listRoutes(router)).toContain('POST /admin/signers/provision');
     expect(listRoutes(router)).toContain('POST /admin/signers/revoke');
+    expect(listRoutes(router)).toContain('POST /admin/break-glass/grant');
+    expect(listRoutes(router)).toContain('POST /admin/break-glass/revoke');
+    expect(listRoutes(router)).toContain('POST /admin/break-glass/review');
   });
 });

--- a/docs/api/cotsel-dashboard-gateway.openapi.yml
+++ b/docs/api/cotsel-dashboard-gateway.openapi.yml
@@ -2300,7 +2300,7 @@ components:
       enum: [operator:read, operator:write]
     OperatorCapabilitySubject:
       type: object
-      required: [accountId, userId, authRole, gatewayRoles]
+      required: [accountId, userId, authRole, gatewayRoles, capabilities]
       properties:
         accountId:
           type: string
@@ -2315,6 +2315,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GatewayRole'
+        capabilities:
+          type: array
+          items:
+            type: string
+            enum:
+              - governance:write
+              - compliance:write
+              - operations:replay
+              - treasury:read
+              - treasury:prepare
+              - treasury:approve
+              - treasury:execute_match
+              - treasury:close
     OperatorRouteCapabilities:
       type: object
       required: [overviewRead, operationsRead, tradesRead, governanceRead, complianceRead]
@@ -2331,11 +2344,32 @@ components:
           type: boolean
     OperatorActionCapabilities:
       type: object
-      required: [governanceWrite, complianceWrite]
+      required:
+        - governanceWrite
+        - complianceWrite
+        - operationsReplay
+        - treasuryRead
+        - treasuryPrepare
+        - treasuryApprove
+        - treasuryExecuteMatch
+        - treasuryClose
       properties:
         governanceWrite:
           type: boolean
         complianceWrite:
+          type: boolean
+        operationsReplay:
+          type: boolean
+          description: True only when the operator has explicit authority to replay failed control-plane operations.
+        treasuryRead:
+          type: boolean
+        treasuryPrepare:
+          type: boolean
+        treasuryApprove:
+          type: boolean
+        treasuryExecuteMatch:
+          type: boolean
+        treasuryClose:
           type: boolean
     OperatorWriteAccess:
       type: object

--- a/docs/runbooks/dashboard-gateway-operations.md
+++ b/docs/runbooks/dashboard-gateway-operations.md
@@ -188,10 +188,18 @@ Approved remote staging health evidence as of `2026-04-02`:
 - Mutation routes additionally require:
   - `GATEWAY_ENABLE_MUTATIONS=true`
   - caller membership in `GATEWAY_WRITE_ALLOWLIST`
+  - route-specific operator capabilities from auth session truth:
+    - `governance:write` for governance direct-sign prepare/confirm routes
+    - `compliance:write` for compliance mutation routes
+    - `operations:replay` for failed-operation replay
+    - `treasury:prepare`, `treasury:approve`, `treasury:execute_match`, or `treasury:close`
+      for the matching treasury workflow routes
+  - approved signer binding policy for signer-required governance and treasury routes
 
 Operational implication:
 
 - a valid admin session alone is not sufficient to mutate protocol controls.
+- broad `operator:write` access does not imply replay, governance, compliance, or treasury authority.
 - connected validation remains read-only until governance/compliance read verification is complete.
 
 ## Request tracing and log policy

--- a/docs/runbooks/gateway-dead-letter-workflow.md
+++ b/docs/runbooks/gateway-dead-letter-workflow.md
@@ -51,6 +51,9 @@ Replay is not recorded for:
 Operator rule:
 
 - do not replay a failed operation until the underlying dependency failure is understood and contained
+- dashboard/API replay requires an admin session with mutation write access and the explicit `operations:replay`
+  operator capability
+- dashboard/API replay is accepted only while the failed-operation record is still `open` and `replayEligible=true`
 - preserve the original intent identity: replay keeps the same `requestId`, `correlationId`, and `idempotencyKey`
 - treat replay as a controlled reattempt of the same logical action, not a new operator request
 
@@ -88,6 +91,15 @@ Replay one failed operation and emit JSON:
 node scripts/gateway-dead-letter-workflow.mjs replay <failedOperationId> --json
 ```
 
+Dashboard/API replay:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer <admin session with operations:replay>" \
+  -H "Idempotency-Key: <unique replay command id>" \
+  "${DASHBOARD_GATEWAY_BASE_URL}/operations/failed-operations/<failedOperationId>/replay"
+```
+
 ## Operator replay procedure
 
 1. Confirm the failure class is `infrastructure` or `unexpected`.
@@ -101,9 +113,11 @@ node scripts/gateway-dead-letter-workflow.mjs replay <failedOperationId> --json
    - `requestId`
    - `correlationId`
    - `idempotencyKey`
-4. Run the replay command.
-5. Confirm the record transitions to `replayed`. If replay fails, it transitions to `replay_failed` and retains the latest terminal error.
-6. Attach the replay output to the incident or operator evidence packet.
+4. Confirm the record remains `open` and `replayEligible=true`.
+5. Confirm the operator has the `operations:replay` capability when using the dashboard/API route.
+6. Run the replay command.
+7. Confirm the record transitions to `replayed`. If replay fails, it transitions to `replay_failed` and retains the latest terminal error.
+8. Attach the replay output to the incident or operator evidence packet.
 
 ## Incident ownership
 
@@ -121,5 +135,7 @@ Record these fields in the incident or operator evidence packet:
 - `correlationId`
 - `idempotencyKey`
 - failure class/code/message
+- pre-replay `failureState` and `replayEligible` values
+- operator replay authority evidence (`operations:replay` capability or CLI service authority)
 - replay result
 - ticket reference and operator identity

--- a/gateway/src/core/authSessionClient.ts
+++ b/gateway/src/core/authSessionClient.ts
@@ -9,6 +9,7 @@ export type AuthServiceRole = 'buyer' | 'supplier' | 'admin' | 'oracle';
 export type OperatorCapability =
   | 'governance:write'
   | 'compliance:write'
+  | 'operations:replay'
   | 'treasury:read'
   | 'treasury:prepare'
   | 'treasury:approve'
@@ -80,6 +81,7 @@ const AUTH_SERVICE_ROLES: AuthServiceRole[] = ['buyer', 'supplier', 'admin', 'or
 const OPERATOR_CAPABILITIES: OperatorCapability[] = [
   'governance:write',
   'compliance:write',
+  'operations:replay',
   'treasury:read',
   'treasury:prepare',
   'treasury:approve',

--- a/gateway/src/core/operatorCapabilities.ts
+++ b/gateway/src/core/operatorCapabilities.ts
@@ -16,6 +16,7 @@ export interface OperatorRouteCapabilities {
 export interface OperatorActionCapabilities {
   governanceWrite: boolean;
   complianceWrite: boolean;
+  operationsReplay: boolean;
   treasuryRead: boolean;
   treasuryPrepare: boolean;
   treasuryApprove: boolean;
@@ -77,6 +78,9 @@ export function buildOperatorCapabilitySnapshot(
       complianceWrite:
         canWriteOperatorActions &&
         principal.operatorActionCapabilities.includes('compliance:write'),
+      operationsReplay:
+        canWriteOperatorActions &&
+        principal.operatorActionCapabilities.includes('operations:replay'),
       treasuryRead: principal.treasuryCapabilities.includes('treasury:read'),
       treasuryPrepare:
         canWriteOperatorActions && principal.treasuryCapabilities.includes('treasury:prepare'),

--- a/gateway/src/middleware/auth.ts
+++ b/gateway/src/middleware/auth.ts
@@ -21,7 +21,10 @@ export type TreasuryCapability =
   | 'treasury:approve'
   | 'treasury:execute_match'
   | 'treasury:close';
-export type OperatorActionCapability = 'governance:write' | 'compliance:write';
+export type OperatorActionCapability =
+  | 'governance:write'
+  | 'compliance:write'
+  | 'operations:replay';
 
 const TREASURY_CAPABILITIES: readonly TreasuryCapability[] = [
   'treasury:read',
@@ -33,6 +36,7 @@ const TREASURY_CAPABILITIES: readonly TreasuryCapability[] = [
 const OPERATOR_ACTION_CAPABILITIES: readonly OperatorActionCapability[] = [
   'governance:write',
   'compliance:write',
+  'operations:replay',
 ];
 
 const INACTIVE_BREAK_GLASS_CONTEXT: BreakGlassSessionContext = {

--- a/gateway/src/routes/operations.ts
+++ b/gateway/src/routes/operations.ts
@@ -15,6 +15,7 @@ import { IdempotencyStore } from '../core/idempotencyStore';
 import { OperationsSummaryReader } from '../core/operationsSummaryService';
 import {
   createAuthenticationMiddleware,
+  requireOperatorActionCapability,
   requireGatewayRole,
   requireMutationWriteAccess,
 } from '../middleware/auth';
@@ -88,6 +89,28 @@ function sanitizeFailedOperation(record: FailedOperationRecord) {
     ...record,
     requestPayload: null,
   };
+}
+
+async function requireReplayableFailedOperation(
+  store: FailedOperationStore | null | undefined,
+  failedOperationId: string,
+): Promise<FailedOperationRecord> {
+  const record = await requireFailedOperationStore(store).get(failedOperationId);
+  if (!record) {
+    throw new GatewayError(404, 'NOT_FOUND', 'Failed operation not found', {
+      failedOperationId,
+    });
+  }
+
+  if (!record.replayEligible || record.failureState !== 'open') {
+    throw new GatewayError(409, 'CONFLICT', 'Failed operation is not replayable', {
+      failedOperationId,
+      replayEligible: record.replayEligible,
+      failureState: record.failureState,
+    });
+  }
+
+  return record;
 }
 
 export function createOperationsRouter(options: OperationsRouterOptions): Router {
@@ -170,6 +193,7 @@ export function createOperationsRouter(options: OperationsRouterOptions): Router
   router.post(
     '/operations/failed-operations/:failedOperationId/replay',
     requireMutationWriteAccess(),
+    requireOperatorActionCapability('operations:replay'),
     replayIdempotency,
     async (req, res, next) => {
       try {
@@ -181,6 +205,7 @@ export function createOperationsRouter(options: OperationsRouterOptions): Router
             'Failed-operation replay is not configured',
           );
         }
+        await requireReplayableFailedOperation(options.failedOperationStore, failedOperationId);
         const replayed = await options.failedOperationReplayer.replay(failedOperationId);
         res.status(202).json(successResponse(sanitizeFailedOperation(replayed)));
       } catch (error) {

--- a/gateway/tests/accessLogs.contract.test.ts
+++ b/gateway/tests/accessLogs.contract.test.ts
@@ -79,6 +79,8 @@ async function startServer(options: StartServerOptions = {}) {
             : '0x00000000000000000000000000000000000000bb',
         role,
         email: role === 'admin' ? 'admin@agroasys.io' : 'buyer@agroasys.io',
+        capabilities: [],
+        signerAuthorizations: [],
         issuedAt: Date.now(),
         expiresAt: Date.now() + 60_000,
       };
@@ -237,5 +239,22 @@ describe('gateway access log routes contract', () => {
 
     expect(disabledResponse.status).toBe(403);
     expect(validateError(disabledPayload)).toBe(true);
+  });
+
+  test('access log reads require authenticated operator authority', async () => {
+    const unauthenticatedApp = await startServer({ sessionRole: null });
+    const unauthenticatedResponse = await sendInProcessRequest(unauthenticatedApp, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/access-logs',
+    });
+    expect(unauthenticatedResponse.status).toBe(401);
+
+    const buyerApp = await startServer({ sessionRole: 'buyer' });
+    const buyerResponse = await sendInProcessRequest(buyerApp, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/access-logs',
+      headers: { authorization: 'Bearer session-buyer' },
+    });
+    expect(buyerResponse.status).toBe(403);
   });
 });

--- a/gateway/tests/capabilitiesRoutes.contract.test.ts
+++ b/gateway/tests/capabilitiesRoutes.contract.test.ts
@@ -79,6 +79,7 @@ async function startServer(
             ? [
                 'governance:write',
                 'compliance:write',
+                'operations:replay',
                 'treasury:read',
                 'treasury:prepare',
                 'treasury:approve',
@@ -199,6 +200,7 @@ describe('gateway capabilities route contract', () => {
       expect(payload.data.subject.capabilities).toEqual([
         'governance:write',
         'compliance:write',
+        'operations:replay',
         'treasury:read',
         'treasury:prepare',
         'treasury:approve',
@@ -209,6 +211,7 @@ describe('gateway capabilities route contract', () => {
       expect(payload.data.routes.governanceRead).toBe(true);
       expect(payload.data.actions.governanceWrite).toBe(true);
       expect(payload.data.actions.complianceWrite).toBe(true);
+      expect(payload.data.actions.operationsReplay).toBe(true);
       expect(payload.data.actions.treasuryRead).toBe(true);
       expect(payload.data.actions.treasuryPrepare).toBe(true);
       expect(payload.data.actions.treasuryApprove).toBe(true);

--- a/gateway/tests/evidenceBundleRoutes.contract.test.ts
+++ b/gateway/tests/evidenceBundleRoutes.contract.test.ts
@@ -351,4 +351,38 @@ describe('gateway evidence bundle routes contract', () => {
     expect(response.status).toBe(403);
     expect(payload.error.code).toBe('FORBIDDEN');
   });
+
+  test('evidence bundle reads require an authenticated operator session', async () => {
+    const unauthenticatedApp = await startServer({ sessionRole: null });
+    const unauthenticatedResponse = await sendInProcessRequest(unauthenticatedApp, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/evidence/bundles',
+    });
+    expect(unauthenticatedResponse.status).toBe(401);
+
+    const buyerApp = await startServer({ sessionRole: 'buyer' });
+    const buyerResponse = await sendInProcessRequest(buyerApp, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/evidence/bundles',
+      headers: { authorization: 'Bearer sess-buyer' },
+    });
+    expect(buyerResponse.status).toBe(403);
+  });
+
+  test('evidence bundle generation requires idempotency before creating a bundle', async () => {
+    const app = await startServer();
+    const response = await sendInProcessRequest(app, {
+      method: 'POST',
+      path: '/api/dashboard-gateway/v1/evidence/bundles',
+      headers: {
+        authorization: 'Bearer sess-admin',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ tradeId: trade.id }),
+    });
+    const payload = response.json<{ error: { code: string } }>();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe('VALIDATION_ERROR');
+  });
 });

--- a/gateway/tests/operationsRoutes.contract.test.ts
+++ b/gateway/tests/operationsRoutes.contract.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../src/core/operationsSummaryService';
 import type { FailedOperationRecord, FailedOperationStore } from '../src/core/failedOperationStore';
 import type { IdempotencyStore } from '../src/core/idempotencyStore';
+import type { OperatorCapability } from '../src/core/authSessionClient';
 
 const config: GatewayConfig = {
   port: 3600,
@@ -163,6 +164,7 @@ async function startServer(
   failedOperationReplayer?: GatewayFailedOperationReplayer | null,
   idempotencyStore?: IdempotencyStore | null,
   routeConfig: GatewayConfig = config,
+  capabilities: OperatorCapability[] = role === 'admin' ? ['operations:replay'] : [],
 ) {
   const authSessionClient: AuthSessionClient = {
     resolveSession: jest.fn().mockImplementation(async () => {
@@ -174,6 +176,8 @@ async function startServer(
         userId: `uid-${role}`,
         walletAddress: '0x00000000000000000000000000000000000000aa',
         role,
+        capabilities,
+        signerAuthorizations: [],
         issuedAt: Date.now(),
         expiresAt: Date.now() + 60_000,
       };
@@ -446,6 +450,261 @@ describe('gateway operations summary route contract', () => {
     }
   });
 
+  test('POST /operations/failed-operations/:id/replay requires explicit replay capability', async () => {
+    const failedOperationStore = {
+      list: jest.fn(),
+      get: jest.fn(),
+      recordFailure: jest.fn(),
+      markReplayed: jest.fn(),
+      markReplayFailed: jest.fn(),
+    } as unknown as FailedOperationStore;
+    const failedOperationReplayer = {
+      replay: jest.fn(),
+    } as unknown as GatewayFailedOperationReplayer;
+    const idempotencyStore = {
+      get: jest.fn(),
+      createPending: jest.fn(),
+      complete: jest.fn(),
+      releasePending: jest.fn(),
+      markReplay: jest.fn(),
+    } as unknown as IdempotencyStore;
+    const writeConfig = {
+      ...config,
+      enableMutations: true,
+      writeAllowlist: ['uid-admin'],
+    };
+    const { server, baseUrl } = await startServer(
+      'admin',
+      operationsFixture,
+      null,
+      failedOperationStore,
+      failedOperationReplayer,
+      idempotencyStore,
+      writeConfig,
+      [],
+    );
+
+    try {
+      const response = await fetch(`${baseUrl}/operations/failed-operations/failed-op-1/replay`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sess-admin',
+          'Idempotency-Key': 'replay-1',
+        },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(payload.error.message).toBe("Operator capability 'operations:replay' is required");
+      expect(idempotencyStore.createPending).not.toHaveBeenCalled();
+      expect(failedOperationReplayer.replay).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
+  test('POST /operations/failed-operations/:id/replay rejects ineligible records before replaying', async () => {
+    const replayedRecord: FailedOperationRecord = {
+      failedOperationId: 'failed-op-2',
+      operationType: 'settlement-callback',
+      operationKey: 'callback-2',
+      targetService: 'agroasys-backend',
+      route: '/settlement/callbacks',
+      method: 'POST',
+      payloadHash: 'hash-2',
+      requestPayload: { callback: true },
+      requestId: 'req-failed-2',
+      correlationId: null,
+      idempotencyKey: 'idem-2',
+      actionKey: null,
+      actorId: null,
+      actorUserId: 'admin-1',
+      actorWalletAddress: null,
+      actorRole: 'admin',
+      sessionReference: 'session-1',
+      replayEligible: false,
+      failureState: 'open',
+      firstFailedAt: '2026-03-12T00:00:00.000Z',
+      lastFailedAt: '2026-03-12T00:05:00.000Z',
+      retryCount: 3,
+      terminalErrorClass: 'client_contract',
+      terminalErrorCode: 'NOT_REPLAYABLE',
+      terminalErrorMessage: 'Permanent validation failure',
+      metadata: { replayed: false },
+      lastReplayedAt: null,
+      createdAt: '2026-03-12T00:00:00.000Z',
+      updatedAt: '2026-03-12T00:10:00.000Z',
+    };
+    const failedOperationStore = {
+      list: jest.fn(),
+      get: jest.fn().mockResolvedValue(replayedRecord),
+      recordFailure: jest.fn(),
+      markReplayed: jest.fn(),
+      markReplayFailed: jest.fn(),
+    } as unknown as FailedOperationStore;
+    const failedOperationReplayer = {
+      replay: jest.fn(),
+    } as unknown as GatewayFailedOperationReplayer;
+    const idempotencyStore = {
+      get: jest.fn(),
+      createPending: jest.fn().mockResolvedValue({
+        created: true,
+        record: {
+          idempotencyKey: 'replay-2',
+          actorId: 'user:uid-admin',
+          endpoint: '/operations/failed-operations/:failedOperationId/replay',
+          requestMethod: 'POST',
+          requestPath: '/api/dashboard-gateway/v1/operations/failed-operations/failed-op-2/replay',
+          requestFingerprint: 'hash',
+          requestId: 'req-replay-2',
+          responseStatus: null,
+          responseHeaders: {},
+          responseBody: null,
+          completedAt: null,
+          createdAt: '2026-03-12T00:00:00.000Z',
+        },
+      }),
+      complete: jest.fn().mockResolvedValue(undefined),
+      releasePending: jest.fn().mockResolvedValue(undefined),
+      markReplay: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IdempotencyStore;
+    const writeConfig = {
+      ...config,
+      enableMutations: true,
+      writeAllowlist: ['uid-admin'],
+    };
+    const { server, baseUrl } = await startServer(
+      'admin',
+      operationsFixture,
+      null,
+      failedOperationStore,
+      failedOperationReplayer,
+      idempotencyStore,
+      writeConfig,
+    );
+
+    try {
+      const response = await fetch(`${baseUrl}/operations/failed-operations/failed-op-2/replay`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sess-admin',
+          'Idempotency-Key': 'replay-2',
+        },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(payload.error.message).toBe('Failed operation is not replayable');
+      expect(failedOperationStore.get).toHaveBeenCalledWith('failed-op-2');
+      expect(failedOperationReplayer.replay).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
+  test('POST /operations/failed-operations/:id/replay rejects already replayed records before replaying again', async () => {
+    const replayedRecord: FailedOperationRecord = {
+      failedOperationId: 'failed-op-replayed',
+      operationType: 'settlement-callback',
+      operationKey: 'callback-replayed',
+      targetService: 'agroasys-backend',
+      route: '/settlement/callbacks',
+      method: 'POST',
+      payloadHash: 'hash-replayed',
+      requestPayload: { callback: true },
+      requestId: 'req-failed-replayed',
+      correlationId: null,
+      idempotencyKey: 'idem-replayed',
+      actionKey: null,
+      actorId: null,
+      actorUserId: 'admin-1',
+      actorWalletAddress: null,
+      actorRole: 'admin',
+      sessionReference: 'session-1',
+      replayEligible: true,
+      failureState: 'replayed',
+      firstFailedAt: '2026-03-12T00:00:00.000Z',
+      lastFailedAt: '2026-03-12T00:05:00.000Z',
+      retryCount: 3,
+      terminalErrorClass: 'infrastructure',
+      terminalErrorCode: 'CALLBACK_503',
+      terminalErrorMessage: 'Callback service unavailable',
+      metadata: { replayed: true },
+      lastReplayedAt: '2026-03-12T00:10:00.000Z',
+      createdAt: '2026-03-12T00:00:00.000Z',
+      updatedAt: '2026-03-12T00:10:00.000Z',
+    };
+    const failedOperationStore = {
+      list: jest.fn(),
+      get: jest.fn().mockResolvedValue(replayedRecord),
+      recordFailure: jest.fn(),
+      markReplayed: jest.fn(),
+      markReplayFailed: jest.fn(),
+    } as unknown as FailedOperationStore;
+    const failedOperationReplayer = {
+      replay: jest.fn(),
+    } as unknown as GatewayFailedOperationReplayer;
+    const idempotencyStore = {
+      get: jest.fn(),
+      createPending: jest.fn().mockResolvedValue({
+        created: true,
+        record: {
+          idempotencyKey: 'replay-already-replayed',
+          actorId: 'user:uid-admin',
+          endpoint: '/operations/failed-operations/:failedOperationId/replay',
+          requestMethod: 'POST',
+          requestPath:
+            '/api/dashboard-gateway/v1/operations/failed-operations/failed-op-replayed/replay',
+          requestFingerprint: 'hash',
+          requestId: 'req-replay-already-replayed',
+          responseStatus: null,
+          responseHeaders: {},
+          responseBody: null,
+          completedAt: null,
+          createdAt: '2026-03-12T00:00:00.000Z',
+        },
+      }),
+      complete: jest.fn().mockResolvedValue(undefined),
+      releasePending: jest.fn().mockResolvedValue(undefined),
+      markReplay: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IdempotencyStore;
+    const writeConfig = {
+      ...config,
+      enableMutations: true,
+      writeAllowlist: ['uid-admin'],
+    };
+    const { server, baseUrl } = await startServer(
+      'admin',
+      operationsFixture,
+      null,
+      failedOperationStore,
+      failedOperationReplayer,
+      idempotencyStore,
+      writeConfig,
+    );
+
+    try {
+      const response = await fetch(
+        `${baseUrl}/operations/failed-operations/failed-op-replayed/replay`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer sess-admin',
+            'Idempotency-Key': 'replay-already-replayed',
+          },
+        },
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(payload.error.message).toBe('Failed operation is not replayable');
+      expect(failedOperationStore.get).toHaveBeenCalledWith('failed-op-replayed');
+      expect(failedOperationReplayer.replay).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
   test('POST /operations/failed-operations/:id/replay requires idempotency before replaying', async () => {
     const replayedRecord: FailedOperationRecord = {
       failedOperationId: 'failed-op-1',
@@ -480,7 +739,11 @@ describe('gateway operations summary route contract', () => {
     };
     const failedOperationStore = {
       list: jest.fn(),
-      get: jest.fn(),
+      get: jest.fn().mockResolvedValue({
+        ...replayedRecord,
+        failureState: 'open',
+        lastReplayedAt: null,
+      }),
       recordFailure: jest.fn(),
       markReplayed: jest.fn(),
       markReplayFailed: jest.fn(),

--- a/gateway/tests/settingsRoutes.contract.test.ts
+++ b/gateway/tests/settingsRoutes.contract.test.ts
@@ -66,6 +66,8 @@ async function startServer(role: 'admin' | 'buyer' | null = 'admin') {
             : '0x00000000000000000000000000000000000000bb',
         role,
         email: role === 'admin' ? 'admin@agroasys.io' : 'buyer@agroasys.io',
+        capabilities: [],
+        signerAuthorizations: [],
         issuedAt: Date.now(),
         expiresAt: Date.now() + 60_000,
       };
@@ -191,5 +193,19 @@ describe('gateway settings routes contract', () => {
       headers: { authorization: 'Bearer session-buyer' },
     });
     expect(forbiddenResponse.status).toBe(403);
+  });
+
+  test('settings audit feed rejects invalid cursors before reading audit state', async () => {
+    const app = await startServer('admin');
+    const response = await sendInProcessRequest(app, {
+      method: 'GET',
+      path: '/api/dashboard-gateway/v1/settings/audit-feed?cursor=not-a-valid-cursor',
+      headers: { authorization: 'Bearer session-admin' },
+    });
+    const payload = response.json<{ error: { code: string; message: string } }>();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe('VALIDATION_ERROR');
+    expect(payload.error.message).toBe("Query parameter 'cursor' is invalid");
   });
 });

--- a/oracle/tests/authenticated-routes.test.ts
+++ b/oracle/tests/authenticated-routes.test.ts
@@ -51,32 +51,32 @@ describe('oracle authenticated routes', () => {
   let server: Server;
   let baseUrl: string;
   const controller = {
-    releaseStage1: async (req: Request, res: Response) => {
+    releaseStage1: jest.fn(async (req: Request, res: Response) => {
       res.status(200).json({
         success: true,
         route: 'release-stage1',
         requestHash: req.hmacSignature,
         nonce: req.hmacNonce,
       });
-    },
-    confirmArrival: async (_req: Request, res: Response) => {
+    }),
+    confirmArrival: jest.fn(async (_req: Request, res: Response) => {
       res.status(200).json({ success: true });
-    },
-    finalizeTrade: async (_req: Request, res: Response) => {
+    }),
+    finalizeTrade: jest.fn(async (_req: Request, res: Response) => {
       res.status(200).json({ success: true });
-    },
-    redriveTrigger: async (_req: Request, res: Response) => {
-      res.status(200).json({ success: true });
-    },
-    approveTrigger: async (_req: Request, res: Response) => {
-      res.status(200).json({ success: true });
-    },
-    rejectTrigger: async (_req: Request, res: Response) => {
-      res.status(200).json({ success: true });
-    },
-    listTriggers: async (req: Request, res: Response) => {
+    }),
+    redriveTrigger: jest.fn(async (req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'redrive', nonce: req.hmacNonce });
+    }),
+    approveTrigger: jest.fn(async (req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'approve', nonce: req.hmacNonce });
+    }),
+    rejectTrigger: jest.fn(async (req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'reject', nonce: req.hmacNonce });
+    }),
+    listTriggers: jest.fn(async (req: Request, res: Response) => {
       res.status(200).json({ success: true, status: req.query.status ?? null });
-    },
+    }),
   };
 
   beforeEach(async () => {
@@ -141,6 +141,7 @@ describe('oracle authenticated routes', () => {
 
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(401);
+    expect(controller.releaseStage1).toHaveBeenCalledTimes(1);
     await expect(secondResponse.json()).resolves.toEqual(
       expect.objectContaining({
         error: 'Unauthorized',
@@ -170,6 +171,7 @@ describe('oracle authenticated routes', () => {
 
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(401);
+    expect(controller.releaseStage1).toHaveBeenCalledTimes(1);
     await expect(secondResponse.json()).resolves.toEqual(
       expect.objectContaining({
         error: 'Unauthorized',
@@ -258,5 +260,102 @@ describe('oracle authenticated routes', () => {
       }),
     );
     expect(mockConsumeHmacNonce).toHaveBeenCalledWith('test-api-key', 'oracle-trigger-list', 600);
+  });
+
+  test('valid signed redrive request reaches redrive route once', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = {
+      tradeId: 'trade-redrive',
+      requestId: 'req-redrive',
+      triggerType: 'release_stage_1',
+    };
+
+    const response = await fetch(`${baseUrl}/api/oracle/redrive`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-redrive-route' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        route: 'redrive',
+        nonce: 'oracle-redrive-route',
+      }),
+    );
+    expect(controller.redriveTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('valid signed approve request reaches approval route once', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = {
+      idempotencyKey: 'RELEASE_STAGE_1:trade-approval:req-approval',
+      actor: 'operator@agroasys',
+    };
+
+    const response = await fetch(`${baseUrl}/api/oracle/approve`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-approve-route' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        route: 'approve',
+        nonce: 'oracle-approve-route',
+      }),
+    );
+    expect(controller.approveTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('valid signed reject request reaches rejection route once with audit reason payload', async () => {
+    mockConsumeHmacNonce.mockResolvedValue(true);
+    const payload = {
+      idempotencyKey: 'RELEASE_STAGE_1:trade-reject:req-reject',
+      actor: 'operator@agroasys',
+      reason: 'Oracle evidence did not match the reviewed trade state.',
+    };
+
+    const response = await fetch(`${baseUrl}/api/oracle/reject`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-reject-route' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        route: 'reject',
+        nonce: 'oracle-reject-route',
+      }),
+    );
+    expect(controller.rejectTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('replayed approval request is rejected before approval controller runs', async () => {
+    mockConsumeHmacNonce.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const payload = {
+      idempotencyKey: 'RELEASE_STAGE_1:trade-replay:req-replay',
+      actor: 'operator@agroasys',
+    };
+
+    const firstResponse = await fetch(`${baseUrl}/api/oracle/approve`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-approval-replay' }),
+      body: JSON.stringify(payload),
+    });
+    const secondResponse = await fetch(`${baseUrl}/api/oracle/approve`, {
+      method: 'POST',
+      headers: createSignedHeaders(payload, { nonce: 'oracle-approval-replay' }),
+      body: JSON.stringify(payload),
+    });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(401);
+    expect(controller.approveTrigger).toHaveBeenCalledTimes(1);
   });
 });

--- a/treasury/tests/adminBridgeRouteSafety.test.ts
+++ b/treasury/tests/adminBridgeRouteSafety.test.ts
@@ -1,0 +1,1208 @@
+import crypto from 'crypto';
+import express, { Request, Response } from 'express';
+import { AddressInfo } from 'net';
+import { Server } from 'http';
+import { createRouter } from '../src/api/routes';
+import {
+  buildServiceAuthCanonicalString,
+  createServiceAuthMiddleware,
+  signServiceAuthCanonicalString,
+} from '../src/auth/serviceAuth';
+
+type ServiceAuthRequest = Request & {
+  serviceAuth?: {
+    apiKeyId: string;
+  };
+};
+
+function createMutationAuthMiddleware(allowedApiKeyId: string) {
+  return (req: ServiceAuthRequest, res: Response, next: () => void) => {
+    if (req.serviceAuth?.apiKeyId === allowedApiKeyId) {
+      next();
+      return;
+    }
+
+    res.status(403).json({ success: false, error: 'Internal mutation caller required' });
+  };
+}
+
+function createSignedRequestParts(options?: {
+  method?: string;
+  path?: string;
+  query?: string;
+  body?: Buffer;
+  apiKey?: string;
+  timestamp?: string;
+  nonce?: string;
+  secret?: string;
+  signatureOverride?: string;
+}) {
+  const method = options?.method ?? 'POST';
+  const path = options?.path ?? '/api/treasury/v1/internal/ingest';
+  const query = options?.query ?? '';
+  const body = options?.body ?? Buffer.from(JSON.stringify({ entryId: 'entry-1' }));
+  const timestamp = options?.timestamp ?? '1700000000';
+  const nonce = options?.nonce ?? crypto.randomUUID();
+  const apiKey = options?.apiKey ?? 'svc-admin';
+  const secret = options?.secret ?? 'secret-admin';
+  const bodySha256 = crypto.createHash('sha256').update(body).digest('hex');
+  const canonical = buildServiceAuthCanonicalString({
+    method,
+    path,
+    query,
+    bodySha256,
+    timestamp,
+    nonce,
+  });
+  const signature = options?.signatureOverride ?? signServiceAuthCanonicalString(secret, canonical);
+
+  return {
+    body,
+    bodyText: body.toString('utf8'),
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'x-agroasys-timestamp': timestamp,
+      'x-agroasys-nonce': nonce,
+      'x-agroasys-signature': signature,
+    },
+  };
+}
+
+describe('admin bridge route safety — close/sweep consumption paths', () => {
+  let server: Server;
+  let baseUrl: string;
+  let consumeNonce: jest.MockedFunction<
+    (apiKey: string, nonce: string, ttlSeconds: number) => Promise<boolean>
+  >;
+  const allowedMutationCallerApiKeyId = 'svc-admin';
+  const unauthorizedApiKeyId = 'svc-readonly';
+
+  const lookupApiKey = (apiKey: string) => {
+    if (apiKey === allowedMutationCallerApiKeyId) {
+      return { id: allowedMutationCallerApiKeyId, secret: 'secret-admin', active: true };
+    }
+    if (apiKey === unauthorizedApiKeyId) {
+      return { id: unauthorizedApiKeyId, secret: 'secret-readonly', active: true };
+    }
+    return undefined;
+  };
+
+  let closeAccountingPeriodHandler: jest.Mock;
+  let requestAccountingPeriodCloseHandler: jest.Mock;
+  let createAccountingPeriodHandler: jest.Mock;
+  let createSweepBatchHandler: jest.Mock;
+  let addSweepBatchEntryHandler: jest.Mock;
+  let requestSweepBatchApprovalHandler: jest.Mock;
+  let approveSweepBatchHandler: jest.Mock;
+  let markSweepBatchExecutedHandler: jest.Mock;
+  let closeSweepBatchHandler: jest.Mock;
+  let recordPartnerHandoffHandler: jest.Mock;
+  let ingestHandler: jest.Mock;
+
+  beforeEach(async () => {
+    consumeNonce = jest.fn().mockResolvedValue(true);
+    const authMiddleware = createServiceAuthMiddleware({
+      enabled: true,
+      maxSkewSeconds: 300,
+      nonceTtlSeconds: 600,
+      lookupApiKey,
+      consumeNonce,
+      nowSeconds: () => 1700000000,
+    });
+    const mutationAuthMiddleware = createMutationAuthMiddleware(allowedMutationCallerApiKeyId);
+
+    closeAccountingPeriodHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'period-close' });
+    });
+    requestAccountingPeriodCloseHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'period-request-close' });
+    });
+    createAccountingPeriodHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(201).json({ success: true, route: 'periods' });
+    });
+    createSweepBatchHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(201).json({ success: true, route: 'batch-create' });
+    });
+    addSweepBatchEntryHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(201).json({ success: true, route: 'batch-entry' });
+    });
+    requestSweepBatchApprovalHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'batch-request-approval' });
+    });
+    approveSweepBatchHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'batch-approve' });
+    });
+    markSweepBatchExecutedHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'batch-match-execution' });
+    });
+    closeSweepBatchHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'batch-close' });
+    });
+    recordPartnerHandoffHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'external-handoff' });
+    });
+    ingestHandler = jest.fn((_req: Request, res: Response) => {
+      res.status(200).json({ success: true, route: 'ingest' });
+    });
+
+    const controller = {
+      ingest: ingestHandler,
+      listEntries: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+      listEntryAccounting: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+      getEntryAccounting: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getTreasuryPartnerHandoff: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      appendState: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { updated: true } });
+      },
+      upsertTreasuryPartnerHandoff: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { stored: true } });
+      },
+      appendTreasuryPartnerHandoffEvidence: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { stored: true } });
+      },
+      createEntryRealization: (_req: Request, res: Response) => {
+        res.status(201).json({ success: true, route: 'realization' });
+      },
+      upsertBankConfirmation: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { confirmed: true } });
+      },
+      listAccountingPeriods: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+      getAccountingPeriodRollforward: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getAccountingPeriodClosePacket: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      createAccountingPeriod: createAccountingPeriodHandler,
+      requestAccountingPeriodClose: requestAccountingPeriodCloseHandler,
+      closeAccountingPeriod: closeAccountingPeriodHandler,
+      listSweepBatches: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+      createSweepBatch: createSweepBatchHandler,
+      getSweepBatch: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      getSweepBatchTrace: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      addSweepBatchEntry: addSweepBatchEntryHandler,
+      requestSweepBatchApproval: requestSweepBatchApprovalHandler,
+      approveSweepBatch: approveSweepBatchHandler,
+      markSweepBatchExecuted: markSweepBatchExecutedHandler,
+      recordPartnerHandoff: recordPartnerHandoffHandler,
+      closeSweepBatch: closeSweepBatchHandler,
+      upsertDeposit: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: { stored: true } });
+      },
+      getReconciliationControlSummary: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: null });
+      },
+      exportEntries: (_req: Request, res: Response) => {
+        res.status(200).json({ success: true, data: [] });
+      },
+    };
+
+    const app = express();
+    app.use(
+      express.json({
+        verify: (req, _res, buffer) => {
+          (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buffer);
+        },
+      }),
+    );
+    app.use(
+      '/api/treasury/v1',
+      createRouter(controller as never, { authMiddleware, mutationAuthMiddleware }),
+    );
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. Close/Sweep route auth — wrong role / missing capability rejected
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('close route auth — wrong role rejected', () => {
+    test('period close rejects callers with valid auth but wrong mutation role', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:rogue', closeReason: 'Q1 close' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'close-wrong-role',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          success: false,
+          error: 'Internal mutation caller required',
+        }),
+      );
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+
+    test('period request-close rejects callers with valid auth but wrong mutation role', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:rogue' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/request-close',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'req-close-wrong-role',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/request-close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      expect(requestAccountingPeriodCloseHandler).not.toHaveBeenCalled();
+    });
+
+    test('period close with no auth headers is rejected at the auth boundary', async () => {
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ actor: 'user:rogue' }),
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+
+    test('period close with correct admin credentials reaches the controller', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin', closeReason: 'Q1 close' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        nonce: 'close-valid-admin',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(closeAccountingPeriodHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. Sweep batch operations — unauthorized access rejected
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('sweep batch operations — unauthorized access rejected', () => {
+    test('create sweep batch rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          batchKey: 'batch-rogue',
+          accountingPeriodId: 7,
+          assetSymbol: 'USDC',
+          expectedTotalRaw: '1000',
+          createdBy: 'user:rogue',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-create-wrong-role',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(403);
+      expect(createSweepBatchHandler).not.toHaveBeenCalled();
+    });
+
+    test('add sweep batch entry rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(
+        JSON.stringify({ ledgerEntryId: 501, allocatedBy: 'user:rogue', entryAmountRaw: '100' }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/entries',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-entry-wrong-role',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/entries`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(403);
+      expect(addSweepBatchEntryHandler).not.toHaveBeenCalled();
+    });
+
+    test('request sweep batch approval rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:rogue' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/request-approval',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-approval-wrong-role',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/sweep-batches/11/request-approval`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      expect(requestSweepBatchApprovalHandler).not.toHaveBeenCalled();
+    });
+
+    test('approve sweep batch rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:rogue' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/approve',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-approve-wrong-role',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/approve`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(403);
+      expect(approveSweepBatchHandler).not.toHaveBeenCalled();
+    });
+
+    test('mark sweep batch executed rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(
+        JSON.stringify({ actor: 'user:rogue', matchedSweepTxHash: '0xfake' }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/match-execution',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-exec-wrong-role',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/sweep-batches/11/match-execution`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      expect(markSweepBatchExecutedHandler).not.toHaveBeenCalled();
+    });
+
+    test('close sweep batch rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:rogue' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/close',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'batch-close-wrong-role',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/close`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(403);
+      expect(closeSweepBatchHandler).not.toHaveBeenCalled();
+    });
+
+    test('external handoff rejects callers with wrong mutation role', async () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          partnerName: 'licensed-counterparty',
+          partnerReference: 'handoff-rogue',
+          handoffStatus: 'ACKNOWLEDGED',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/external-handoff',
+        body,
+        apiKey: unauthorizedApiKeyId,
+        secret: 'secret-readonly',
+        nonce: 'handoff-wrong-role',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/sweep-batches/11/external-handoff`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      expect(recordPartnerHandoffHandler).not.toHaveBeenCalled();
+    });
+
+    test('sweep batch operations succeed with correct admin credentials', async () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          batchKey: 'batch-valid',
+          accountingPeriodId: 7,
+          assetSymbol: 'USDC',
+          expectedTotalRaw: '1000',
+          createdBy: 'user:admin',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches',
+        body,
+        nonce: 'batch-create-valid',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(201);
+      expect(createSweepBatchHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. Service auth routes — replay protection, stale request rejection
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('service auth — replay protection on close/sweep paths', () => {
+    test('replayed period close request is rejected before controller runs', async () => {
+      consumeNonce.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin', closeReason: 'Q1 close' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        nonce: 'close-replay',
+      });
+
+      const firstResponse = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      const secondResponse = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(401);
+      await expect(secondResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_NONCE_REPLAY',
+          error: 'Replay detected for nonce',
+        }),
+      );
+      expect(closeAccountingPeriodHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('replayed sweep batch create request is rejected before controller runs', async () => {
+      consumeNonce.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      const body = Buffer.from(
+        JSON.stringify({
+          batchKey: 'batch-replay',
+          accountingPeriodId: 7,
+          assetSymbol: 'USDC',
+          expectedTotalRaw: '500',
+          createdBy: 'user:admin',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches',
+        body,
+        nonce: 'batch-replay',
+      });
+
+      const firstResponse = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      const secondResponse = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(firstResponse.status).toBe(201);
+      expect(secondResponse.status).toBe(401);
+      await expect(secondResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_NONCE_REPLAY',
+        }),
+      );
+      expect(createSweepBatchHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('stale timestamp on period close is rejected at the route boundary', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin', closeReason: 'Q1 close' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        nonce: 'close-stale',
+        timestamp: '1699999600',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(consumeNonce).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_TIMESTAMP_SKEW',
+          error: 'Timestamp outside allowed skew window',
+        }),
+      );
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+
+    test('stale timestamp on sweep batch close is rejected at the route boundary', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/close',
+        body,
+        nonce: 'batch-close-stale',
+        timestamp: '1699999600',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/close`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(401);
+      expect(consumeNonce).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_TIMESTAMP_SKEW',
+        }),
+      );
+      expect(closeSweepBatchHandler).not.toHaveBeenCalled();
+    });
+
+    test('invalid signature on period close is rejected at the route boundary', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        nonce: 'close-invalid-sig',
+        signatureOverride: 'f'.repeat(64),
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(consumeNonce).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_INVALID_SIGNATURE',
+          error: 'Invalid signature',
+        }),
+      );
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+
+    test('invalid signature on sweep batch approve is rejected at the route boundary', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/approve',
+        body,
+        nonce: 'approve-invalid-sig',
+        signatureOverride: 'f'.repeat(64),
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/approve`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(401);
+      expect(consumeNonce).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_INVALID_SIGNATURE',
+        }),
+      );
+      expect(approveSweepBatchHandler).not.toHaveBeenCalled();
+    });
+
+    test('unknown API key on close route is rejected at the auth boundary', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:unknown' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        apiKey: 'svc-unknown',
+        secret: 'secret-unknown',
+        nonce: 'close-unknown-key',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+
+    test('nonce persistence failure on close route returns auth unavailable', async () => {
+      consumeNonce.mockRejectedValue(new Error('redis unavailable'));
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/close',
+        body,
+        nonce: 'close-db-error',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'AUTH_UNAVAILABLE',
+          error: 'Authentication service unavailable',
+        }),
+      );
+      expect(closeAccountingPeriodHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 4. Complete admin bridge consumption path — authorized end-to-end
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('authorized admin bridge paths reach controller exactly once', () => {
+    test('create accounting period with valid admin credentials reaches controller', async () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          periodKey: '2026-Q1',
+          startsAt: '2026-01-01T00:00:00.000Z',
+          endsAt: '2026-03-31T23:59:59.000Z',
+          createdBy: 'user:admin',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods',
+        body,
+        nonce: 'period-create-valid',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/accounting-periods`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(201);
+      expect(createAccountingPeriodHandler).toHaveBeenCalledTimes(1);
+      expect(consumeNonce).toHaveBeenCalledWith('svc-admin', 'period-create-valid', 600);
+    });
+
+    test('request period close with valid admin credentials reaches controller', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/accounting-periods/7/request-close',
+        body,
+        nonce: 'req-close-valid',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/accounting-periods/7/request-close`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(requestAccountingPeriodCloseHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('close sweep batch with valid admin credentials reaches controller', async () => {
+      const body = Buffer.from(JSON.stringify({ actor: 'user:admin' }));
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/close',
+        body,
+        nonce: 'batch-close-valid',
+      });
+
+      const response = await fetch(`${baseUrl}/api/treasury/v1/internal/sweep-batches/11/close`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.bodyText,
+      });
+
+      expect(response.status).toBe(200);
+      expect(closeSweepBatchHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('external handoff with valid admin credentials reaches controller', async () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          partnerName: 'licensed-counterparty',
+          partnerReference: 'handoff-valid',
+          handoffStatus: 'ACKNOWLEDGED',
+        }),
+      );
+      const signed = createSignedRequestParts({
+        path: '/api/treasury/v1/internal/sweep-batches/11/external-handoff',
+        body,
+        nonce: 'handoff-valid',
+      });
+
+      const response = await fetch(
+        `${baseUrl}/api/treasury/v1/internal/sweep-batches/11/external-handoff`,
+        {
+          method: 'POST',
+          headers: signed.headers,
+          body: signed.bodyText,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(recordPartnerHandoffHandler).toHaveBeenCalledTimes(1);
+      expect(consumeNonce).toHaveBeenCalledWith('svc-admin', 'handoff-valid', 600);
+    });
+  });
+});
+
+describe('admin bridge route safety — state guard tests', () => {
+  // These tests use the real TreasuryController to verify that state guards
+  // at the controller layer reject invalid state transitions.
+
+  process.env.PORT = process.env.PORT || '3200';
+  process.env.DB_HOST = process.env.DB_HOST || '127.0.0.1';
+  process.env.DB_PORT = process.env.DB_PORT || '5432';
+  process.env.DB_NAME = process.env.DB_NAME || 'treasury_test';
+  process.env.DB_USER = process.env.DB_USER || 'postgres';
+  process.env.DB_PASSWORD = process.env.DB_PASSWORD || 'postgres';
+  process.env.INDEXER_GRAPHQL_URL =
+    process.env.INDEXER_GRAPHQL_URL || 'http://127.0.0.1:3100/graphql';
+
+  jest.mock('../src/database/queries', () => ({
+    ...jest.requireActual('../src/database/queries'),
+    updateAccountingPeriodStatus: jest.fn(),
+    getSweepBatchDetail: jest.fn(),
+    updateSweepBatchStatus: jest.fn(),
+  }));
+
+  jest.mock('../src/core/closeReporting', () => ({
+    loadTreasuryAccountingPeriodClosePacket: jest.fn(),
+    loadTreasuryBatchTraceReport: jest.fn(),
+    renderTreasuryAccountingPeriodClosePacketMarkdown: jest.fn().mockReturnValue('# close packet'),
+  }));
+
+  type TreasuryControllerType = typeof import('../src/api/controller').TreasuryController;
+  type QueriesModule = typeof import('../src/database/queries');
+  type CloseReportingModule = typeof import('../src/core/closeReporting');
+
+  type MockResponse = Response & {
+    status: jest.MockedFunction<(code: number) => MockResponse>;
+    json: jest.MockedFunction<(body: unknown) => MockResponse>;
+  };
+
+  type CloseAccountingPeriodRequest = Request<
+    { periodId: string },
+    unknown,
+    { actor: string; closeReason?: string }
+  >;
+
+  type CloseSweepBatchRequest = Request<{ batchId: string }, unknown, { actor: string }>;
+
+  let LoadedTreasuryController: TreasuryControllerType;
+  let queriesModule: QueriesModule;
+  let closeReportingModule: CloseReportingModule;
+
+  function mockResponse(): MockResponse {
+    const response = {} as MockResponse;
+    response.status = jest.fn().mockReturnValue(response);
+    response.json = jest.fn().mockReturnValue(response);
+    return response;
+  }
+
+  beforeEach(async () => {
+    jest.resetModules();
+    ({ TreasuryController: LoadedTreasuryController } = await import('../src/api/controller'));
+    queriesModule = await import('../src/database/queries');
+    closeReportingModule = await import('../src/core/closeReporting');
+    jest.clearAllMocks();
+  });
+
+  test('closeAccountingPeriod rejects when close packet indicates blocking issues', async () => {
+    jest.mocked(closeReportingModule.loadTreasuryAccountingPeriodClosePacket).mockResolvedValue({
+      period: {
+        id: 7,
+        period_key: '2026-Q1',
+        starts_at: new Date('2026-01-01T00:00:00.000Z'),
+        ends_at: new Date('2026-03-31T23:59:59.000Z'),
+        status: 'PENDING_CLOSE',
+        created_by: 'user:uid-admin',
+        close_reason: null,
+        pending_close_at: null,
+        closed_at: null,
+        closed_by: null,
+        metadata: {},
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-03-31T23:00:00.000Z'),
+      },
+      generated_at: '2026-03-31T23:30:00.000Z',
+      ready_for_close: false,
+      rollforward: {
+        period: {
+          id: 7,
+          period_key: '2026-Q1',
+          starts_at: new Date('2026-01-01T00:00:00.000Z'),
+          ends_at: new Date('2026-03-31T23:59:59.000Z'),
+          status: 'PENDING_CLOSE',
+          created_by: 'user:uid-admin',
+          close_reason: null,
+          pending_close_at: null,
+          closed_at: null,
+          closed_by: null,
+          metadata: {},
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-03-31T23:00:00.000Z'),
+        },
+        generated_at: '2026-03-31T23:30:00.000Z',
+        opening_held_raw: '0',
+        new_accruals_raw: '0',
+        allocated_to_batches_raw: '0',
+        swept_onchain_raw: '0',
+        handed_off_raw: '0',
+        realized_raw: '0',
+        ending_held_raw: '0',
+        unresolved_exception_raw: '0',
+        blocking_issue_count: 1,
+        warning_issue_count: 0,
+        blocking_issues: [],
+        warning_issues: [],
+      },
+      reconciliation: {
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latest_completed_run_key: 'run-1',
+        latest_completed_run_at: '2026-03-31T23:00:00.000Z',
+        stale_running_run_count: 0,
+        blocked_reasons: [],
+      },
+      batches: [],
+      blocking_issues: [
+        {
+          code: 'SWEEP_TX_UNMATCHED',
+          severity: 'BLOCKING',
+          owner: 'TREASURY',
+          message: 'Sweep batch is marked executed without matched treasury claim evidence',
+          trade_id: null,
+          sweep_batch_id: 999,
+          ledger_entry_id: null,
+          details: { batchStatus: 'EXECUTED' },
+        },
+      ],
+      warning_issues: [],
+    });
+
+    const controller = new LoadedTreasuryController();
+    const req = {
+      params: { periodId: '7' },
+      body: { actor: 'user:uid-admin', closeReason: 'Quarter close review' },
+    } as unknown as CloseAccountingPeriodRequest;
+    const res = mockResponse();
+
+    await controller.closeAccountingPeriod(req, res);
+
+    expect(queriesModule.updateAccountingPeriodStatus).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: 'CloseBlocked',
+        message: expect.stringContaining('blocking treasury close issues remain'),
+      }),
+    );
+  });
+
+  test('closeAccountingPeriod succeeds when close packet is ready', async () => {
+    jest.mocked(closeReportingModule.loadTreasuryAccountingPeriodClosePacket).mockResolvedValue({
+      period: {
+        id: 7,
+        period_key: '2026-Q1',
+        starts_at: new Date('2026-01-01T00:00:00.000Z'),
+        ends_at: new Date('2026-03-31T23:59:59.000Z'),
+        status: 'PENDING_CLOSE',
+        created_by: 'user:uid-admin',
+        close_reason: null,
+        pending_close_at: null,
+        closed_at: null,
+        closed_by: null,
+        metadata: {},
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-03-31T23:00:00.000Z'),
+      },
+      generated_at: '2026-03-31T23:30:00.000Z',
+      ready_for_close: true,
+      rollforward: {
+        period: {
+          id: 7,
+          period_key: '2026-Q1',
+          starts_at: new Date('2026-01-01T00:00:00.000Z'),
+          ends_at: new Date('2026-03-31T23:59:59.000Z'),
+          status: 'PENDING_CLOSE',
+          created_by: 'user:uid-admin',
+          close_reason: null,
+          pending_close_at: null,
+          closed_at: null,
+          closed_by: null,
+          metadata: {},
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-03-31T23:00:00.000Z'),
+        },
+        generated_at: '2026-03-31T23:30:00.000Z',
+        opening_held_raw: '0',
+        new_accruals_raw: '0',
+        allocated_to_batches_raw: '0',
+        swept_onchain_raw: '0',
+        handed_off_raw: '0',
+        realized_raw: '0',
+        ending_held_raw: '0',
+        unresolved_exception_raw: '0',
+        blocking_issue_count: 0,
+        warning_issue_count: 0,
+        blocking_issues: [],
+        warning_issues: [],
+      },
+      reconciliation: {
+        status: 'CLEAR',
+        freshness: 'FRESH',
+        latest_completed_run_key: 'run-1',
+        latest_completed_run_at: '2026-03-31T23:00:00.000Z',
+        stale_running_run_count: 0,
+        blocked_reasons: [],
+      },
+      batches: [],
+      blocking_issues: [],
+      warning_issues: [],
+    });
+
+    jest.mocked(queriesModule.updateAccountingPeriodStatus).mockResolvedValue({
+      id: 7,
+      period_key: '2026-Q1',
+      status: 'CLOSED',
+    } as never);
+
+    const controller = new LoadedTreasuryController();
+    const req = {
+      params: { periodId: '7' },
+      body: { actor: 'user:uid-admin', closeReason: 'Quarter close review' },
+    } as unknown as CloseAccountingPeriodRequest;
+    const res = mockResponse();
+
+    await controller.closeAccountingPeriod(req, res);
+
+    expect(queriesModule.updateAccountingPeriodStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        periodId: 7,
+        status: 'CLOSED',
+        actor: 'user:uid-admin',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('closeSweepBatch rejects when partner handoff is not completed', async () => {
+    jest.mocked(queriesModule.getSweepBatchDetail).mockResolvedValue({
+      batch: {
+        id: 11,
+        batch_key: 'batch-q1-001',
+        status: 'HANDED_OFF',
+      },
+      entries: [],
+      partnerHandoff: {
+        id: 33,
+        handoff_status: 'ACKNOWLEDGED',
+      },
+      totals: { allocatedAmountRaw: '100', entryCount: 1 },
+    } as never);
+
+    const controller = new LoadedTreasuryController();
+    const req = {
+      params: { batchId: '11' },
+      body: { actor: 'user:uid-admin' },
+    } as unknown as CloseSweepBatchRequest;
+    const res = mockResponse();
+
+    await controller.closeSweepBatch(req, res);
+
+    expect(queriesModule.updateSweepBatchStatus).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: 'CloseBlocked',
+        message: expect.stringContaining('completed external handoff evidence'),
+      }),
+    );
+  });
+
+  test('closeSweepBatch rejects when entries are not fully realized', async () => {
+    jest.mocked(queriesModule.getSweepBatchDetail).mockResolvedValue({
+      batch: {
+        id: 11,
+        batch_key: 'batch-q1-001',
+        status: 'HANDED_OFF',
+      },
+      entries: [
+        { ledger_entry_id: 501, accounting_state: 'SWEPT' },
+        { ledger_entry_id: 502, accounting_state: 'REALIZED' },
+      ],
+      partnerHandoff: {
+        id: 33,
+        handoff_status: 'COMPLETED',
+      },
+      totals: { allocatedAmountRaw: '200', entryCount: 2 },
+    } as never);
+
+    const controller = new LoadedTreasuryController();
+    const req = {
+      params: { batchId: '11' },
+      body: { actor: 'user:uid-admin' },
+    } as unknown as CloseSweepBatchRequest;
+    const res = mockResponse();
+
+    await controller.closeSweepBatch(req, res);
+
+    expect(queriesModule.updateSweepBatchStatus).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: 'CloseBlocked',
+        message: expect.stringContaining('unrealized'),
+      }),
+    );
+  });
+
+  test('closeSweepBatch rejects when batch is not found', async () => {
+    jest.mocked(queriesModule.getSweepBatchDetail).mockResolvedValue(null as never);
+
+    const controller = new LoadedTreasuryController();
+    const req = {
+      params: { batchId: '999' },
+      body: { actor: 'user:uid-admin' },
+    } as unknown as CloseSweepBatchRequest;
+    const res = mockResponse();
+
+    await controller.closeSweepBatch(req, res);
+
+    expect(queriesModule.updateSweepBatchStatus).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the Cotsel admin-bridge route safety proof for #558. This adds explicit `operations:replay` authority through auth and gateway contracts, gates failed-operation replay on that capability plus replayable/open state, expands oracle approve/reject/redrive route-level proof, and tightens evidence, access-log, settings, auth route, and runbook coverage.

## Scope

- Adds `operations:replay` to auth capability truth, gateway session validation, capability snapshots, and OpenAPI.
- Requires `operations:replay` for dashboard failed-operation replay and rejects ineligible or already replayed failed operations before calling the replayer.
- Adds route-level oracle approve/reject/redrive auth and replay tests.
- Adds missing negative route proof for evidence bundle reads/generation, access-log reads, settings audit-feed cursor validation, and auth break-glass route inventory.
- Updates existing runbooks so replay and gateway mutation authority document route-specific capabilities instead of broad admin write access.

## Validation

- `pnpm --filter gateway run test` — 50 suites, 307 tests passed
- `pnpm --filter auth run test` — 10 suites, 59 tests passed
- `pnpm --filter oracle run test` — 10 suites passed, 46 passed, 16 existing skipped
- `pnpm --filter treasury run test` — 27 passed, 1 existing skipped suite, 130 passed, 2 existing skipped
- `pnpm run lint` — passed
- `pnpm run typecheck` — passed
- `pnpm --filter auth run build && pnpm --filter gateway run build && pnpm --filter oracle run build && pnpm --filter treasury run build` — passed
- `pnpm run format:check` — clean
- `git diff --check` — clean

Closes neither #558 nor any issue automatically; #558 should only close after review confirms this is sufficient route-safety proof for the admin bridge.
