### PR TITLE
chore(contracts): exclude local outputs from Docker context

### DIFF
--- a/contracts/.dockerignore
+++ b/contracts/.dockerignore
@@ -1,0 +1,17 @@
+.env
+.DS_Store
+npm-debug.log*
+*.log
+
+node_modules
+artifacts
+cache
+coverage
+coverage.json
+reports
+typechain
+typechain-types
+
+foundry/cache
+foundry/out
+ignition/deployments/chain-31337


### PR DESCRIPTION
## Summary
- exclude local environment files and generated contract outputs from the contracts Docker build context
- keep node modules, coverage, reports, Foundry outputs, and local Hardhat deployment data out of image uploads

## Validation
- `git diff --check`
- reviewed each ignored path against `contracts/Dockerfile`

Docker runtime validation was not available because the local Colima daemon is stopped. The change affects context selection only; it does not change the Dockerfile or application code.