### PR TITLE
docs: define technical writing standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Agent Instructions
+
+## Technical documentation standard
+
+Use project-specific terminology and documentation rules first.
+
+Select one standard before writing:
+
+- Use ASD-STE100 Issue 9 for procedures, runbooks, operational instructions, security instructions, compliance instructions, safety text, and international documentation.
+- Use Google Technical Writing and the Google developer documentation style guide for other technical documentation.
+
+When strict ASD-STE100 conformance is required, apply its writing rules and controlled dictionary. Simplified wording alone is not conformance.
+
+Before writing, identify the audience, scope, prerequisites, and intended outcome. Put essential information first. Add detail in a logical order.
+
+Apply these rules:
+
+- Use one term for one meaning.
+- Define unfamiliar terms and abbreviations.
+- Avoid ambiguous pronouns, idioms, unnecessary jargon, and vague qualifiers.
+- Prefer active voice and specific verbs.
+- Write instructions in the imperative.
+- Put required conditions before the action.
+- Use one action in each numbered step.
+- Use no more than 20 words in an ASD-STE100 procedural sentence.
+- Use no more than 25 words in an ASD-STE100 descriptive sentence.
+- Keep one topic in each paragraph.
+- Use numbered lists for ordered tasks.
+- Use bulleted lists for unordered information.
+- Keep list items parallel.
+- Introduce each list and table.
+- Use descriptive headings and link text.
+- Add useful alternative text.
+- Use sufficient contrast in diagrams.
+- Use inclusive language.
+
+Preserve exact API names, code identifiers, commands, configuration keys, schema fields, quoted UI text, and required legal terms.
+
+Never remove constraints, exceptions, ownership boundaries, security controls, failure behavior, or recovery steps to simplify text.
+
+Verify technical accuracy before style editing. Review the final document for correctness, completeness, consistency, readability, accessibility, and translation readiness.
+
+Authoritative references:
+
+- [ASD-STE100 Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf)
+- [Google Technical Writing](https://developers.google.com/tech-writing)
+- [Google developer documentation style guide](https://developers.google.com/style)


### PR DESCRIPTION
## Summary

- Define the repository-wide technical writing standard in the root `AGENTS.md`.
- Use ASD-STE100 Issue 9 for procedural, operational, security, compliance, safety, and international documentation.
- Use Google Technical Writing and the Google developer documentation style guide for other technical documentation.
- Preserve exact technical terms, constraints, ownership boundaries, failure behavior, security controls, and recovery steps.
- Include authoritative references for future maintainers.

## Scope

This is documentation guidance only. It does not change runtime behavior, APIs, CI, dependencies, data, or user interfaces. No `SKILL.md` file changes.

## Verification

- `git diff --check`
- Documentation-only commit.
- Source links point to ASD-STE100 Issue 9 and official Google documentation guidance.
