### PR TITLE
fix(contracts): finalize AgroasysEscrow with admin quorum floor for immutable lock

### DIFF
--- a/contracts/foundry/src/AgroasysEscrow.sol
+++ b/contracts/foundry/src/AgroasysEscrow.sol
@@ -492,7 +492,11 @@ contract AgroasysEscrow is ReentrancyGuard, Pausable {
         require(_treasuryAddress != address(0), "invalid treasury");
         require(_relayerAddress != address(0), "invalid relayer");
         require(_requiredApprovals >= 2, "required approvals must be >= 2");
-        require(_admins.length >= _requiredApprovals, "not enough admins");
+        // Strictly greater, not equal: the admin set must keep at least one spare signer beyond
+        // the approval threshold. At parity (admins == requiredApprovals) the loss of a single
+        // key permanently disables dispute resolution, unpause, and all governance rotation,
+        // and this contract has no admin-removal or threshold-change path to recover.
+        require(_admins.length > _requiredApprovals, "not enough admins");
 
         usdcToken = IERC20(_usdcToken);
         oracleAddress = _oracleAddress;

--- a/contracts/reports/deploy/base-sepolia/agroasysescrow-deploy.json
+++ b/contracts/reports/deploy/base-sepolia/agroasysescrow-deploy.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T20:19:09.509Z",
-  "commitSha": "8b4a693eb4cff3fe62605f2d10435f895afebb78",
+  "generatedAt": "2026-08-02T22:09:51.267Z",
+  "commitSha": "1f54c7acec55f3f618cbee9f7494dee621b72755",
   "network": {
     "hardhatName": "base-sepolia",
     "runtimeKey": "base-sepolia",
@@ -9,16 +9,18 @@
   },
   "contract": {
     "name": "AgroasysEscrow",
-    "address": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
-    "deploymentTxHash": "0x49dbe6d714c9b19901256e55c4407ec4722d55ea9110c1f0866f424e40b55b5d",
-    "explorerAddressUrl": "https://sepolia.basescan.org/address/0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+    "address": "0x8e1e152167FeD9FF7833156A023fFCa88f243B3d",
+    "deploymentTxHash": "0x2972491842eef29463d16c9e569284c426feba2cf343b17182708442732e7ff7",
+    "explorerAddressUrl": "https://sepolia.basescan.org/address/0x8e1e152167FeD9FF7833156A023fFCa88f243B3d",
     "constructorArguments": {
       "usdcAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
       "oracleAddress": "0x4beB8eeEC8dA57CaB76D2cAFD27Af6dFA22f972a",
       "treasuryAddress": "0x4beB8eeEC8dA57CaB76D2cAFD27Af6dFA22f972a",
+      "relayerAddress": "0x4beB8eeEC8dA57CaB76D2cAFD27Af6dFA22f972a",
       "admins": [
         "0x4beB8eeEC8dA57CaB76D2cAFD27Af6dFA22f972a",
-        "0x20e7E6fC0905E17De2D28E926Ad56324a6844a1D"
+        "0x20e7E6fC0905E17De2D28E926Ad56324a6844a1D",
+        "0x4aF052cB4B3eC7b58322548021bF254Cc4c80b2c"
       ],
       "requiredApprovals": 2
     }
@@ -26,12 +28,12 @@
   "verification": {
     "requested": true,
     "status": "verified",
-    "verificationUrl": "https://sepolia.basescan.org/address/0x54391ad22880B845021D49e79bA7E47bA8CcDDA7#code"
+    "verificationUrl": "https://sepolia.basescan.org/address/0x8e1e152167FeD9FF7833156A023fFCa88f243B3d#code"
   },
   "artifact": {
     "compilerVersion": "0.8.34",
-    "abiSha256": "a9d62d6adf98963f5d010f8636261fdb826408b188dd00f82f0b59afbcc1ff3b",
-    "bytecodeSha256": "066a90e3edf81fe8529c44924be8185da0b36fff972b1fa417848b863123d75a",
-    "deployedBytecodeSha256": "8ae6bd40151f975007997152aa60a5421b1fccc59e2fc866da27f8467af7b61a"
+    "abiSha256": "572c473d519c81c67d0fe6fa3174439aca53d17f45b9b8438c196bcf916aaed1",
+    "bytecodeSha256": "b3429757821ff6089d330e2c97f69c0fe8ee489d392cced82c689bb5b76b6909",
+    "deployedBytecodeSha256": "faaa5d4489c4cf0bb774a7be0eabbb7ce7c1bd67603b774fc687af52c316c5b7"
   }
 }

--- a/contracts/scripts/lib/baseDeploymentConfig.ts
+++ b/contracts/scripts/lib/baseDeploymentConfig.ts
@@ -209,8 +209,11 @@ export function loadBaseDeploymentConfig(
   assertAdminsDoNotIncludeForbiddenUsers(admins, forbiddenUserWallets);
   assertRelayerDoesNotIncludeForbiddenUsers(relayerAddress, forbiddenUserWallets);
   const requiredApprovals = parsePositiveIntEnv("DEPLOY_REQUIRED_APPROVALS", env);
-  if (requiredApprovals > admins.length) {
-    throw new Error("DEPLOY_REQUIRED_APPROVALS must not exceed the number of admin addresses");
+  if (requiredApprovals >= admins.length) {
+    throw new Error(
+      "DEPLOY_ADMINS must contain more addresses than DEPLOY_REQUIRED_APPROVALS. " +
+        "Deploying at parity means losing one admin key permanently disables governance.",
+    );
   }
 
   const confirmations = parsePositiveIntEnv(

--- a/contracts/src/AgroasysEscrow.sol
+++ b/contracts/src/AgroasysEscrow.sol
@@ -492,7 +492,11 @@ contract AgroasysEscrow is ReentrancyGuard, Pausable {
         require(_treasuryAddress != address(0), "invalid treasury");
         require(_relayerAddress != address(0), "invalid relayer");
         require(_requiredApprovals >= 2, "required approvals must be >= 2");
-        require(_admins.length >= _requiredApprovals, "not enough admins");
+        // Strictly greater, not equal: the admin set must keep at least one spare signer beyond
+        // the approval threshold. At parity (admins == requiredApprovals) the loss of a single
+        // key permanently disables dispute resolution, unpause, and all governance rotation,
+        // and this contract has no admin-removal or threshold-change path to recover.
+        require(_admins.length > _requiredApprovals, "not enough admins");
 
         usdcToken = IERC20(_usdcToken);
         oracleAddress = _oracleAddress;

--- a/contracts/tests/AgroasysEscrow.ts
+++ b/contracts/tests/AgroasysEscrow.ts
@@ -480,6 +480,51 @@ describe('AgroasysEscrow', function () {
         ),
       ).to.be.revertedWith('not enough admins');
     });
+
+    it('Should reject an admin set at parity with the approval threshold', async function () {
+      const EscrowFactory = await ethers.getContractFactory('AgroasysEscrow');
+
+      // admins == requiredApprovals leaves no spare signer: losing one key would
+      // permanently disable dispute resolution, unpause and governance rotation.
+      await expect(
+        EscrowFactory.deploy(
+          await usdc.getAddress(),
+          oracle.address,
+          treasury.address,
+          relayer.address,
+          [admin1.address, admin2.address],
+          2,
+        ),
+      ).to.be.revertedWith('not enough admins');
+
+      await expect(
+        EscrowFactory.deploy(
+          await usdc.getAddress(),
+          oracle.address,
+          treasury.address,
+          relayer.address,
+          [admin1.address, admin2.address, admin3.address],
+          3,
+        ),
+      ).to.be.revertedWith('not enough admins');
+    });
+
+    it('Should accept an admin set with at least one spare signer', async function () {
+      const EscrowFactory = await ethers.getContractFactory('AgroasysEscrow');
+
+      const spareEscrow = await EscrowFactory.deploy(
+        await usdc.getAddress(),
+        oracle.address,
+        treasury.address,
+        relayer.address,
+        [admin1.address, admin2.address, admin3.address],
+        2,
+      );
+      await spareEscrow.waitForDeployment();
+
+      expect(await spareEscrow.requiredApprovals()).to.equal(2);
+      expect(await spareEscrow.isAdmin(admin3.address)).to.be.true;
+    });
   });
 
   describe('Emergency Controls', function () {
@@ -510,7 +555,7 @@ describe('AgroasysEscrow', function () {
         oracle.address,
         treasury.address,
         relayer.address,
-        [admin1.address, admin2.address],
+        [admin1.address, admin2.address, admin3.address],
         2,
       );
       await quorumEscrow.waitForDeployment();

--- a/contracts/tests/baseDeploymentConfig.ts
+++ b/contracts/tests/baseDeploymentConfig.ts
@@ -49,7 +49,16 @@ describe('Base deployment config', function () {
         ...validEnv,
         DEPLOY_REQUIRED_APPROVALS: '4',
       }),
-    ).to.throw(/must not exceed the number of admin addresses/);
+    ).to.throw(/must contain more addresses than DEPLOY_REQUIRED_APPROVALS/);
+  });
+
+  it('rejects an admin set at parity with the approval threshold', async function () {
+    expect(() =>
+      loadBaseDeploymentConfig('base-sepolia', 84532, {
+        ...validEnv,
+        DEPLOY_REQUIRED_APPROVALS: '3',
+      }),
+    ).to.throw(/must contain more addresses than DEPLOY_REQUIRED_APPROVALS/);
   });
 
   it('rejects single-admin deployment matrices because governance requires two admins', async function () {


### PR DESCRIPTION
## What changed

- **Constructor quorum floor.** `_admins.length > _requiredApprovals` (previously `>=`). Deploying at parity meant losing a single admin key would permanently disable dispute resolution, unpause, and all governance rotation, with no admin-removal or threshold-change path to recover.
- **Deploy validator** (`baseDeploymentConfig.ts`) tightened to the same rule, so an invalid admin matrix fails before a transaction is sent instead of reverting on-chain.
- **Tests** for the new parity boundary in both the contract and the config validator, plus a fixture that deployed at 2 admins / 2 approvals. 110 passing (was 107).
- **Deployment record** for Base Sepolia `0x8e1e152167FeD9FF7833156A023fFCa88f243B3d`.

Contract behaviour is otherwise untouched: no changes to payout economics, token-flow paths, ABI, or event signatures. Deployed bytecode is 24,417 / 24,576 bytes, unchanged from before this PR.