### PR TITLE
fix(indexer): restore migration for unused TradeEvent arrival column

### DIFF
--- a/indexer/db/migrations/1784580542957-Data.js
+++ b/indexer/db/migrations/1784580542957-Data.js
@@ -1,0 +1,11 @@
+module.exports = class Data1784580542957 {
+  name = 'Data1784580542957';
+
+  async up(db) {
+    await db.query(`ALTER TABLE "trade_event" DROP COLUMN "arrival_timestamp"`);
+  }
+
+  async down(db) {
+    await db.query(`ALTER TABLE "trade_event" ADD "arrival_timestamp" numeric`);
+  }
+};


### PR DESCRIPTION
## Summary

- restore the generated migration removed during PR #591 closeout
- drop the unused `trade_event.arrival_timestamp` column so the database matches the GraphQL schema and generated `TradeEvent` model
- retain the active `trade.arrival_timestamp` column used by trade-level reads

## Migration safety

- development-only cleanup; no deployed indexer compatibility window is required
- `up` drops only the unused nullable event column
- `down` restores the event column as `numeric`

## Validation

- indexer tests: 21 passed
- indexer lint: passed
- indexer typecheck: passed
- Prettier: passed
- full 15-migration chain applied successfully to an isolated PostgreSQL 16 database
- verified `up`, `down`, and reapply behavior; the active `trade.arrival_timestamp` remained intact throughout
