### PR TITLE
Complete controlled-pilot issue-form traceability

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -28,7 +28,13 @@ body:
     id: impact_map
     attributes:
       label: SOW, journey, control, and gate impact
-      description: List requirements, financial records, and evidence invalidated by this defect.
+      description: Keep the four SOW fields separate for each affected row. Then identify the journeys, controls, gates, financial records, and evidence invalidated by this defect.
+      placeholder: |
+        | ID | Required work | Implementation requirement | Acceptance evidence |
+        | --- | --- | --- | --- |
+        | X.1 | ... | ... | ... |
+
+        Invalidated journeys, controls, gates, records, and evidence: ...
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel defect
 description: Record a verified chain, callback, settlement, or evidence defect that can affect a release gate.
 title: '[Defect] '
-labels: ['bug', 'status:backlog']
+labels: ['bug', 'status:backlog', 'programme:controlled-pilot']
 body:
   - type: textarea
     id: impact

--- a/.github/ISSUE_TEMPLATE/external-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/external-dependency.yml
@@ -21,7 +21,13 @@ body:
     id: traceability
     attributes:
       label: SOW traceability and gate impact
-      description: List exact rows, work package, journey, and gate blocked by this dependency.
+      description: Keep the four SOW fields separate for each affected row. Then list the work package, journey, and gate blocked by this dependency.
+      placeholder: |
+        | ID | Required work | Implementation requirement | Acceptance evidence |
+        | --- | --- | --- | --- |
+        | X.1 | ... | ... | ... |
+
+        Blocked work package, journey, and gate: ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/external-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/external-dependency.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel dependency
 description: Track a backend, chain/RPC, provider, signer, environment, finance, or decision dependency.
 title: '[WP-X/External] '
-labels: ['priority:P0', 'status:blocked', 'type:ops']
+labels: ['priority:P0', 'status:blocked', 'type:ops', 'programme:controlled-pilot']
 body:
   - type: textarea
     id: outcome

--- a/.github/ISSUE_TEMPLATE/p0-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/p0-implementation.yml
@@ -14,7 +14,13 @@ body:
     id: traceability
     attributes:
       label: SOW traceability
-      description: List exact SOW rows, parent work package, P0 gate, journeys, controls, and failure scenarios.
+      description: Keep Required work, Implementation requirement, and Acceptance evidence as separate fields for every exact SOW row. Then identify the parent, gate, journeys, controls, and failure scenarios.
+      placeholder: |
+        | ID | Required work | Implementation requirement | Acceptance evidence |
+        | --- | --- | --- | --- |
+        | X.1 | ... | ... | ... |
+
+        Parent, gate, journeys, controls, and failure scenarios: ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/p0-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/p0-implementation.yml
@@ -1,7 +1,7 @@
 name: Controlled-pilot Cotsel implementation
 description: Define a release-blocking Cotsel, chain, settlement, or reconciliation deliverable.
 title: '[WP-X/Cotsel] '
-labels: ['priority:P0', 'status:backlog']
+labels: ['priority:P0', 'status:backlog', 'programme:controlled-pilot']
 body:
   - type: textarea
     id: outcome


### PR DESCRIPTION
## Summary

- add the controlled-pilot programme label to the Cotsel issue forms
- require `ID`, `Required work`, `Implementation requirement`, and `Acceptance evidence` as separate SOW fields
- preserve exact deployment, chain, contract, provider, callback, settlement, reconciliation, failure, recovery, and rollback traceability

## Why

Cotsel readiness issues need to identify one paired release and preserve safe financial authority, finality, idempotency, reconciliation, and containment boundaries. The governing SOW's `Required work` field must not be collapsed into implementation detail.

Programme: Agroasys/agroasys-backend#482

## Validation

- all issue-form YAML parses successfully
- `git diff --check` passes

This is issue-governance setup only. It does not start or claim implementation of any readiness issue.
