### PR TITLE
Mount settlement ingress before dashboard auth

### DIFF
--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -413,6 +413,17 @@ async function bootstrap(): Promise<void> {
 
   const extraRouter = Router();
   extraRouter.use(
+    createSettlementRouter({
+      config,
+      settlementService,
+      settlementStore,
+      gaslessSettlementService,
+      nonceStore: settlementNonceStore,
+      idempotencyStore,
+      lookupServiceApiKey: settlementServiceApiKeyLookup,
+    }),
+  );
+  extraRouter.use(
     createCapabilitiesRouter({
       authSessionClient,
       config,
@@ -500,17 +511,6 @@ async function bootstrap(): Promise<void> {
       config,
       gaslessSettlementService,
       idempotencyStore,
-    }),
-  );
-  extraRouter.use(
-    createSettlementRouter({
-      config,
-      settlementService,
-      settlementStore,
-      gaslessSettlementService,
-      nonceStore: settlementNonceStore,
-      idempotencyStore,
-      lookupServiceApiKey: settlementServiceApiKeyLookup,
     }),
   );
   extraRouter.use(


### PR DESCRIPTION
## Summary
- Mount settlement service-ingress routes before dashboard-auth routers.
- Keeps dashboard/session routes protected while allowing settlement HMAC auth to run on `/settlement/*` routes.
- Matches the live Cotsel VM hotfix applied during Phase 6 release verification.

## Evidence
- `npm --prefix gateway test -- settlementRoutes.contract.test.ts`
- `npm --prefix gateway run build`
- `pnpm exec eslint --max-warnings=0 gateway/src/server.ts`
- `pnpm exec prettier --check gateway/src/server.ts`
- `git diff --check -- gateway/src/server.ts`
- Live VM `cotsel-staging` rebuilt healthy and signed Agroasys backend gateway read returned HTTP 200.

## Notes
The live VM also has runtime env updates for settlement ingress service auth and callback credentials. Secret values were not printed or committed.
