### PR TITLE
fix(deps): resolve open Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "protocol:health": "node scripts/full-protocol-health-report.mjs",
     "licenses:report": "node scripts/generate-license-report.mjs",
     "security:deps": "node scripts/security-deps-report.mjs",
+    "security:deps:compat": "node scripts/dependency-compatibility-check.mjs",
     "security:deps:gate": "node scripts/security-deps-gate.mjs",
     "dashboard:route-inventory:check": "node scripts/tests/dashboard-gateway-route-inventory-guard.mjs",
     "shared:boundary:guard": "node scripts/shared-package-boundary-guard.mjs"
@@ -106,10 +107,6 @@
     "@babel/core@<=7.29.0": "7.29.6",
     "js-yaml@<3.15.0": "3.15.0",
     "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
-    "brace-expansion@^1.1.7": "1.1.16",
-    "brace-expansion@^2.0.1": "2.1.2",
-    "brace-expansion@^2.0.2": "2.1.2",
-    "brace-expansion@>=4 <5.0.8": "5.0.8",
     "body-parser@>=2 <2.3.0": "2.3.0",
     "qs": "6.15.2",
     "uuid@<11.1.1": "11.1.1",

--- a/package.json
+++ b/package.json
@@ -88,13 +88,13 @@
     ]
   },
   "overrides": {
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "hardhat-gas-reporter": {
-      "axios": "1.16.1"
+      "axios": "1.18.0"
     },
     "@protobufjs/utf8": "1.1.1",
     "cookie": "0.7.0",
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.4",
     "follow-redirects": "1.16.0",
     "js-cookie": "3.0.7",
     "lodash": "4.18.1",
@@ -105,11 +105,11 @@
     "form-data@>=4.0.0 <4.0.6": "4.0.6",
     "@babel/core@<=7.29.0": "7.29.6",
     "js-yaml@<3.15.0": "3.15.0",
-    "js-yaml@>=4.0.0 <=4.1.1": "4.2.0",
-    "brace-expansion@^1.1.7": "1.1.14",
-    "brace-expansion@^2.0.1": "2.1.0",
-    "brace-expansion@^2.0.2": "2.1.0",
-    "brace-expansion@>=4 <5.0.5": "5.0.6",
+    "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
+    "brace-expansion@^1.1.7": "1.1.16",
+    "brace-expansion@^2.0.1": "2.1.2",
+    "brace-expansion@^2.0.2": "2.1.2",
+    "brace-expansion@>=4 <5.0.8": "5.0.8",
     "body-parser@>=2 <2.3.0": "2.3.0",
     "qs": "6.15.2",
     "uuid@<11.1.1": "11.1.1",
@@ -122,7 +122,7 @@
     "@nomicfoundation/hardhat-ignition": "0.15.16",
     "@nomicfoundation/hardhat-ignition-ethers": "0.15.17",
     "handlebars@<4.7.9": "4.7.9",
-    "immutable": "4.3.8",
+    "immutable": "4.3.9",
     "picomatch@<2.3.2": "2.3.2",
     "picomatch@>=4 <4.0.4": "4.0.4",
     "path-to-regexp@<0.1.13": "0.1.13",

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index be9df86be09c7655787a65c55ae6da01858894c3..eee03f870533191534bacdcaa54aa3ede8e3455a 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -260,4 +260,7 @@ function expand_(str, max, maxLength, isTop) {
+     }
+     return acc;
+ }
++// Preserve the callable CommonJS export used by brace-expansion 1.x and 2.x
++// consumers while retaining the named exports introduced in 5.x.
++module.exports = Object.assign(exports.expand, exports);
+ //# sourceMappingURL=index.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 overrides:
   '@protobufjs/utf8': 1.1.1
-  axios: 1.16.1
+  axios: 1.18.0
   bn.js: 4.12.3
   cookie: 0.7.0
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   follow-redirects: 1.16.0
   js-cookie: 3.0.7
   lodash: 4.18.1
