### PR TITLE
chore(readiness): format issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel defect
 description: Record a verified chain, callback, settlement, or evidence defect that can affect a release gate.
-title: "[Defect] "
-labels: ["bug", "status:backlog"]
+title: '[Defect] '
+labels: ['bug', 'status:backlog']
 body:
   - type: textarea
     id: impact

--- a/.github/ISSUE_TEMPLATE/external-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/external-dependency.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel dependency
 description: Track a backend, chain/RPC, provider, signer, environment, finance, or decision dependency.
-title: "[WP-X/External] "
-labels: ["priority:P0", "status:blocked", "type:ops"]
+title: '[WP-X/External] '
+labels: ['priority:P0', 'status:blocked', 'type:ops']
 body:
   - type: textarea
     id: outcome

--- a/.github/ISSUE_TEMPLATE/p0-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/p0-implementation.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel implementation
 description: Define a release-blocking Cotsel, chain, settlement, or reconciliation deliverable.
-title: "[WP-X/Cotsel] "
-labels: ["priority:P0", "status:backlog"]
+title: '[WP-X/Cotsel] '
+labels: ['priority:P0', 'status:backlog']
 body:
   - type: textarea
     id: outcome
@@ -50,7 +50,7 @@ body:
     attributes:
       label: Acceptance criteria
       description: Use observable criteria tied to one deployment, chain ID, contract set, provider mode, and paired release.
-      placeholder: "- [ ] ..."
+      placeholder: '- [ ] ...'
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary

Format the three controlled-pilot issue forms with the repository Prettier version.

## Scope

This is setup hygiene only. It does not implement any readiness work package or change runtime behavior.

## Verification

- `npx --yes prettier@3.8.3 --check .github/ISSUE_TEMPLATE/defect.yml .github/ISSUE_TEMPLATE/external-dependency.yml .github/ISSUE_TEMPLATE/p0-implementation.yml`
- `git diff --check`