### PR TITLE
docs: remove stale governance mutation route references

### DIFF
--- a/docs/runbooks/dashboard-gateway-route-inventory.md
+++ b/docs/runbooks/dashboard-gateway-route-inventory.md
@@ -53,39 +53,23 @@ removal only after gateway access logs, contract tests, and dashboard live parit
 
 ## Observed Dashboard Gateway Mutations
 
-| Route                                                                                    | Cotsel module                                         | Dashboard adapter         |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------- |
-| `POST /access-logs`                                                                      | `gateway/src/routes/accessLogs.ts`                    | `accessLogs.ts`           |
-| `POST /evidence/bundles`                                                                 | `gateway/src/routes/evidenceBundles.ts`               | `evidence.ts`             |
-| `POST /compliance/decisions`                                                             | `gateway/src/routes/compliance.ts`                    | `compliance.ts`           |
-| `POST /compliance/trades/:tradeId/block-oracle-progression`                              | `gateway/src/routes/compliance.ts`                    | `compliance.ts`           |
-| `POST /compliance/trades/:tradeId/resume-oracle-progression`                             | `gateway/src/routes/compliance.ts`                    | `compliance.ts`           |
-| `POST /governance/pause/prepare`                                                         | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/unpause/proposal/prepare`                                              | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/unpause/proposal/approve/prepare`                                      | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/unpause/proposal/cancel/prepare`                                       | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/claims/pause/prepare`                                                  | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/claims/unpause/prepare`                                                | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/treasury/sweep/prepare`                                                | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/oracle/disable-emergency/prepare`                                      | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/oracle/proposals/prepare`                                              | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/oracle/proposals/:proposalId/approve/prepare`                          | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/oracle/proposals/:proposalId/execute/prepare`                          | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/oracle/proposals/:proposalId/cancel-expired/prepare`                   | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/treasury/payout-receiver/proposals/prepare`                            | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/treasury/payout-receiver/proposals/:proposalId/approve/prepare`        | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/treasury/payout-receiver/proposals/:proposalId/execute/prepare`        | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/treasury/payout-receiver/proposals/:proposalId/cancel-expired/prepare` | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /governance/actions/:actionId/confirm`                                             | `gateway/src/routes/governanceDirectSignMutations.ts` | `governance.ts`           |
-| `POST /treasury/sweep-batches/:batchId/approve`                                          | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/accounting-periods/:periodId/close`                                      | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/sweep-batches/:batchId/close`                                            | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/entries/:entryId/realizations`                                           | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/sweep-batches/:batchId/match-execution`                                  | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/sweep-batches/:batchId/external-handoff`                                 | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/accounting-periods/:periodId/request-close`                              | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /treasury/sweep-batches/:batchId/request-approval`                                 | `gateway/src/routes/treasury.ts`                      | `treasury.ts`             |
-| `POST /dashboard-settlement/gasless-executions/create-trade`                             | `gateway/src/routes/dashboardSettlement.ts`           | `settlement-execution.ts` |
+| Route                                                        | Cotsel module                               | Dashboard adapter         |
+| ------------------------------------------------------------ | ------------------------------------------- | ------------------------- |
+| `POST /access-logs`                                          | `gateway/src/routes/accessLogs.ts`          | `accessLogs.ts`           |
+| `POST /evidence/bundles`                                     | `gateway/src/routes/evidenceBundles.ts`     | `evidence.ts`             |
+| `POST /compliance/decisions`                                 | `gateway/src/routes/compliance.ts`          | `compliance.ts`           |
+| `POST /compliance/trades/:tradeId/block-oracle-progression`  | `gateway/src/routes/compliance.ts`          | `compliance.ts`           |
+| `POST /compliance/trades/:tradeId/resume-oracle-progression` | `gateway/src/routes/compliance.ts`          | `compliance.ts`           |
+| ~~Governance direct-sign mutation routes~~                   | ~~Removed in PR #567~~                      | ~~`governance.ts`~~       |
+| `POST /treasury/sweep-batches/:batchId/approve`              | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/accounting-periods/:periodId/close`          | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/sweep-batches/:batchId/close`                | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/entries/:entryId/realizations`               | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/sweep-batches/:batchId/match-execution`      | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/sweep-batches/:batchId/external-handoff`     | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/accounting-periods/:periodId/request-close`  | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /treasury/sweep-batches/:batchId/request-approval`     | `gateway/src/routes/treasury.ts`            | `treasury.ts`             |
+| `POST /dashboard-settlement/gasless-executions/create-trade` | `gateway/src/routes/dashboardSettlement.ts` | `settlement-execution.ts` |
 
 ## Auth Service Routes Used By Cotsel.dash
 

--- a/docs/runbooks/maintainability-hardening-review-remediation.md
+++ b/docs/runbooks/maintainability-hardening-review-remediation.md
@@ -72,10 +72,9 @@ Files that remain large by design or current risk level:
 Remediated now:
 
 - `gateway/src/routes/governanceMutations.ts` mixed retired queue routes, active
-  direct-sign routes, signer validation helpers, and response helpers. Active
-  direct-sign prepare/confirm routes now live in
-  `gateway/src/routes/governanceDirectSignMutations.ts`, with shared route
-  helpers in `gateway/src/routes/governanceMutationRouteSupport.ts`.
+  direct-sign routes, signer validation helpers, and response helpers. The
+  governance mutation/execution surface was subsequently removed from the gateway
+  entirely (PR #567), so `governanceDirectSignMutations.ts` no longer exists.
 - `gateway/src/core/settlementStore.ts` mixed production Postgres persistence
   with the in-memory adapter used by gateway route/read-service tests. The
   in-memory adapter now lives in


### PR DESCRIPTION
## Summary
- Remove 17 governance direct-sign mutation route entries from the dashboard gateway route inventory that referenced the deleted `governanceDirectSignMutations.ts` (removed in PR #567)
- Update the maintainability remediation doc to reflect that the governance mutation surface no longer exists in the gateway

## Context
After merging PRs #566, #568, and #571, the `ci/docs-profile-guard` began failing on main because the route inventory still listed routes against a file that PR #567 had already removed.

## Test plan
- [ ] `ci/docs-profile-guard` passes (no more missing file errors)
- [ ] `ci/release-gate` passes (unblocked by docs-profile-guard)
- [ ] Route count remains above guard minimum (49 routes > 30 required)