@@ -20,13 +20,17 @@ overrides:
   form-data@>=4.0.0 <4.0.6: 4.0.6
   '@babel/core@<=7.29.0': 7.29.6
   js-yaml@<3.15.0: 3.15.0
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
-  brace-expansion@>=4 <5.0.6: 5.0.6
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  brace-expansion@^1.1.7: 1.1.16
+  brace-expansion@^2.0.1: 2.1.2
+  brace-expansion@^2.0.2: 2.1.2
+  brace-expansion@>=4 <5.0.8: 5.0.8
   body-parser@>=2 <2.3.0: 2.3.0
   qs: 6.15.2
   uuid@<11.1.1: 11.1.1
   ws@>=7 <7.5.11: 7.5.11
   ws@>=8 <8.20.1: 8.21.0
+  immutable: 4.3.9
   graphql: 15.10.2
 
 importers:
@@ -279,8 +283,8 @@ importers:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.0
+        version: 4.3.0
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.29.6)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)))(typescript@6.0.3)
@@ -528,10 +532,10 @@ importers:
         version: 17.4.2
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
+        version: 30.4.2(@types/node@25.6.0)
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.6)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.9(@babel/core@7.29.6)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.6.0))(typescript@6.0.3)
       typescript:
         specifier: '>=6.0.2'
         version: 6.0.3
@@ -552,7 +556,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
+        version: 30.4.2(@types/node@25.6.0)
 
   shared-http: {}
 
@@ -4305,10 +4309,10 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  axios@1.16.1:
+  axios@1.18.0:
     resolution:
       {
-        integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==,
+        integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==,
       }
 
   babel-jest@30.4.1:
@@ -4487,24 +4491,24 @@ packages:
       }
     engines: { node: '>=10' }
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     resolution:
       {
-        integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==,
+        integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
       }
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     resolution:
       {
-        integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
+        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
       }
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     resolution:
       {
-        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+        integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==,
       }
-    engines: { node: 18 || 20 || >=22 }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -5935,10 +5939,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.2:
+  fast-uri@3.1.4:
     resolution:
       {
-        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+        integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==,
       }
 
   fastest-levenshtein@1.0.16:
@@ -6611,10 +6615,10 @@ packages:
         integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==,
       }
 
-  immutable@4.3.8:
+  immutable@4.3.9:
     resolution:
       {
-        integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==,
+        integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==,
       }
 
   import-local@3.2.0:
@@ -7285,10 +7289,10 @@ packages:
       }
     hasBin: true
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     resolution:
       {
-        integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==,
+        integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==,
       }
     hasBin: true
 
@@ -10739,7 +10743,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10914,7 +10918,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10969,7 +10973,7 @@ snapshots:
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -11680,7 +11684,7 @@ snapshots:
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
       '@types/lodash': 4.17.24
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       pony-cause: 2.1.11
       semver: 7.8.0
@@ -11695,7 +11699,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.8.0
       uuid: 11.1.1
@@ -11709,7 +11713,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.8.0
       uuid: 11.1.1
@@ -11824,7 +11828,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))(typescript@6.0.3)(utf-8-validate@5.0.10))':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       hardhat: 2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))(typescript@6.0.3)(utf-8-validate@5.0.10)
       lodash.isequal: 4.5.0
@@ -11845,7 +11849,7 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.15(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@nomicfoundation/ignition-ui': 0.15.13
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       hardhat: 2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))(typescript@6.0.3)(utf-8-validate@5.0.10)
       json5: 2.2.3
@@ -11886,7 +11890,7 @@ snapshots:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       hardhat: 2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))(typescript@6.0.3)(utf-8-validate@5.0.10)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
@@ -11901,7 +11905,7 @@ snapshots:
       '@ethersproject/address': 5.6.1
       '@nomicfoundation/solidity-analyzer': 0.1.2
       cbor: 9.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       fs-extra: 10.1.0
       immer: 10.0.2
@@ -12945,7 +12949,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12955,7 +12959,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -12974,7 +12978,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -12989,7 +12993,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.17
@@ -13573,7 +13577,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13596,7 +13600,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13740,7 +13744,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.1:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
@@ -13869,7 +13873,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -13898,16 +13902,16 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14434,7 +14438,7 @@ snapshots:
   engine.io-client@6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
@@ -14559,7 +14563,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -14796,7 +14800,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.0
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -14852,7 +14856,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -14897,7 +14901,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -14931,7 +14935,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -15113,7 +15117,7 @@ snapshots:
 
   graphql-parse-resolve-info@4.14.1(graphql@15.10.2):
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       graphql: 15.10.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15157,7 +15161,7 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/units': 5.8.0
       '@solidity-parser/parser': 0.20.2
-      axios: 1.16.1
+      axios: 1.18.0
       brotli-wasm: 2.0.1
       chalk: 4.1.2
       cli-table3: 0.6.5
@@ -15190,14 +15194,14 @@ snapshots:
       boxen: 5.1.2
       chokidar: 4.0.3
       ci-info: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
       find-up: 5.0.0
       fp-ts: 1.19.3
       fs-extra: 7.0.1
-      immutable: 4.3.8
+      immutable: 4.3.9
       io-ts: 1.10.4
       json-stream-stringify: 3.1.6
       keccak: 3.0.4
@@ -15289,7 +15293,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15327,7 +15331,7 @@ snapshots:
 
   immer@10.0.2: {}
 
-  immutable@4.3.8: {}
+  immutable@4.3.9: {}
 
   import-local@3.2.0:
     dependencies:
@@ -15365,7 +15369,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
@@ -15528,7 +15532,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -15593,6 +15597,25 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  jest-cli@30.4.2(@types/node@25.6.0):
+    dependencies:
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
 
   jest-cli@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
@@ -15904,6 +15927,19 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  jest@30.4.2(@types/node@25.6.0):
+    dependencies:
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
+      '@jest/types': 30.4.1
+      import-local: 3.2.0
+      jest-cli: 30.4.2(@types/node@25.6.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
@@ -15930,7 +15966,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -16164,19 +16200,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -16207,7 +16243,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
@@ -16850,7 +16886,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -16949,7 +16985,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -17100,7 +17136,7 @@ snapshots:
   socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       engine.io-client: 6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       socket.io-parser: 4.2.6
     transitivePeerDependencies:
@@ -17111,7 +17147,7 @@ snapshots:
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17397,6 +17433,26 @@ snapshots:
       babel-jest: 30.4.1(@babel/core@7.29.6)
       jest-util: 30.4.1
 
+  ts-jest@29.4.9(@babel/core@7.29.6)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.6.0))(typescript@6.0.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.4.2(@types/node@25.6.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 6.0.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.6
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.6)
+      jest-util: 30.4.1
+
   ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -17465,7 +17521,7 @@ snapshots:
   typechain@8.3.2(typescript@6.0.3):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -17499,7 +17555,7 @@ snapshots:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
       dayjs: 1.11.21
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       dedent: 1.7.2
       reflect-metadata: 0.2.2
       sql-highlight: 6.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,7 @@ overrides:
   '@babel/core@<=7.29.0': 7.29.6
   js-yaml@<3.15.0: 3.15.0
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  brace-expansion@^1.1.7: 1.1.16
-  brace-expansion@^2.0.1: 2.1.2
-  brace-expansion@^2.0.2: 2.1.2
-  brace-expansion@>=4 <5.0.8: 5.0.8
+  brace-expansion: 5.0.8
   body-parser@>=2 <2.3.0: 2.3.0
   qs: 6.15.2
   uuid@<11.1.1: 11.1.1
@@ -32,6 +29,11 @@ overrides:
   ws@>=8 <8.20.1: 8.21.0
   immutable: 4.3.9
   graphql: 15.10.2
+
+patchedDependencies:
+  brace-expansion@5.0.8:
+    hash: c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c
+    path: patches/brace-expansion@5.0.8.patch
 
 importers:
   .:
@@ -4355,12 +4357,6 @@ packages:
     peerDependencies:
       '@babel/core': 7.29.6
 
-  balanced-match@1.0.2:
-    resolution:
-      {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-      }
-
   balanced-match@4.0.4:
     resolution:
       {
@@ -4490,18 +4486,6 @@ packages:
         integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==,
       }
     engines: { node: '>=10' }
-
-  brace-expansion@1.1.16:
-    resolution:
-      {
-        integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
-      }
-
-  brace-expansion@2.1.2:
-    resolution:
-      {
-        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
-      }
 
   brace-expansion@5.0.8:
     resolution:
@@ -4977,12 +4961,6 @@ packages:
         integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==,
       }
     engines: { node: '>= 12' }
-
-  concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
 
   content-disposition@0.5.4:
     resolution:
@@ -13806,8 +13784,6 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6)
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base-x@3.0.11:
@@ -13902,16 +13878,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.8(patch_hash=c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c):
     dependencies:
       balanced-match: 4.0.4
 
@@ -14186,8 +14153,6 @@ snapshots:
   commander@2.20.3: {}
 
   commander@8.3.0: {}
-
-  concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -16200,19 +16165,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.8(patch_hash=c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8(patch_hash=c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8(patch_hash=c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8(patch_hash=c695111e00c1e87392a718974ddd5648e01d9fc67e85e303dd3d0a3088cd4f1c)
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,12 +17,15 @@ packages:
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  # Security fix for GHSA-mh99-v99m-4gvg. Keep the exception version-specific.
+  - brace-expansion@5.0.8
 overrides:
   '@protobufjs/utf8': 1.1.1
-  axios: 1.16.1
+  axios: 1.18.0
   bn.js: 4.12.3
   cookie: 0.7.0
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   follow-redirects: 1.16.0
   js-cookie: 3.0.7
   lodash: 4.18.1
@@ -33,13 +36,17 @@ overrides:
   form-data@>=4.0.0 <4.0.6: 4.0.6
   '@babel/core@<=7.29.0': 7.29.6
   js-yaml@<3.15.0: 3.15.0
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
-  brace-expansion@>=4 <5.0.6: 5.0.6
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  brace-expansion@^1.1.7: 1.1.16
+  brace-expansion@^2.0.1: 2.1.2
+  brace-expansion@^2.0.2: 2.1.2
+  brace-expansion@>=4 <5.0.8: 5.0.8
   body-parser@>=2 <2.3.0: 2.3.0
   qs: 6.15.2
   uuid@<11.1.1: 11.1.1
   ws@>=7 <7.5.11: 7.5.11
   ws@>=8 <8.20.1: 8.21.0
+  immutable: 4.3.9
   # Dedupe graphql to a single instance. @subsquid/openreader builds the schema
   # while @subsquid/graphql-server merges it; when they resolve different graphql
   # patch versions, cross-instance `instanceof` checks fail and mergeSchemas throws

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,10 +37,9 @@ overrides:
   '@babel/core@<=7.29.0': 7.29.6
   js-yaml@<3.15.0: 3.15.0
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  brace-expansion@^1.1.7: 1.1.16
-  brace-expansion@^2.0.1: 2.1.2
-  brace-expansion@^2.0.2: 2.1.2
-  brace-expansion@>=4 <5.0.8: 5.0.8
+  # Route every legacy consumer through the patched 5.x implementation.
+  # The package patch preserves the callable CommonJS API expected by 1.x and 2.x consumers.
+  brace-expansion: 5.0.8
   body-parser@>=2 <2.3.0: 2.3.0
   qs: 6.15.2
   uuid@<11.1.1: 11.1.1
@@ -53,3 +52,6 @@ overrides:
   # "Unknown type Query". One graphql version keeps the indexer GraphQL API working
   # without patching @subsquid/graphql-server.
   graphql: 15.10.2
+
+patchedDependencies:
+  brace-expansion@5.0.8: patches/brace-expansion@5.0.8.patch

--- a/scripts/dependency-compatibility-check.mjs
+++ b/scripts/dependency-compatibility-check.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const virtualStore = path.resolve('node_modules/.pnpm');
+const minimatchVersions = ['3.1.5', '5.1.9', '9.0.9', '10.2.5'];
+
+function packagePath(name, version) {
+  const prefix = `${name}@${version}`;
+  const matches = fs
+    .readdirSync(virtualStore)
+    .filter((entry) => entry === prefix || entry.startsWith(`${prefix}_`));
+
+  assert.equal(
+    matches.length,
+    1,
+    `Expected one installed ${name}@${version}, found ${matches.length}`,
+  );
+  return path.join(virtualStore, matches[0], 'node_modules', name);
+}
+
+const braceTargets = new Set();
+for (const version of minimatchVersions) {
+  const minimatchPath = packagePath('minimatch', version);
+  const bracePath = fs.realpathSync(path.join(path.dirname(minimatchPath), 'brace-expansion'));
+  braceTargets.add(bracePath);
+
+  const minimatchModule = require(minimatchPath);
+  const minimatch =
+    typeof minimatchModule === 'function' ? minimatchModule : minimatchModule.minimatch;
+  assert.equal(typeof minimatch, 'function', `minimatch@${version} must expose a callable API`);
+  assert.equal(minimatch('src/routes/trade.ts', 'src/**/*.ts'), true);
+}
+
+assert.equal(
+  braceTargets.size,
+  1,
+  'All minimatch versions must resolve one patched brace-expansion',
+);
+const [bracePath] = braceTargets;
+assert.match(bracePath, /brace-expansion@5\.0\.8_patch_hash=/);
+
+const braceExpansion = require(bracePath);
+assert.equal(
+  typeof braceExpansion,
+  'function',
+  'Legacy CommonJS consumers require a callable export',
+);
+assert.equal(
+  braceExpansion.expand,
+  braceExpansion,
+  'The named and callable APIs must use the same function',
+);
+assert.deepEqual(braceExpansion('file-{a,b}.txt'), ['file-a.txt', 'file-b.txt']);
+assert.equal(braceExpansion('{1..200000}').length, braceExpansion.EXPANSION_MAX);
+
+const lengthCapped = braceExpansion('{a,b}'.repeat(1500), { maxLength: 100 });
+assert.ok(lengthCapped.reduce((total, value) => total + value.length, 0) <= 100);
+
+console.log(
+  `Dependency compatibility check passed: minimatch ${minimatchVersions.join(', ')} -> patched brace-expansion 5.0.8`,
+);

--- a/scripts/security-deps-gate.mjs
+++ b/scripts/security-deps-gate.mjs
@@ -1,6 +1,22 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
 
+const developmentAuditAllowlist = new Map([
+  [
+    'GHSA-848j-6mx2-7j84',
+    {
+      moduleName: 'elliptic',
+      severity: 'low',
+      versions: new Set(['6.6.1']),
+      patchedVersions: '<0.0.0',
+      owner: 'Cotsel security maintainers',
+      expiresOn: '2026-10-31',
+      reason:
+        'No patched release exists. The affected path is limited to development-only Hardhat tooling.',
+    },
+  ],
+]);
+
 function runPnpm(args) {
   try {
     const stdout = execFileSync('pnpm', args, {
@@ -44,21 +60,106 @@ function vulnerabilities(report) {
   };
 }
 
+function advisories(report) {
+  return Object.values(report?.advisories ?? {});
+}
+
+function advisoryId(advisory) {
+  return advisory?.github_advisory_id ?? String(advisory?.id ?? 'unknown');
+}
+
+function matchesDevelopmentAllowlist(advisory, currentDate = new Date()) {
+  const allowed = developmentAuditAllowlist.get(advisoryId(advisory));
+  if (!allowed) {
+    return false;
+  }
+
+  const expiresAt = new Date(`${allowed.expiresOn}T23:59:59Z`);
+  const findingVersions = (advisory.findings ?? []).map((finding) => finding.version);
+
+  return (
+    currentDate <= expiresAt &&
+    advisory.module_name === allowed.moduleName &&
+    advisory.severity === allowed.severity &&
+    advisory.patched_versions === allowed.patchedVersions &&
+    findingVersions.length > 0 &&
+    findingVersions.every((version) => allowed.versions.has(version))
+  );
+}
+
+function auditDescription(advisory) {
+  const versions = [...new Set((advisory.findings ?? []).map((finding) => finding.version))];
+  return `${advisoryId(advisory)} ${advisory.module_name ?? 'unknown-package'}@${versions.join(',') || 'unknown'} (${advisory.severity ?? 'unknown-severity'})`;
+}
+
 const auditProd = runPnpm(['audit', '--prod', '--json']);
-const auditReport = parseAudit(auditProd.stdout);
-const summary = vulnerabilities(auditReport);
+const auditProdReport = parseAudit(auditProd.stdout);
+const prodSummary = vulnerabilities(auditProdReport);
+const auditAll = runPnpm(['audit', '--json']);
+const auditAllReport = parseAudit(auditAll.stdout);
+const allSummary = vulnerabilities(auditAllReport);
+const dependencyCompatibility = runPnpm(['run', 'security:deps:compat']);
 const lsAll = runPnpm(['list', '--depth', 'Infinity']);
 
 console.log('Security dependency release gate');
 console.log(`Generated: ${new Date().toISOString()}`);
 console.log(
-  `pnpm audit --prod: critical=${summary.critical} high=${summary.high} moderate=${summary.moderate} low=${summary.low} total=${summary.total}`,
+  `pnpm audit --prod: critical=${prodSummary.critical} high=${prodSummary.high} moderate=${prodSummary.moderate} low=${prodSummary.low} total=${prodSummary.total}`,
 );
+console.log(
+  `pnpm audit: critical=${allSummary.critical} high=${allSummary.high} moderate=${allSummary.moderate} low=${allSummary.low} total=${allSummary.total}`,
+);
+console.log(`dependency compatibility: exit=${dependencyCompatibility.exitCode}`);
 console.log(`pnpm list --depth Infinity: exit=${lsAll.exitCode}`);
 
 let failed = false;
-if (summary.critical > 0 || summary.high > 0 || summary.moderate > 0 || summary.low > 0) {
+if (
+  prodSummary.critical > 0 ||
+  prodSummary.high > 0 ||
+  prodSummary.moderate > 0 ||
+  prodSummary.low > 0
+) {
   console.error('Release gate failed: production dependency audit has findings.');
+  failed = true;
+}
+
+if (auditAllReport) {
+  const allAdvisories = advisories(auditAllReport);
+  const acceptedAdvisories = allAdvisories.filter(matchesDevelopmentAllowlist);
+  const unexpectedAdvisories = allAdvisories.filter(
+    (advisory) => !matchesDevelopmentAllowlist(advisory),
+  );
+
+  if (allSummary.total > 0 && allAdvisories.length === 0) {
+    console.error('Release gate failed: full dependency audit findings could not be classified.');
+    failed = true;
+  }
+
+  for (const advisory of acceptedAdvisories) {
+    const allowed = developmentAuditAllowlist.get(advisoryId(advisory));
+    console.log(
+      `Accepted development advisory: ${auditDescription(advisory)}; owner=${allowed.owner}; expires=${allowed.expiresOn}; reason=${allowed.reason}`,
+    );
+  }
+
+  for (const advisory of unexpectedAdvisories) {
+    console.error(
+      `Release gate failed: unexpected dependency advisory: ${auditDescription(advisory)}`,
+    );
+    failed = true;
+  }
+}
+
+if (dependencyCompatibility.exitCode !== 0) {
+  const tail = (dependencyCompatibility.stderr || dependencyCompatibility.stdout)
+    .trim()
+    .split('\n')
+    .slice(-20)
+    .join('\n');
+  console.error('Release gate failed: dependency compatibility check failed.');
+  if (tail) {
+    console.error(tail);
+  }
   failed = true;
 }
 
@@ -71,8 +172,13 @@ if (lsAll.exitCode !== 0) {
   failed = true;
 }
 
-if (auditProd.exitCode !== 0 && !auditReport) {
-  console.error('Release gate failed: pnpm audit did not return parseable JSON.');
+if (!auditProdReport) {
+  console.error('Release gate failed: production dependency audit did not return parseable JSON.');
+  failed = true;
+}
+
+if (!auditAllReport) {
+  console.error('Release gate failed: full dependency audit did not return parseable JSON.');
   failed = true;
 }
 


### PR DESCRIPTION
## Summary
- update the five dependency families behind the 19 open Dependabot alerts
- resolve every `brace-expansion` consumer to patched version 5.0.8
- preserve the callable CommonJS API required by legacy minimatch consumers
- make the security gate enforce both production and full dependency audits
- keep the 5.0.8 release-age exception exact and version-specific

## Compatibility controls
- the pnpm patch changes only the CommonJS export shape; upstream security limits remain unchanged
- the compatibility check exercises minimatch 3, 5, 9, and 10 against the patched package
- the lockfile contains one `brace-expansion` version and no vulnerable 1.x or 2.x package

## Validation
- clean Node 20 `pnpm install --frozen-lockfile`
- `pnpm run security:deps:gate`
- production audit: zero findings
- full audit: zero critical, high, or moderate findings
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check:full`
- all workspace builds passed
- 876 tests passed across 13 dependency-reachable packages, with expected skips only

## Accepted low advisory
The full audit reports `GHSA-848j-6mx2-7j84` for `elliptic@6.6.1`. It has no patched release and is limited to development-only Hardhat tooling. The gate restricts this exception to the exact advisory, package, version, and severity. Cotsel security maintainers own the exception, which expires on 2026-10-31.