### PR TITLE
feat(readiness): bind release evidence to an immutable candidate manifest

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -228,6 +228,7 @@ jobs:
           run_check repo-lint pnpm run lint
           run_check repo-format-check pnpm run format:check:full
           run_check repo-typecheck pnpm run typecheck
+          run_check release-evidence-binding pnpm run release:evidence:check
 
           if [[ "$fail" -ne 0 ]]; then
             exit 1

--- a/docs/runbooks/cross-repository-release-manifest.md
+++ b/docs/runbooks/cross-repository-release-manifest.md
@@ -4,6 +4,8 @@ The Integration Lead is the single accountable owner of the Cotsel cross-reposit
 
 `integration/release-manifest.json` is checked in as `candidate`, not as evidence of production approval. It pins the locally verified Agroasys backend, platform.v1 and Cotsel-Dash commits. Draft and baseline manifests cannot supply workflow checkout outputs. Any repository change requires the Integration Lead to update the corresponding full commit SHA and return the manifest to `candidate`. The hosted compatibility workflow then verifies clean checkouts at those exact commits, compares the Cotsel and Agroasys callback fixtures, runs the Agroasys backend provider contracts, runs the platform.v1 consumer contracts, runs the Cotsel settlement provider contract, and executes the M3 backend/gateway/Cotsel-Dash continuity suite. The result is attached to the release record. Status may change to `approved` only after those checks and the remaining SOW release gates pass for the exact pinned commits.
 
+A candidate manifest binds this file into a single candidate identity by canonical digest, so a pin change here produces a new candidate. See `docs/runbooks/release-candidate-evidence-binding.md`.
+
 Run the local structural check with:
 
 ```bash

--- a/docs/runbooks/release-candidate-evidence-binding.md
+++ b/docs/runbooks/release-candidate-evidence-binding.md
@@ -1,0 +1,137 @@
+# Release candidate manifest and evidence index
+
+This runbook defines the two machine-readable contracts that bind Cotsel readiness evidence to an
+exact candidate, and the rules CI enforces on them. It implements SOW rows REPORT-02 and PROG-01
+under work package WP-0 ([#636](https://github.com/Agroasys/Cotsel/issues/636), gate E-0).
+
+The programme verdict is **NO-GO**. These contracts describe how evidence is bound and accepted.
+They do not authorize a rehearsal, pilot or mainnet release, and no candidate is pinned yet.
+
+## The two documents
+
+| Document                                     | Schema                         | Owner                                                 |
+| -------------------------------------------- | ------------------------------ | ----------------------------------------------------- |
+| `integration/candidate-manifest.schema.json` | `cotsel.candidate-manifest.v1` | Release Owner                                         |
+| `integration/evidence-index.schema.json`     | `cotsel.evidence-index.v1`     | Release Owner, with Security and Operations reviewers |
+
+The **candidate manifest** is the immutable identity of one deployable candidate: source commit,
+artifact digests, migration heads, chain, contract address and ABI digest, provider mode, redacted
+configuration digest, environment, approvals and rollback target. It also carries the digest of
+`integration/release-manifest.json`, so the sibling-repository pins (`agroasys-backend`,
+`platform.v1`, `Cotsel-Dash`) are part of the candidate identity rather than a parallel record.
+
+The **evidence index** maps SOW control identities to reproducible artifacts. Every entry records
+the identity it was produced against, who produced it, and who accepted it.
+
+## Candidate identity, and what may change without invalidating evidence
+
+The identity digest covers only the dimensions that can change what a run proves:
+
+```
+candidateId, sourceCommit, crossRepositoryManifestSha256, artifactDigests, environment,
+chainId, contractAddress, contractAbiSha256, contractDeployedBytecodeSha256,
+migrationIdentities, providerMode, configDigestSha256
+```
+
+Lifecycle fields — `status`, `approvals`, `supersedes`, `rollbackTarget` notes — are deliberately
+excluded. Promoting a candidate from `candidate` to `promoted` therefore does **not** invalidate
+evidence already accepted against it. Changing any identity dimension does, and produces a new
+candidate.
+
+Compute the digest with:
+
+```bash
+node scripts/check-release-evidence-binding.mjs --manifest <candidate-manifest.json>
+```
+
+## Rules CI enforces
+
+`pnpm run release:evidence:check` runs inside `ci/repo-quality`. It fails closed on all of the
+following.
+
+**Binding**
+
+- The index `candidateId` matches the manifest, and `manifest.sha256` equals the candidate identity
+  digest. Evidence bound to another build is rejected.
+- The environment report carries the same identity digest and the same redacted configuration
+  digest as the manifest (PROG-01).
+- Every entry's `boundIdentity` equals the manifest on all eight dimensions REPORT-02 names:
+  `sourceCommit`, `artifactDigests`, `environment`, `chainId`, `contractAddress`,
+  `migrationIdentities`, `providerMode`, `configDigestSha256`.
+
+**Acceptance**
+
+- An entry accepted by its own producer is rejected; acceptance is four-eyes.
+- A reviewer must hold one of `Release Owner`, `Security reviewer` or `Operations reviewer`.
+- `assertEvidenceIndexComplete` reports any required control with no `accepted` entry. Delivery
+  completion alone leaves a control unaccepted.
+- Only a `candidate` or `promoted` manifest may bind evidence. A `draft` must name its activation
+  blockers; a `superseded` candidate accrues nothing further.
+- `promoted` requires an `approved` decision from all three roles.
+
+**Boundaries**
+
+- Outside `base-mainnet`, `publicParticipants` and `realCommercialValue` must be false (ENV-01,
+  ENV-02), and each environment may only declare its own classifications.
+- `chain.chainId` and `environment.name` must agree about Base mainnet in both directions.
+- The configuration digest must be marked redacted. No raw configuration, secret or participant
+  data enters either document.
+
+## Accepted equivalence
+
+Evidence may be reused across a changed dimension only with an explicit equivalence record naming
+the dimensions, the accepting authority and role, the rationale, and an expiry:
+
+```json
+"equivalence": {
+  "dimensions": ["configDigestSha256"],
+  "acceptedBy": "release-owner@example.invalid",
+  "role": "Release Owner",
+  "rationale": "Log verbosity only; no settlement, signer or provider setting changed.",
+  "expiresAt": "2026-09-01T00:00:00.000Z"
+}
+```
+
+The validator rejects an expired equivalence, one that covers a dimension that did not actually
+differ, and one that covers a different dimension than the one that drifted.
+
+**Not waivable:** equivalence across the Base mainnet boundary. Rehearsal evidence from Base
+Sepolia can never be carried onto Base mainnet by equivalence — ASSUMPTION-03 and ENV-04 require a
+fresh WP-12 packet.
+
+## Producing a candidate
+
+1. Build and publish artifacts; record each image or package digest.
+2. Record migration heads and checksums for every component with a schema.
+3. Record the deployed contract identity from
+   `contracts/reports/deploy/<network>/agroasysescrow-deploy.json` — address, ABI digest, deployed
+   bytecode digest, compiler version and deployment transaction.
+4. Update `integration/release-manifest.json` if any sibling pin changed, then embed its canonical
+   digest in the candidate manifest. Verify with
+   `node scripts/check-release-evidence-binding.mjs --manifest <path> --verify-cross-repository`.
+5. Produce the redacted configuration inventory and its digest.
+6. Emit the environment report carrying the identity digest and configuration digest.
+7. Append evidence entries as each control produces proof, then have the named reviewer record a
+   decision.
+
+Fixtures showing a complete, valid pair are in `scripts/tests/fixtures/release-evidence/`. They are
+test data, not a pinned candidate, and no value in them is release evidence.
+
+## Open dependencies
+
+The contracts are complete, but two WP-0 inputs remain unapproved and no candidate can be pinned
+until they land:
+
+| Dependency                                                             | Effect                                                                                                                          |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [#635](https://github.com/Agroasys/Cotsel/issues/635) `wp0-charter`    | Fixes the environment owner, provider mode, participant class and value caps a real candidate must declare.                     |
+| [#637](https://github.com/Agroasys/Cotsel/issues/637) `wp0-governance` | Supplies the decision log and defect policy that record an equivalence acceptance and its revocation trigger outside this file. |
+
+The seven journeys specified in `docs/readiness/cotsel-golden-journeys-v1.md`
+([#638](https://github.com/Agroasys/Cotsel/issues/638)) bind their runs through this contract.
+
+## Change and invalidation rule
+
+A change to any identity dimension produces a new candidate and invalidates evidence bound to the
+previous one. A change to these schemas or to the enforced rules requires Release Owner, Security
+and Operations review, and reopens any acceptance that relied on the previous contract.

--- a/docs/runbooks/release-candidate-evidence-binding.md
+++ b/docs/runbooks/release-candidate-evidence-binding.md
@@ -55,16 +55,36 @@ following.
   digest. Evidence bound to another build is rejected.
 - The environment report carries the same identity digest and the same redacted configuration
   digest as the manifest (PROG-01).
-- Every entry's `boundIdentity` equals the manifest on all eight dimensions REPORT-02 names:
+- Every entry's `boundIdentity` equals the manifest on all nine dimensions REPORT-02 names:
   `sourceCommit`, `artifactDigests`, `environment`, `chainId`, `contractAddress`,
-  `migrationIdentities`, `providerMode`, `configDigestSha256`.
+  `contractDeployedBytecodeSha256`, `migrationIdentities`, `providerMode`, `configDigestSha256`.
+
+  `contractDeployedBytecodeSha256` is recorded per entry because an address is not an
+  implementation: a proxy upgrade keeps the address by design, and the same source compiled with a
+  different solc version or optimizer setting keeps both the address and the commit. Without it,
+  evidence produced against the old implementation would bind to the new candidate unchallenged.
+  `contractAbiSha256` is not a separate dimension — any ABI difference that changes behaviour
+  changes the deployed bytecode with it, and an ABI difference that leaves the bytecode identical
+  is metadata only.
 
 **Acceptance**
 
 - An entry accepted by its own producer is rejected; acceptance is four-eyes.
+- An equivalence accepted by the producer of the evidence it waives is rejected on the same rule. A
+  waiver is the more consequential decision, so it cannot carry less separation than the acceptance
+  it bypasses. The reviewer of an entry **may** accept its equivalence: evidence produced by one
+  person and waived by another is still two people.
 - A reviewer must hold one of `Release Owner`, `Security reviewer` or `Operations reviewer`.
-- `assertEvidenceIndexComplete` reports any required control with no `accepted` entry. Delivery
-  completion alone leaves a control unaccepted.
+- Every actor identity — `approvals[].identity`, `producedBy.identity`, `reviewer.identity` and
+  `equivalence.acceptedBy` — must be a canonical handle: lowercase, no whitespace, 2 to 64
+  characters, matching `^[a-z0-9][a-z0-9._@/+-]{1,63}$`. Separation of duties is decided by string
+  equality on these fields, so one person must not be nameable as `avitus`, `AvitusI` and
+  `Avitus I`. Use the same handle a person holds in `approvals`.
+- Acceptance is checked only when the required control set is named:
+  `--require-controls REPORT-02,PROG-01` calls `assertEvidenceIndexComplete` and fails closed on
+  any control with no `accepted` entry. Without the flag the command validates **binding only** —
+  an index whose every entry is still `pending` is correctly bound and not accepted, and the
+  summary line reports both counts.
 - Only a `candidate` or `promoted` manifest may bind evidence. A `draft` must name its activation
   blockers; a `superseded` candidate accrues nothing further.
 - `promoted` requires an `approved` decision from all three roles.
@@ -93,7 +113,8 @@ the dimensions, the accepting authority and role, the rationale, and an expiry:
 ```
 
 The validator rejects an expired equivalence, one that covers a dimension that did not actually
-differ, and one that covers a different dimension than the one that drifted.
+differ, one that covers a different dimension than the one that drifted, and one whose `acceptedBy`
+is the producer of the entry.
 
 **Not waivable:** equivalence across the Base mainnet boundary. Rehearsal evidence from Base
 Sepolia can never be carried onto Base mainnet by equivalence — ASSUMPTION-03 and ENV-04 require a
@@ -112,7 +133,18 @@ fresh WP-12 packet.
 5. Produce the redacted configuration inventory and its digest.
 6. Emit the environment report carrying the identity digest and configuration digest.
 7. Append evidence entries as each control produces proof, then have the named reviewer record a
-   decision.
+   decision. The reviewer must not be the producer, and both must use their canonical handle.
+8. Check that the decisions actually landed. The binding check alone does not do this:
+
+   ```bash
+   node scripts/check-release-evidence-binding.mjs \
+     --manifest <candidate-manifest.json> \
+     --index <evidence-index.json> \
+     --require-controls <CONTROL,CONTROL>
+   ```
+
+   Without `--require-controls` the command reports `acceptance not checked`. Read `Evidence index
+valid` as "bound to this candidate", never as "accepted".
 
 Fixtures showing a complete, valid pair are in `scripts/tests/fixtures/release-evidence/`. They are
 test data, not a pinned candidate, and no value in them is release evidence.

--- a/integration/candidate-manifest.schema.json
+++ b/integration/candidate-manifest.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agroasys.com/schemas/cotsel/candidate-manifest.v1.json",
+  "title": "Cotsel release candidate manifest",
+  "description": "Immutable identity of one deployable Cotsel candidate. Every evidence-index entry must resolve to exactly one candidate manifest. Implements SOW REPORT-02 and PROG-01 for work package WP-0.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "candidateId",
+    "status",
+    "owner",
+    "createdAt",
+    "environment",
+    "source",
+    "crossRepositoryManifest",
+    "artifacts",
+    "migrations",
+    "chain",
+    "contract",
+    "providerMode",
+    "configDigest",
+    "rollbackTarget"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "cotsel.candidate-manifest.v1"
+    },
+    "candidateId": {
+      "description": "Stable identity of this candidate. Never reused, never edited after promotion.",
+      "type": "string",
+      "pattern": "^cotsel-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{4,16}$"
+    },
+    "status": {
+      "enum": ["draft", "candidate", "promoted", "superseded"]
+    },
+    "activationBlockers": {
+      "description": "Required while status is draft. Names what prevents this candidate from being used.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role"],
+      "properties": {
+        "role": { "const": "Release Owner" }
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "supersedes": {
+      "description": "Candidate identity replaced by this one, when applicable.",
+      "type": "string",
+      "pattern": "^cotsel-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{4,16}$"
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "classification", "owner", "publicParticipants", "realCommercialValue"],
+      "properties": {
+        "name": {
+          "enum": ["local-ci", "base-sepolia-staging", "base-mainnet"]
+        },
+        "classification": {
+          "enum": ["non-deployed", "private-staging", "controlled-pilot", "production"]
+        },
+        "owner": { "type": "string", "minLength": 1 },
+        "publicParticipants": { "type": "boolean" },
+        "realCommercialValue": { "type": "boolean" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "commit", "workflowRunId"],
+      "properties": {
+        "repository": { "const": "Agroasys/Cotsel" },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "workflowRunId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "crossRepositoryManifest": {
+      "description": "Binds the sibling-repository pins in integration/release-manifest.json to this candidate.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "schemaVersion", "sha256"],
+      "properties": {
+        "path": { "const": "integration/release-manifest.json" },
+        "schemaVersion": { "const": "cotsel.release-manifest.v1" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "kind", "digest"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["container-image", "npm-package", "contract-bundle"] },
+          "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "migrations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["component", "headIdentity", "checksumSha256"],
+        "properties": {
+          "component": { "type": "string", "minLength": 1 },
+          "headIdentity": { "type": "string", "minLength": 1 },
+          "checksumSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "chain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "chainId", "finalityConfirmations"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "chainId": { "type": "integer", "minimum": 1 },
+        "finalityConfirmations": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "address",
+        "abiSha256",
+        "deployedBytecodeSha256",
+        "compilerVersion",
+        "deploymentBlock",
+        "deploymentTxHash",
+        "verificationStatus"
+      ],
+      "properties": {
+        "name": { "const": "AgroasysEscrow" },
+        "address": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+        "abiSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "deployedBytecodeSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "compilerVersion": { "type": "string", "minLength": 1 },
+        "deploymentBlock": { "type": "integer", "minimum": 0 },
+        "deploymentTxHash": { "type": "string", "pattern": "^0x[0-9a-f]{64}$" },
+        "verificationStatus": { "enum": ["verified", "unverified"] }
+      }
+    },
+    "providerMode": {
+      "description": "Externally observable provider posture. A change to any field invalidates evidence bound to the previous posture.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fiatOffRamp", "signer", "rpc"],
+      "properties": {
+        "fiatOffRamp": { "enum": ["disabled", "sandbox", "live"] },
+        "signer": { "enum": ["local-key", "kms", "mpc"] },
+        "rpc": { "enum": ["single", "primary-with-fallback"] }
+      }
+    },
+    "configDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["redacted", "sha256", "inventoryPath"],
+      "properties": {
+        "redacted": { "const": true },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "inventoryPath": { "type": "string", "minLength": 1 }
+      }
+    },
+    "approvals": {
+      "description": "Required when status is promoted. All three roles must record a decision.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["role", "identity", "decision", "decidedAt"],
+        "properties": {
+          "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
+          "identity": { "type": "string", "minLength": 1 },
+          "decision": { "enum": ["approved", "rejected"] },
+          "decidedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "rollbackTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "compatibilityNote"],
+      "properties": {
+        "kind": { "enum": ["candidate", "none"] },
+        "candidateId": {
+          "type": "string",
+          "pattern": "^cotsel-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{4,16}$"
+        },
+        "compatibilityNote": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "candidate" } } },
+          "then": { "required": ["candidateId"] }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "draft" } } },
+      "then": { "required": ["activationBlockers"] }
+    },
+    {
+      "if": { "properties": { "status": { "const": "promoted" } } },
+      "then": { "required": ["approvals"] }
+    }
+  ]
+}

--- a/integration/candidate-manifest.schema.json
+++ b/integration/candidate-manifest.schema.json
@@ -186,7 +186,7 @@
         "required": ["role", "identity", "decision", "decidedAt"],
         "properties": {
           "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
-          "identity": { "type": "string", "minLength": 1 },
+          "identity": { "$ref": "#/$defs/actorIdentity" },
           "decision": { "enum": ["approved", "rejected"] },
           "decidedAt": { "type": "string", "format": "date-time" }
         }
@@ -221,5 +221,12 @@
       "if": { "properties": { "status": { "const": "promoted" } } },
       "then": { "required": ["approvals"] }
     }
-  ]
+  ],
+  "$defs": {
+    "actorIdentity": {
+      "description": "Canonical actor handle: lowercase, no whitespace, 2 to 64 characters. The evidence index resolves four-eyes separation by string equality on the same form.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._@/+-]{1,63}$"
+    }
+  }
 }

--- a/integration/evidence-index.schema.json
+++ b/integration/evidence-index.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agroasys.com/schemas/cotsel/evidence-index.v1.json",
+  "title": "Cotsel release evidence index",
+  "description": "Maps SOW control identities to reproducible evidence artifacts bound to exactly one candidate manifest. Implements SOW REPORT-02 and PROG-01 for work package WP-0.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "candidateId",
+    "manifest",
+    "environmentReport",
+    "generatedAt",
+    "entries"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "cotsel.evidence-index.v1"
+    },
+    "candidateId": {
+      "type": "string",
+      "pattern": "^cotsel-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{4,16}$"
+    },
+    "manifest": {
+      "description": "The candidate manifest this index binds to, identified by canonical digest.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "environmentReport": {
+      "description": "PROG-01 requires every environment report to carry the release manifest identity and the redacted configuration digest.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "manifestSha256", "configDigestSha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "manifestSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "configDigestSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "controlId",
+          "route",
+          "issue",
+          "artifact",
+          "producedBy",
+          "boundIdentity",
+          "reviewer"
+        ],
+        "properties": {
+          "controlId": {
+            "description": "SOW control or finding identity, for example REPORT-02, AUTH-04 or GJ-06.",
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9-]{1,23}$"
+          },
+          "route": {
+            "description": "Primary acceptance route slug, for example wp0-release-evidence.",
+            "type": "string",
+            "pattern": "^wp[0-9]{1,2}-[a-z0-9-]+$"
+          },
+          "issue": {
+            "type": "string",
+            "pattern": "^https://github\\.com/Agroasys/[A-Za-z0-9._-]+/issues/[0-9]+$"
+          },
+          "artifact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["uri", "sha256", "runId"],
+            "properties": {
+              "uri": { "type": "string", "minLength": 1 },
+              "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "runId": { "type": "string", "minLength": 1 }
+            }
+          },
+          "producedBy": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["identity", "role"],
+            "properties": {
+              "identity": { "type": "string", "minLength": 1 },
+              "role": { "type": "string", "minLength": 1 }
+            }
+          },
+          "boundIdentity": {
+            "description": "The candidate identity this artifact was produced against. Every field must equal the candidate manifest unless an accepted equivalence covers that dimension.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sourceCommit",
+              "artifactDigests",
+              "environment",
+              "chainId",
+              "contractAddress",
+              "migrationIdentities",
+              "providerMode",
+              "configDigestSha256"
+            ],
+            "properties": {
+              "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+              "artifactDigests": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+              },
+              "environment": {
+                "enum": ["local-ci", "base-sepolia-staging", "base-mainnet"]
+              },
+              "chainId": { "type": "integer", "minimum": 1 },
+              "contractAddress": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+              "migrationIdentities": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "providerMode": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["fiatOffRamp", "signer", "rpc"],
+                "properties": {
+                  "fiatOffRamp": { "enum": ["disabled", "sandbox", "live"] },
+                  "signer": { "enum": ["local-key", "kms", "mpc"] },
+                  "rpc": { "enum": ["single", "primary-with-fallback"] }
+                }
+              },
+              "configDigestSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+            }
+          },
+          "reviewer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["identity", "role", "decision", "reviewedAt"],
+            "properties": {
+              "identity": { "type": "string", "minLength": 1 },
+              "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
+              "decision": { "enum": ["accepted", "rejected", "pending"] },
+              "reviewedAt": { "type": "string", "format": "date-time" }
+            }
+          },
+          "equivalence": {
+            "description": "Accepted reuse of evidence across a named identity dimension. Bounded by scope, authority and expiry.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["dimensions", "acceptedBy", "role", "rationale", "expiresAt"],
+            "properties": {
+              "dimensions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "enum": [
+                    "sourceCommit",
+                    "artifactDigests",
+                    "environment",
+                    "chainId",
+                    "contractAddress",
+                    "migrationIdentities",
+                    "providerMode",
+                    "configDigestSha256"
+                  ]
+                }
+              },
+              "acceptedBy": { "type": "string", "minLength": 1 },
+              "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
+              "rationale": { "type": "string", "minLength": 1 },
+              "expiresAt": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/integration/evidence-index.schema.json
+++ b/integration/evidence-index.schema.json
@@ -89,7 +89,7 @@
             "additionalProperties": false,
             "required": ["identity", "role"],
             "properties": {
-              "identity": { "type": "string", "minLength": 1 },
+              "identity": { "$ref": "#/$defs/actorIdentity" },
               "role": { "type": "string", "minLength": 1 }
             }
           },
@@ -103,6 +103,7 @@
               "environment",
               "chainId",
               "contractAddress",
+              "contractDeployedBytecodeSha256",
               "migrationIdentities",
               "providerMode",
               "configDigestSha256"
@@ -119,6 +120,11 @@
               },
               "chainId": { "type": "integer", "minimum": 1 },
               "contractAddress": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+              "contractDeployedBytecodeSha256": {
+                "description": "The implementation this artifact was produced against. An address alone does not identify one: a proxy upgrade keeps the address, and a different compiler or optimizer setting keeps both the address and the source commit.",
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
               "migrationIdentities": {
                 "type": "array",
                 "minItems": 1,
@@ -142,14 +148,14 @@
             "additionalProperties": false,
             "required": ["identity", "role", "decision", "reviewedAt"],
             "properties": {
-              "identity": { "type": "string", "minLength": 1 },
+              "identity": { "$ref": "#/$defs/actorIdentity" },
               "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
               "decision": { "enum": ["accepted", "rejected", "pending"] },
               "reviewedAt": { "type": "string", "format": "date-time" }
             }
           },
           "equivalence": {
-            "description": "Accepted reuse of evidence across a named identity dimension. Bounded by scope, authority and expiry.",
+            "description": "Accepted reuse of evidence across a named identity dimension. Bounded by scope, authority and expiry. As a waiver of the binding rule it carries the same four-eyes separation as acceptance: acceptedBy may not be the producer of the entry.",
             "type": "object",
             "additionalProperties": false,
             "required": ["dimensions", "acceptedBy", "role", "rationale", "expiresAt"],
@@ -164,13 +170,14 @@
                     "environment",
                     "chainId",
                     "contractAddress",
+                    "contractDeployedBytecodeSha256",
                     "migrationIdentities",
                     "providerMode",
                     "configDigestSha256"
                   ]
                 }
               },
-              "acceptedBy": { "type": "string", "minLength": 1 },
+              "acceptedBy": { "$ref": "#/$defs/actorIdentity" },
               "role": { "enum": ["Release Owner", "Security reviewer", "Operations reviewer"] },
               "rationale": { "type": "string", "minLength": 1 },
               "expiresAt": { "type": "string", "format": "date-time" }
@@ -178,6 +185,13 @@
           }
         }
       }
+    }
+  },
+  "$defs": {
+    "actorIdentity": {
+      "description": "Canonical actor handle: lowercase, no whitespace, 2 to 64 characters. Four-eyes separation is string equality on these fields, so one person must not be nameable in several forms.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._@/+-]{1,63}$"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "readiness:cotsel:test": "node --test scripts/readiness/cotsel-production-readiness-contracts.test.mjs",
     "readiness:cotsel:audit-live": "node scripts/readiness/audit-cotsel-production-readiness-live.mjs",
     "integration:manifest:check": "node scripts/check-cross-repo-release-manifest.mjs && node --test scripts/tests/cross-repo-release-manifest.test.mjs",
+    "release:evidence:check": "node --test scripts/tests/release-evidence-binding.test.mjs",
     "build": "pnpm --filter @agroasys/sdk run build",
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --max-warnings=0 --fix .",

--- a/scripts/check-release-evidence-binding.mjs
+++ b/scripts/check-release-evidence-binding.mjs
@@ -1,0 +1,750 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(SCRIPT_DIR, '..');
+
+const CANDIDATE_ID_PATTERN = /^cotsel-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{4,16}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const TX_HASH_PATTERN = /^0x[0-9a-f]{64}$/;
+const ISSUE_PATTERN = /^https:\/\/github\.com\/Agroasys\/[A-Za-z0-9._-]+\/issues\/[0-9]+$/;
+const CONTROL_ID_PATTERN = /^[A-Z][A-Z0-9-]{1,23}$/;
+const ROUTE_PATTERN = /^wp[0-9]{1,2}-[a-z0-9-]+$/;
+
+const MANIFEST_STATUSES = ['draft', 'candidate', 'promoted', 'superseded'];
+const ENVIRONMENTS = ['local-ci', 'base-sepolia-staging', 'base-mainnet'];
+const CLASSIFICATIONS = ['non-deployed', 'private-staging', 'controlled-pilot', 'production'];
+const ARTIFACT_KINDS = ['container-image', 'npm-package', 'contract-bundle'];
+const PROVIDER_MODES = {
+  fiatOffRamp: ['disabled', 'sandbox', 'live'],
+  signer: ['local-key', 'kms', 'mpc'],
+  rpc: ['single', 'primary-with-fallback'],
+};
+const ACCEPTANCE_ROLES = ['Release Owner', 'Security reviewer', 'Operations reviewer'];
+const REVIEW_DECISIONS = ['accepted', 'rejected', 'pending'];
+
+/**
+ * Environment classifications each environment may declare. ENV-01 through ENV-04 keep local,
+ * private staging, controlled pilot and production boundaries distinct.
+ */
+const ALLOWED_CLASSIFICATIONS = new Map([
+  ['local-ci', ['non-deployed']],
+  ['base-sepolia-staging', ['private-staging', 'controlled-pilot']],
+  ['base-mainnet', ['production']],
+]);
+
+const BASE_MAINNET_CHAIN_ID = 8453;
+
+/**
+ * The identity dimensions REPORT-02 and PROG-01 name. Evidence may not be reused across any of
+ * them without an accepted equivalence.
+ */
+export const IDENTITY_DIMENSIONS = [
+  'sourceCommit',
+  'artifactDigests',
+  'environment',
+  'chainId',
+  'contractAddress',
+  'migrationIdentities',
+  'providerMode',
+  'configDigestSha256',
+];
+
+function failManifest(message) {
+  throw new Error(`Candidate manifest invalid: ${message}`);
+}
+
+function failIndex(message) {
+  throw new Error(`Evidence index invalid: ${message}`);
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireString(fail, value, name, pattern) {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail(`${name} is required`);
+  }
+  if (pattern && !pattern.test(value)) {
+    fail(`${name} does not match ${pattern}`);
+  }
+  return value;
+}
+
+function requireEnum(fail, value, name, allowed) {
+  if (!allowed.includes(value)) {
+    fail(`${name} must be one of ${allowed.join(', ')}`);
+  }
+  return value;
+}
+
+function requireInteger(fail, value, name, minimum) {
+  if (!Number.isInteger(value) || value < minimum) {
+    fail(`${name} must be an integer of at least ${minimum}`);
+  }
+  return value;
+}
+
+function requireTimestamp(fail, value, name) {
+  requireString(fail, value, name);
+  if (Number.isNaN(Date.parse(value))) {
+    fail(`${name} must be an ISO-8601 timestamp`);
+  }
+  return value;
+}
+
+/**
+ * Deterministic serialization. Two documents with the same content produce the same digest
+ * regardless of key order, so an identity digest cannot drift on reserialization.
+ */
+export function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function canonicalDigest(value) {
+  return crypto.createHash('sha256').update(canonicalize(value)).digest('hex');
+}
+
+function normalizeProviderMode(providerMode) {
+  return {
+    fiatOffRamp: providerMode.fiatOffRamp,
+    signer: providerMode.signer,
+    rpc: providerMode.rpc,
+  };
+}
+
+/**
+ * The immutable identity of a candidate. Lifecycle fields (status, approvals, rollback notes)
+ * are deliberately excluded: promoting a candidate must not invalidate evidence already bound
+ * to it, but changing any identity dimension must.
+ */
+export function candidateIdentity(manifest) {
+  return {
+    candidateId: manifest.candidateId,
+    sourceCommit: manifest.source.commit,
+    crossRepositoryManifestSha256: manifest.crossRepositoryManifest.sha256,
+    artifactDigests: manifest.artifacts.map((artifact) => artifact.digest).sort(),
+    environment: manifest.environment.name,
+    chainId: manifest.chain.chainId,
+    contractAddress: manifest.contract.address.toLowerCase(),
+    contractAbiSha256: manifest.contract.abiSha256,
+    contractDeployedBytecodeSha256: manifest.contract.deployedBytecodeSha256,
+    migrationIdentities: manifest.migrations
+      .map((migration) => `${migration.component}@${migration.headIdentity}`)
+      .sort(),
+    providerMode: normalizeProviderMode(manifest.providerMode),
+    configDigestSha256: manifest.configDigest.sha256,
+  };
+}
+
+export function candidateIdentityDigest(manifest) {
+  return canonicalDigest(candidateIdentity(manifest));
+}
+
+function validateEnvironment(environment) {
+  if (!isPlainObject(environment)) {
+    failManifest('environment is required');
+  }
+  requireEnum(failManifest, environment.name, 'environment.name', ENVIRONMENTS);
+  requireEnum(
+    failManifest,
+    environment.classification,
+    'environment.classification',
+    CLASSIFICATIONS,
+  );
+  requireString(failManifest, environment.owner, 'environment.owner');
+
+  const allowed = ALLOWED_CLASSIFICATIONS.get(environment.name);
+  if (!allowed.includes(environment.classification)) {
+    failManifest(
+      `environment ${environment.name} cannot be classified ${environment.classification}`,
+    );
+  }
+  if (typeof environment.publicParticipants !== 'boolean') {
+    failManifest('environment.publicParticipants must be declared');
+  }
+  if (typeof environment.realCommercialValue !== 'boolean') {
+    failManifest('environment.realCommercialValue must be declared');
+  }
+  if (environment.name !== 'base-mainnet') {
+    // ENV-01 and ENV-02 prohibit public users and real commercial value outside production.
+    if (environment.publicParticipants) {
+      failManifest(`environment ${environment.name} cannot admit public participants`);
+    }
+    if (environment.realCommercialValue) {
+      failManifest(`environment ${environment.name} cannot carry real commercial value`);
+    }
+  }
+}
+
+function validateContract(contract) {
+  if (!isPlainObject(contract)) {
+    failManifest('contract is required');
+  }
+  if (contract.name !== 'AgroasysEscrow') {
+    failManifest('contract.name must be AgroasysEscrow');
+  }
+  requireString(failManifest, contract.address, 'contract.address', ADDRESS_PATTERN);
+  requireString(failManifest, contract.abiSha256, 'contract.abiSha256', SHA256_PATTERN);
+  requireString(
+    failManifest,
+    contract.deployedBytecodeSha256,
+    'contract.deployedBytecodeSha256',
+    SHA256_PATTERN,
+  );
+  requireString(failManifest, contract.compilerVersion, 'contract.compilerVersion');
+  requireInteger(failManifest, contract.deploymentBlock, 'contract.deploymentBlock', 0);
+  requireString(
+    failManifest,
+    contract.deploymentTxHash,
+    'contract.deploymentTxHash',
+    TX_HASH_PATTERN,
+  );
+  requireEnum(failManifest, contract.verificationStatus, 'contract.verificationStatus', [
+    'verified',
+    'unverified',
+  ]);
+}
+
+function validateProviderMode(providerMode, fail, name) {
+  if (!isPlainObject(providerMode)) {
+    fail(`${name} is required`);
+  }
+  for (const [field, allowed] of Object.entries(PROVIDER_MODES)) {
+    requireEnum(fail, providerMode[field], `${name}.${field}`, allowed);
+  }
+  for (const key of Object.keys(providerMode)) {
+    if (!(key in PROVIDER_MODES)) {
+      fail(`${name}.${key} is not a recognized provider dimension`);
+    }
+  }
+}
+
+export function validateCandidateManifest(manifest) {
+  if (!isPlainObject(manifest)) {
+    failManifest('root must be an object');
+  }
+  if (manifest.schemaVersion !== 'cotsel.candidate-manifest.v1') {
+    failManifest('schemaVersion must be cotsel.candidate-manifest.v1');
+  }
+  requireString(failManifest, manifest.candidateId, 'candidateId', CANDIDATE_ID_PATTERN);
+  requireEnum(failManifest, manifest.status, 'status', MANIFEST_STATUSES);
+  if (manifest.owner?.role !== 'Release Owner') {
+    failManifest('the single accountable owner must be Release Owner');
+  }
+  requireTimestamp(failManifest, manifest.createdAt, 'createdAt');
+  if (manifest.supersedes !== undefined) {
+    requireString(failManifest, manifest.supersedes, 'supersedes', CANDIDATE_ID_PATTERN);
+    if (manifest.supersedes === manifest.candidateId) {
+      failManifest('a candidate cannot supersede itself');
+    }
+  }
+
+  if (manifest.status === 'draft') {
+    if (
+      !Array.isArray(manifest.activationBlockers) ||
+      manifest.activationBlockers.length === 0 ||
+      manifest.activationBlockers.some(
+        (blocker) => typeof blocker !== 'string' || blocker.trim().length === 0,
+      )
+    ) {
+      failManifest('draft status requires at least one activation blocker');
+    }
+  }
+
+  validateEnvironment(manifest.environment);
+
+  if (!isPlainObject(manifest.source)) {
+    failManifest('source is required');
+  }
+  if (manifest.source.repository !== 'Agroasys/Cotsel') {
+    failManifest('source.repository must be Agroasys/Cotsel');
+  }
+  requireString(failManifest, manifest.source.commit, 'source.commit', COMMIT_PATTERN);
+  requireString(failManifest, manifest.source.workflowRunId, 'source.workflowRunId');
+
+  if (!isPlainObject(manifest.crossRepositoryManifest)) {
+    failManifest('crossRepositoryManifest is required');
+  }
+  if (manifest.crossRepositoryManifest.path !== 'integration/release-manifest.json') {
+    failManifest('crossRepositoryManifest.path must be integration/release-manifest.json');
+  }
+  if (manifest.crossRepositoryManifest.schemaVersion !== 'cotsel.release-manifest.v1') {
+    failManifest('crossRepositoryManifest.schemaVersion must be cotsel.release-manifest.v1');
+  }
+  requireString(
+    failManifest,
+    manifest.crossRepositoryManifest.sha256,
+    'crossRepositoryManifest.sha256',
+    SHA256_PATTERN,
+  );
+
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length === 0) {
+    failManifest('at least one artifact must be pinned');
+  }
+  const artifactNames = new Set();
+  for (const artifact of manifest.artifacts) {
+    requireString(failManifest, artifact?.name, 'artifact.name');
+    if (artifactNames.has(artifact.name)) {
+      failManifest(`duplicate artifact ${artifact.name}`);
+    }
+    artifactNames.add(artifact.name);
+    requireEnum(failManifest, artifact.kind, `artifact ${artifact.name} kind`, ARTIFACT_KINDS);
+    requireString(
+      failManifest,
+      artifact.digest,
+      `artifact ${artifact.name} digest`,
+      DIGEST_PATTERN,
+    );
+  }
+
+  if (!Array.isArray(manifest.migrations) || manifest.migrations.length === 0) {
+    failManifest('at least one migration identity must be pinned');
+  }
+  const migrationComponents = new Set();
+  for (const migration of manifest.migrations) {
+    requireString(failManifest, migration?.component, 'migration.component');
+    if (migrationComponents.has(migration.component)) {
+      failManifest(`duplicate migration component ${migration.component}`);
+    }
+    migrationComponents.add(migration.component);
+    requireString(
+      failManifest,
+      migration.headIdentity,
+      `migration ${migration.component} headIdentity`,
+    );
+    requireString(
+      failManifest,
+      migration.checksumSha256,
+      `migration ${migration.component} checksumSha256`,
+      SHA256_PATTERN,
+    );
+  }
+
+  if (!isPlainObject(manifest.chain)) {
+    failManifest('chain is required');
+  }
+  requireString(failManifest, manifest.chain.name, 'chain.name');
+  requireInteger(failManifest, manifest.chain.chainId, 'chain.chainId', 1);
+  requireInteger(
+    failManifest,
+    manifest.chain.finalityConfirmations,
+    'chain.finalityConfirmations',
+    1,
+  );
+  if (
+    (manifest.chain.chainId === BASE_MAINNET_CHAIN_ID) !==
+    (manifest.environment.name === 'base-mainnet')
+  ) {
+    // ASSUMPTION-03 keeps rehearsal and mainnet identities distinct in both directions.
+    failManifest('chain.chainId and environment.name disagree about Base mainnet');
+  }
+
+  validateContract(manifest.contract);
+  validateProviderMode(manifest.providerMode, failManifest, 'providerMode');
+
+  if (!isPlainObject(manifest.configDigest)) {
+    failManifest('configDigest is required');
+  }
+  if (manifest.configDigest.redacted !== true) {
+    failManifest('configDigest.redacted must be true; raw configuration is never indexed');
+  }
+  requireString(failManifest, manifest.configDigest.sha256, 'configDigest.sha256', SHA256_PATTERN);
+  requireString(failManifest, manifest.configDigest.inventoryPath, 'configDigest.inventoryPath');
+
+  if (!isPlainObject(manifest.rollbackTarget)) {
+    failManifest('rollbackTarget is required');
+  }
+  requireEnum(failManifest, manifest.rollbackTarget.kind, 'rollbackTarget.kind', [
+    'candidate',
+    'none',
+  ]);
+  requireString(
+    failManifest,
+    manifest.rollbackTarget.compatibilityNote,
+    'rollbackTarget.compatibilityNote',
+  );
+  if (manifest.rollbackTarget.kind === 'candidate') {
+    requireString(
+      failManifest,
+      manifest.rollbackTarget.candidateId,
+      'rollbackTarget.candidateId',
+      CANDIDATE_ID_PATTERN,
+    );
+    if (manifest.rollbackTarget.candidateId === manifest.candidateId) {
+      failManifest('a candidate cannot be its own rollback target');
+    }
+  }
+
+  if (manifest.approvals !== undefined) {
+    if (!Array.isArray(manifest.approvals)) {
+      failManifest('approvals must be an array');
+    }
+    const approvalRoles = new Set();
+    for (const approval of manifest.approvals) {
+      requireEnum(failManifest, approval?.role, 'approval.role', ACCEPTANCE_ROLES);
+      if (approvalRoles.has(approval.role)) {
+        failManifest(`duplicate approval for ${approval.role}`);
+      }
+      approvalRoles.add(approval.role);
+      requireString(failManifest, approval.identity, `approval ${approval.role} identity`);
+      requireEnum(failManifest, approval.decision, `approval ${approval.role} decision`, [
+        'approved',
+        'rejected',
+      ]);
+      requireTimestamp(failManifest, approval.decidedAt, `approval ${approval.role} decidedAt`);
+    }
+  }
+
+  if (manifest.status === 'promoted') {
+    const approved = new Set(
+      (manifest.approvals ?? [])
+        .filter((approval) => approval.decision === 'approved')
+        .map((approval) => approval.role),
+    );
+    const missing = ACCEPTANCE_ROLES.filter((role) => !approved.has(role));
+    if (missing.length > 0) {
+      failManifest(`promoted status requires approval from ${missing.join(', ')}`);
+    }
+  }
+
+  return manifest;
+}
+
+/**
+ * Only a candidate or promoted manifest may receive evidence. A draft is not an identity yet and
+ * a superseded candidate can no longer accrue proof.
+ */
+export function assertCandidateBindable(manifest) {
+  if (!['candidate', 'promoted'].includes(manifest.status)) {
+    failManifest(`status ${manifest.status} cannot bind evidence`);
+  }
+  return manifest;
+}
+
+function entryIdentity(boundIdentity) {
+  return {
+    sourceCommit: boundIdentity.sourceCommit,
+    artifactDigests: [...boundIdentity.artifactDigests].sort(),
+    environment: boundIdentity.environment,
+    chainId: boundIdentity.chainId,
+    contractAddress: boundIdentity.contractAddress.toLowerCase(),
+    migrationIdentities: [...boundIdentity.migrationIdentities].sort(),
+    providerMode: normalizeProviderMode(boundIdentity.providerMode),
+    configDigestSha256: boundIdentity.configDigestSha256,
+  };
+}
+
+function validateBoundIdentity(boundIdentity, label) {
+  if (!isPlainObject(boundIdentity)) {
+    failIndex(`${label} boundIdentity is required`);
+  }
+  requireString(failIndex, boundIdentity.sourceCommit, `${label} sourceCommit`, COMMIT_PATTERN);
+  if (!Array.isArray(boundIdentity.artifactDigests) || boundIdentity.artifactDigests.length === 0) {
+    failIndex(`${label} artifactDigests is required`);
+  }
+  for (const digest of boundIdentity.artifactDigests) {
+    requireString(failIndex, digest, `${label} artifact digest`, DIGEST_PATTERN);
+  }
+  requireEnum(failIndex, boundIdentity.environment, `${label} environment`, ENVIRONMENTS);
+  requireInteger(failIndex, boundIdentity.chainId, `${label} chainId`, 1);
+  requireString(
+    failIndex,
+    boundIdentity.contractAddress,
+    `${label} contractAddress`,
+    ADDRESS_PATTERN,
+  );
+  if (
+    !Array.isArray(boundIdentity.migrationIdentities) ||
+    boundIdentity.migrationIdentities.length === 0
+  ) {
+    failIndex(`${label} migrationIdentities is required`);
+  }
+  for (const identity of boundIdentity.migrationIdentities) {
+    requireString(failIndex, identity, `${label} migration identity`);
+  }
+  validateProviderMode(boundIdentity.providerMode, failIndex, `${label} providerMode`);
+  requireString(
+    failIndex,
+    boundIdentity.configDigestSha256,
+    `${label} configDigestSha256`,
+    SHA256_PATTERN,
+  );
+}
+
+function validateEquivalence(equivalence, label, now) {
+  requireString(failIndex, equivalence.acceptedBy, `${label} equivalence acceptedBy`);
+  requireEnum(failIndex, equivalence.role, `${label} equivalence role`, ACCEPTANCE_ROLES);
+  requireString(failIndex, equivalence.rationale, `${label} equivalence rationale`);
+  requireTimestamp(failIndex, equivalence.expiresAt, `${label} equivalence expiresAt`);
+  if (!Array.isArray(equivalence.dimensions) || equivalence.dimensions.length === 0) {
+    failIndex(`${label} equivalence must name at least one dimension`);
+  }
+  for (const dimension of equivalence.dimensions) {
+    requireEnum(failIndex, dimension, `${label} equivalence dimension`, IDENTITY_DIMENSIONS);
+  }
+  if (Date.parse(equivalence.expiresAt) <= now.getTime()) {
+    failIndex(`${label} equivalence expired at ${equivalence.expiresAt}`);
+  }
+  return new Set(equivalence.dimensions);
+}
+
+/**
+ * Binds an evidence index to exactly one candidate manifest. Every entry must have been produced
+ * against the same identity, on every dimension REPORT-02 and PROG-01 name, unless an unexpired
+ * equivalence accepted by a named authority covers that dimension.
+ */
+export function validateEvidenceIndex(index, manifest, options = {}) {
+  const now = options.now ? new Date(options.now) : new Date();
+  validateCandidateManifest(manifest);
+  assertCandidateBindable(manifest);
+
+  if (!isPlainObject(index)) {
+    failIndex('root must be an object');
+  }
+  if (index.schemaVersion !== 'cotsel.evidence-index.v1') {
+    failIndex('schemaVersion must be cotsel.evidence-index.v1');
+  }
+  requireString(failIndex, index.candidateId, 'candidateId', CANDIDATE_ID_PATTERN);
+  if (index.candidateId !== manifest.candidateId) {
+    failIndex(`candidateId ${index.candidateId} does not match manifest ${manifest.candidateId}`);
+  }
+  requireTimestamp(failIndex, index.generatedAt, 'generatedAt');
+
+  const expectedDigest = candidateIdentityDigest(manifest);
+  if (!isPlainObject(index.manifest)) {
+    failIndex('manifest reference is required');
+  }
+  requireString(failIndex, index.manifest.path, 'manifest.path');
+  requireString(failIndex, index.manifest.sha256, 'manifest.sha256', SHA256_PATTERN);
+  if (index.manifest.sha256 !== expectedDigest) {
+    failIndex(
+      `manifest.sha256 ${index.manifest.sha256} does not resolve to the promoted candidate identity ${expectedDigest}`,
+    );
+  }
+
+  // PROG-01: the environment report carries the manifest identity and the redacted config digest.
+  if (!isPlainObject(index.environmentReport)) {
+    failIndex('environmentReport is required');
+  }
+  requireString(failIndex, index.environmentReport.path, 'environmentReport.path');
+  requireString(
+    failIndex,
+    index.environmentReport.sha256,
+    'environmentReport.sha256',
+    SHA256_PATTERN,
+  );
+  requireString(
+    failIndex,
+    index.environmentReport.manifestSha256,
+    'environmentReport.manifestSha256',
+    SHA256_PATTERN,
+  );
+  requireString(
+    failIndex,
+    index.environmentReport.configDigestSha256,
+    'environmentReport.configDigestSha256',
+    SHA256_PATTERN,
+  );
+  if (index.environmentReport.manifestSha256 !== expectedDigest) {
+    failIndex('environmentReport is bound to a different candidate identity');
+  }
+  if (index.environmentReport.configDigestSha256 !== manifest.configDigest.sha256) {
+    failIndex('environmentReport configuration digest does not match the candidate manifest');
+  }
+
+  if (!Array.isArray(index.entries) || index.entries.length === 0) {
+    failIndex('at least one evidence entry is required');
+  }
+
+  const expected = candidateIdentity(manifest);
+  const seenArtifacts = new Set();
+
+  for (const [position, entry] of index.entries.entries()) {
+    const label = `entry ${position} (${entry?.controlId ?? '<missing control>'})`;
+    if (!isPlainObject(entry)) {
+      failIndex(`${label} must be an object`);
+    }
+    requireString(failIndex, entry.controlId, `${label} controlId`, CONTROL_ID_PATTERN);
+    requireString(failIndex, entry.route, `${label} route`, ROUTE_PATTERN);
+    requireString(failIndex, entry.issue, `${label} issue`, ISSUE_PATTERN);
+
+    if (!isPlainObject(entry.artifact)) {
+      failIndex(`${label} artifact is required`);
+    }
+    requireString(failIndex, entry.artifact.uri, `${label} artifact uri`);
+    requireString(failIndex, entry.artifact.sha256, `${label} artifact sha256`, SHA256_PATTERN);
+    requireString(failIndex, entry.artifact.runId, `${label} artifact runId`);
+
+    const artifactKey = `${entry.controlId}:${entry.artifact.sha256}`;
+    if (seenArtifacts.has(artifactKey)) {
+      failIndex(`${label} duplicates an artifact already indexed for ${entry.controlId}`);
+    }
+    seenArtifacts.add(artifactKey);
+
+    if (!isPlainObject(entry.producedBy)) {
+      failIndex(`${label} producedBy is required`);
+    }
+    requireString(failIndex, entry.producedBy.identity, `${label} producedBy identity`);
+    requireString(failIndex, entry.producedBy.role, `${label} producedBy role`);
+
+    if (!isPlainObject(entry.reviewer)) {
+      failIndex(`${label} reviewer is required`);
+    }
+    requireString(failIndex, entry.reviewer.identity, `${label} reviewer identity`);
+    requireEnum(failIndex, entry.reviewer.role, `${label} reviewer role`, ACCEPTANCE_ROLES);
+    requireEnum(failIndex, entry.reviewer.decision, `${label} reviewer decision`, REVIEW_DECISIONS);
+    requireTimestamp(failIndex, entry.reviewer.reviewedAt, `${label} reviewer reviewedAt`);
+    if (entry.reviewer.identity === entry.producedBy.identity) {
+      failIndex(`${label} was accepted by its own producer; four-eyes review is required`);
+    }
+
+    validateBoundIdentity(entry.boundIdentity, label);
+    const actual = entryIdentity(entry.boundIdentity);
+
+    let accepted = new Set();
+    if (entry.equivalence !== undefined) {
+      if (!isPlainObject(entry.equivalence)) {
+        failIndex(`${label} equivalence must be an object`);
+      }
+      accepted = validateEquivalence(entry.equivalence, label, now);
+    }
+
+    for (const dimension of IDENTITY_DIMENSIONS) {
+      const expectedValue = canonicalize(expected[dimension]);
+      const actualValue = canonicalize(actual[dimension]);
+      if (expectedValue === actualValue) {
+        continue;
+      }
+      if (!accepted.has(dimension)) {
+        failIndex(
+          `${label} was produced against a different ${dimension} (${actualValue}) than the candidate manifest (${expectedValue}); stale evidence cannot be reused without an accepted equivalence`,
+        );
+      }
+      if (
+        (dimension === 'chainId' &&
+          (actual.chainId === BASE_MAINNET_CHAIN_ID ||
+            expected.chainId === BASE_MAINNET_CHAIN_ID)) ||
+        (dimension === 'environment' &&
+          (actual.environment === 'base-mainnet' || expected.environment === 'base-mainnet'))
+      ) {
+        // ASSUMPTION-03 and ENV-04: mainnet readiness is never inherited from a rehearsal run.
+        failIndex(
+          `${label} claims equivalence across the Base mainnet boundary, which is not waivable`,
+        );
+      }
+    }
+
+    for (const dimension of accepted) {
+      if (canonicalize(expected[dimension]) === canonicalize(actual[dimension])) {
+        failIndex(`${label} accepts equivalence for ${dimension}, which does not differ`);
+      }
+    }
+  }
+
+  return index;
+}
+
+/**
+ * The candidate inherits the sibling-repository pins by digest. A pin change in
+ * integration/release-manifest.json therefore produces a different candidate identity.
+ */
+export function assertCrossRepositoryManifestBinding(manifest, releaseManifestPath) {
+  const actual = canonicalDigest(readJsonDocument(releaseManifestPath));
+  if (manifest.crossRepositoryManifest.sha256 !== actual) {
+    failManifest(
+      `crossRepositoryManifest.sha256 ${manifest.crossRepositoryManifest.sha256} does not match ${releaseManifestPath} (${actual})`,
+    );
+  }
+  return manifest;
+}
+
+/**
+ * Delivery completion is not acceptance. An index is complete only when every required control
+ * carries at least one entry a named authority accepted.
+ */
+export function assertEvidenceIndexComplete(index, requiredControlIds) {
+  const acceptedControls = new Set(
+    index.entries
+      .filter((entry) => entry.reviewer.decision === 'accepted')
+      .map((entry) => entry.controlId),
+  );
+  const missing = requiredControlIds.filter((controlId) => !acceptedControls.has(controlId));
+  if (missing.length > 0) {
+    failIndex(`no accepted evidence for ${missing.join(', ')}`);
+  }
+  return index;
+}
+
+export function readJsonDocument(documentPath) {
+  return JSON.parse(fs.readFileSync(documentPath, 'utf8'));
+}
+
+export function readCandidateManifest(manifestPath) {
+  return validateCandidateManifest(readJsonDocument(manifestPath));
+}
+
+function readFlag(args, name) {
+  const position = args.indexOf(name);
+  if (position < 0) {
+    return undefined;
+  }
+  const value = args[position + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a path`);
+  }
+  return path.resolve(ROOT_DIR, value);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const manifestPath = readFlag(args, '--manifest');
+  const indexPath = readFlag(args, '--index');
+
+  if (!manifestPath) {
+    throw new Error(
+      'usage: check-release-evidence-binding.mjs --manifest <candidate-manifest.json> [--index <evidence-index.json>]',
+    );
+  }
+
+  const manifest = readCandidateManifest(manifestPath);
+  if (args.includes('--verify-cross-repository')) {
+    assertCrossRepositoryManifestBinding(
+      manifest,
+      path.join(ROOT_DIR, 'integration/release-manifest.json'),
+    );
+  }
+  process.stdout.write(
+    `Candidate manifest valid (${manifest.status}); candidate=${manifest.candidateId} identity=${candidateIdentityDigest(manifest)}\n`,
+  );
+
+  if (indexPath) {
+    const index = validateEvidenceIndex(readJsonDocument(indexPath), manifest);
+    process.stdout.write(
+      `Evidence index valid; ${index.entries.length} entries bound to ${index.candidateId}\n`,
+    );
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-release-evidence-binding.mjs
+++ b/scripts/check-release-evidence-binding.mjs
@@ -16,6 +16,13 @@ const TX_HASH_PATTERN = /^0x[0-9a-f]{64}$/;
 const ISSUE_PATTERN = /^https:\/\/github\.com\/Agroasys\/[A-Za-z0-9._-]+\/issues\/[0-9]+$/;
 const CONTROL_ID_PATTERN = /^[A-Z][A-Z0-9-]{1,23}$/;
 const ROUTE_PATTERN = /^wp[0-9]{1,2}-[a-z0-9-]+$/;
+/**
+ * Every actor identity — approver, producer, reviewer, equivalence acceptor — is written in one
+ * canonical handle form: lowercase, no whitespace, 2 to 64 characters. Four-eyes separation is
+ * string equality on these fields, so `avitus`, `AvitusI` and `Avitus I` must not be able to name
+ * the same person three ways.
+ */
+const IDENTITY_PATTERN = /^[a-z0-9][a-z0-9._@/+-]{1,63}$/;
 
 const MANIFEST_STATUSES = ['draft', 'candidate', 'promoted', 'superseded'];
 const ENVIRONMENTS = ['local-ci', 'base-sepolia-staging', 'base-mainnet'];
@@ -44,6 +51,13 @@ const BASE_MAINNET_CHAIN_ID = 8453;
 /**
  * The identity dimensions REPORT-02 and PROG-01 name. Evidence may not be reused across any of
  * them without an accepted equivalence.
+ *
+ * `contractDeployedBytecodeSha256` is a dimension in its own right because a contract address is
+ * not an implementation: a proxy upgrade keeps the address, and the same source under a different
+ * compiler or optimizer setting keeps both the address and the commit. Any ABI difference that
+ * changes behaviour changes the deployed bytecode with it, so the bytecode digest also covers
+ * `contractAbiSha256`; an ABI difference that leaves the bytecode identical is metadata only and
+ * cannot change what a run proves.
  */
 export const IDENTITY_DIMENSIONS = [
   'sourceCommit',
@@ -51,6 +65,7 @@ export const IDENTITY_DIMENSIONS = [
   'environment',
   'chainId',
   'contractAddress',
+  'contractDeployedBytecodeSha256',
   'migrationIdentities',
   'providerMode',
   'configDigestSha256',
@@ -401,7 +416,12 @@ export function validateCandidateManifest(manifest) {
         failManifest(`duplicate approval for ${approval.role}`);
       }
       approvalRoles.add(approval.role);
-      requireString(failManifest, approval.identity, `approval ${approval.role} identity`);
+      requireString(
+        failManifest,
+        approval.identity,
+        `approval ${approval.role} identity`,
+        IDENTITY_PATTERN,
+      );
       requireEnum(failManifest, approval.decision, `approval ${approval.role} decision`, [
         'approved',
         'rejected',
@@ -443,6 +463,7 @@ function entryIdentity(boundIdentity) {
     environment: boundIdentity.environment,
     chainId: boundIdentity.chainId,
     contractAddress: boundIdentity.contractAddress.toLowerCase(),
+    contractDeployedBytecodeSha256: boundIdentity.contractDeployedBytecodeSha256,
     migrationIdentities: [...boundIdentity.migrationIdentities].sort(),
     providerMode: normalizeProviderMode(boundIdentity.providerMode),
     configDigestSha256: boundIdentity.configDigestSha256,
@@ -468,6 +489,12 @@ function validateBoundIdentity(boundIdentity, label) {
     `${label} contractAddress`,
     ADDRESS_PATTERN,
   );
+  requireString(
+    failIndex,
+    boundIdentity.contractDeployedBytecodeSha256,
+    `${label} contractDeployedBytecodeSha256`,
+    SHA256_PATTERN,
+  );
   if (
     !Array.isArray(boundIdentity.migrationIdentities) ||
     boundIdentity.migrationIdentities.length === 0
@@ -486,8 +513,24 @@ function validateBoundIdentity(boundIdentity, label) {
   );
 }
 
-function validateEquivalence(equivalence, label, now) {
-  requireString(failIndex, equivalence.acceptedBy, `${label} equivalence acceptedBy`);
+/**
+ * An equivalence is a waiver of the binding rule, so it carries the same separation of duties as
+ * the acceptance it bypasses: the producer of the evidence may not certify that their own stale
+ * evidence still counts. A reviewer may accept an equivalence for evidence someone else produced —
+ * that is still two people.
+ */
+function validateEquivalence(equivalence, entry, label, now) {
+  requireString(
+    failIndex,
+    equivalence.acceptedBy,
+    `${label} equivalence acceptedBy`,
+    IDENTITY_PATTERN,
+  );
+  if (equivalence.acceptedBy === entry.producedBy.identity) {
+    failIndex(
+      `${label} equivalence was accepted by its own producer; four-eyes review is required`,
+    );
+  }
   requireEnum(failIndex, equivalence.role, `${label} equivalence role`, ACCEPTANCE_ROLES);
   requireString(failIndex, equivalence.rationale, `${label} equivalence rationale`);
   requireTimestamp(failIndex, equivalence.expiresAt, `${label} equivalence expiresAt`);
@@ -599,13 +642,23 @@ export function validateEvidenceIndex(index, manifest, options = {}) {
     if (!isPlainObject(entry.producedBy)) {
       failIndex(`${label} producedBy is required`);
     }
-    requireString(failIndex, entry.producedBy.identity, `${label} producedBy identity`);
+    requireString(
+      failIndex,
+      entry.producedBy.identity,
+      `${label} producedBy identity`,
+      IDENTITY_PATTERN,
+    );
     requireString(failIndex, entry.producedBy.role, `${label} producedBy role`);
 
     if (!isPlainObject(entry.reviewer)) {
       failIndex(`${label} reviewer is required`);
     }
-    requireString(failIndex, entry.reviewer.identity, `${label} reviewer identity`);
+    requireString(
+      failIndex,
+      entry.reviewer.identity,
+      `${label} reviewer identity`,
+      IDENTITY_PATTERN,
+    );
     requireEnum(failIndex, entry.reviewer.role, `${label} reviewer role`, ACCEPTANCE_ROLES);
     requireEnum(failIndex, entry.reviewer.decision, `${label} reviewer decision`, REVIEW_DECISIONS);
     requireTimestamp(failIndex, entry.reviewer.reviewedAt, `${label} reviewer reviewedAt`);
@@ -621,7 +674,7 @@ export function validateEvidenceIndex(index, manifest, options = {}) {
       if (!isPlainObject(entry.equivalence)) {
         failIndex(`${label} equivalence must be an object`);
       }
-      accepted = validateEquivalence(entry.equivalence, label, now);
+      accepted = validateEquivalence(entry.equivalence, entry, label, now);
     }
 
     for (const dimension of IDENTITY_DIMENSIONS) {
@@ -710,15 +763,37 @@ function readFlag(args, name) {
   return path.resolve(ROOT_DIR, value);
 }
 
+function readControlListFlag(args, name) {
+  const position = args.indexOf(name);
+  if (position < 0) {
+    return undefined;
+  }
+  const value = args[position + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a comma-separated list of control identities`);
+  }
+  const controlIds = value.split(',').map((controlId) => controlId.trim());
+  for (const controlId of controlIds) {
+    if (!CONTROL_ID_PATTERN.test(controlId)) {
+      throw new Error(`${name} value ${controlId} is not a control identity`);
+    }
+  }
+  return controlIds;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const manifestPath = readFlag(args, '--manifest');
   const indexPath = readFlag(args, '--index');
+  const requiredControlIds = readControlListFlag(args, '--require-controls');
 
   if (!manifestPath) {
     throw new Error(
-      'usage: check-release-evidence-binding.mjs --manifest <candidate-manifest.json> [--index <evidence-index.json>]',
+      'usage: check-release-evidence-binding.mjs --manifest <candidate-manifest.json> [--index <evidence-index.json>] [--require-controls <CONTROL,CONTROL>]',
     );
+  }
+  if (requiredControlIds && !indexPath) {
+    throw new Error('--require-controls also requires --index');
   }
 
   const manifest = readCandidateManifest(manifestPath);
@@ -734,9 +809,24 @@ function main() {
 
   if (indexPath) {
     const index = validateEvidenceIndex(readJsonDocument(indexPath), manifest);
+    // Delivery completion is not acceptance: report accepted entries, not merely bound ones, and
+    // fail before printing anything when a required control has no accepted evidence.
+    if (requiredControlIds) {
+      assertEvidenceIndexComplete(index, requiredControlIds);
+    }
+    const acceptedCount = index.entries.filter(
+      (entry) => entry.reviewer.decision === 'accepted',
+    ).length;
     process.stdout.write(
-      `Evidence index valid; ${index.entries.length} entries bound to ${index.candidateId}\n`,
+      `Evidence index valid; ${index.entries.length} entries bound to ${index.candidateId}, ${acceptedCount} accepted\n`,
     );
+    if (requiredControlIds) {
+      process.stdout.write(`Accepted evidence present for ${requiredControlIds.join(', ')}\n`);
+    } else {
+      process.stdout.write(
+        'Binding checked, acceptance not checked; pass --require-controls to require accepted evidence\n',
+      );
+    }
   }
 }
 

--- a/scripts/tests/fixtures/release-evidence/candidate-manifest.json
+++ b/scripts/tests/fixtures/release-evidence/candidate-manifest.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": "cotsel.candidate-manifest.v1",
+  "candidateId": "cotsel-2026-08-05-fixture",
+  "status": "candidate",
+  "owner": {
+    "role": "Release Owner"
+  },
+  "createdAt": "2026-08-05T09:00:00.000Z",
+  "environment": {
+    "name": "base-sepolia-staging",
+    "classification": "private-staging",
+    "owner": "Platform Operations",
+    "publicParticipants": false,
+    "realCommercialValue": false
+  },
+  "source": {
+    "repository": "Agroasys/Cotsel",
+    "commit": "8b4a693eb4cff3fe62605f2d10435f895afebb78",
+    "workflowRunId": "fixture-run-1"
+  },
+  "crossRepositoryManifest": {
+    "path": "integration/release-manifest.json",
+    "schemaVersion": "cotsel.release-manifest.v1",
+    "sha256": "82b76f55d91fba06ade6a837d3cc05a3d527e82a05f9ea222e4e8dfaa41e9955"
+  },
+  "artifacts": [
+    {
+      "name": "gateway",
+      "kind": "container-image",
+      "digest": "sha256:0a2b3b297e6065476bdd1df01d4b40191682522c13dd4f932014b917c800a149"
+    },
+    {
+      "name": "indexer",
+      "kind": "container-image",
+      "digest": "sha256:2568a281b9aa8b6b5092908edfe81ce00452bed10b3617631ec35e184e57bc61"
+    },
+    {
+      "name": "treasury",
+      "kind": "container-image",
+      "digest": "sha256:1a4bbbd16723882b09a665aceaaf7120a007753d04b5c5caa07d144d255000a7"
+    },
+    {
+      "name": "@agroasys/sdk",
+      "kind": "npm-package",
+      "digest": "sha256:c670dd418c1bd71c900a4ece5b31f788b5deb8a7d0438d9c1eb6a02c49bc9fea"
+    }
+  ],
+  "migrations": [
+    {
+      "component": "indexer",
+      "headIdentity": "0042_trade_timeline",
+      "checksumSha256": "8938260e7320d7995ae7421e41606c2addf756371ca7aa7aa52484abd54c81dc"
+    },
+    {
+      "component": "treasury",
+      "headIdentity": "0017_close_packet",
+      "checksumSha256": "ac054cd0e98d229fdabc17560520b2c49743e261662e2756fe271191dfda83b3"
+    }
+  ],
+  "chain": {
+    "name": "Base Sepolia",
+    "chainId": 84532,
+    "finalityConfirmations": 12
+  },
+  "contract": {
+    "name": "AgroasysEscrow",
+    "address": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+    "abiSha256": "a9d62d6adf98963f5d010f8636261fdb826408b188dd00f82f0b59afbcc1ff3b",
+    "deployedBytecodeSha256": "8ae6bd40151f975007997152aa60a5421b1fccc59e2fc866da27f8467af7b61a",
+    "compilerVersion": "0.8.34",
+    "deploymentBlock": 32014771,
+    "deploymentTxHash": "0x49dbe6d714c9b19901256e55c4407ec4722d55ea9110c1f0866f424e40b55b5d",
+    "verificationStatus": "verified"
+  },
+  "providerMode": {
+    "fiatOffRamp": "disabled",
+    "signer": "kms",
+    "rpc": "primary-with-fallback"
+  },
+  "configDigest": {
+    "redacted": true,
+    "sha256": "ec9d52dbc40c92b82e4610bcf07d164b31e92da0f59717f9fd5bc1ebbc24a517",
+    "inventoryPath": "ci-reports/config-inventory.redacted.json"
+  },
+  "rollbackTarget": {
+    "kind": "none",
+    "compatibilityNote": "Fixture candidate. No prior deployed candidate exists to roll back to."
+  }
+}

--- a/scripts/tests/fixtures/release-evidence/evidence-index.json
+++ b/scripts/tests/fixtures/release-evidence/evidence-index.json
@@ -37,6 +37,7 @@
         "environment": "base-sepolia-staging",
         "chainId": 84532,
         "contractAddress": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+        "contractDeployedBytecodeSha256": "8ae6bd40151f975007997152aa60a5421b1fccc59e2fc866da27f8467af7b61a",
         "migrationIdentities": ["indexer@0042_trade_timeline", "treasury@0017_close_packet"],
         "providerMode": {
           "fiatOffRamp": "disabled",
@@ -76,6 +77,7 @@
         "environment": "base-sepolia-staging",
         "chainId": 84532,
         "contractAddress": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+        "contractDeployedBytecodeSha256": "8ae6bd40151f975007997152aa60a5421b1fccc59e2fc866da27f8467af7b61a",
         "migrationIdentities": ["indexer@0042_trade_timeline", "treasury@0017_close_packet"],
         "providerMode": {
           "fiatOffRamp": "disabled",

--- a/scripts/tests/fixtures/release-evidence/evidence-index.json
+++ b/scripts/tests/fixtures/release-evidence/evidence-index.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "cotsel.evidence-index.v1",
+  "candidateId": "cotsel-2026-08-05-fixture",
+  "manifest": {
+    "path": "scripts/tests/fixtures/release-evidence/candidate-manifest.json",
+    "sha256": "7ee026a1e964c288c4db7390c157ed151ee30e925dd22ab8f2a5359e9978e370"
+  },
+  "environmentReport": {
+    "path": "ci-reports/environment-report.json",
+    "sha256": "66d51889f1ac4eeee3064c44ab784d5039216adf53c0b1ae073f1c61a5f4e2e1",
+    "manifestSha256": "7ee026a1e964c288c4db7390c157ed151ee30e925dd22ab8f2a5359e9978e370",
+    "configDigestSha256": "ec9d52dbc40c92b82e4610bcf07d164b31e92da0f59717f9fd5bc1ebbc24a517"
+  },
+  "generatedAt": "2026-08-05T10:00:00.000Z",
+  "entries": [
+    {
+      "controlId": "REPORT-02",
+      "route": "wp0-release-evidence",
+      "issue": "https://github.com/Agroasys/Cotsel/issues/636",
+      "artifact": {
+        "uri": "ci-reports/release-evidence-binding.txt",
+        "sha256": "ae45a2f5eb72fdb7566763ebf712aef83d77843563ec2ece9c24e20201585891",
+        "runId": "fixture-run-1"
+      },
+      "producedBy": {
+        "identity": "ci/release-gate",
+        "role": "Release engineering"
+      },
+      "boundIdentity": {
+        "sourceCommit": "8b4a693eb4cff3fe62605f2d10435f895afebb78",
+        "artifactDigests": [
+          "sha256:0a2b3b297e6065476bdd1df01d4b40191682522c13dd4f932014b917c800a149",
+          "sha256:2568a281b9aa8b6b5092908edfe81ce00452bed10b3617631ec35e184e57bc61",
+          "sha256:1a4bbbd16723882b09a665aceaaf7120a007753d04b5c5caa07d144d255000a7",
+          "sha256:c670dd418c1bd71c900a4ece5b31f788b5deb8a7d0438d9c1eb6a02c49bc9fea"
+        ],
+        "environment": "base-sepolia-staging",
+        "chainId": 84532,
+        "contractAddress": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+        "migrationIdentities": ["indexer@0042_trade_timeline", "treasury@0017_close_packet"],
+        "providerMode": {
+          "fiatOffRamp": "disabled",
+          "signer": "kms",
+          "rpc": "primary-with-fallback"
+        },
+        "configDigestSha256": "ec9d52dbc40c92b82e4610bcf07d164b31e92da0f59717f9fd5bc1ebbc24a517"
+      },
+      "reviewer": {
+        "identity": "release-owner@example.invalid",
+        "role": "Release Owner",
+        "decision": "accepted",
+        "reviewedAt": "2026-08-05T11:00:00.000Z"
+      }
+    },
+    {
+      "controlId": "PROG-01",
+      "route": "wp0-release-evidence",
+      "issue": "https://github.com/Agroasys/Cotsel/issues/636",
+      "artifact": {
+        "uri": "ci-reports/environment-report.json",
+        "sha256": "66d51889f1ac4eeee3064c44ab784d5039216adf53c0b1ae073f1c61a5f4e2e1",
+        "runId": "fixture-run-1"
+      },
+      "producedBy": {
+        "identity": "ci/release-gate",
+        "role": "Release engineering"
+      },
+      "boundIdentity": {
+        "sourceCommit": "8b4a693eb4cff3fe62605f2d10435f895afebb78",
+        "artifactDigests": [
+          "sha256:0a2b3b297e6065476bdd1df01d4b40191682522c13dd4f932014b917c800a149",
+          "sha256:2568a281b9aa8b6b5092908edfe81ce00452bed10b3617631ec35e184e57bc61",
+          "sha256:1a4bbbd16723882b09a665aceaaf7120a007753d04b5c5caa07d144d255000a7",
+          "sha256:c670dd418c1bd71c900a4ece5b31f788b5deb8a7d0438d9c1eb6a02c49bc9fea"
+        ],
+        "environment": "base-sepolia-staging",
+        "chainId": 84532,
+        "contractAddress": "0x54391ad22880B845021D49e79bA7E47bA8CcDDA7",
+        "migrationIdentities": ["indexer@0042_trade_timeline", "treasury@0017_close_packet"],
+        "providerMode": {
+          "fiatOffRamp": "disabled",
+          "signer": "kms",
+          "rpc": "primary-with-fallback"
+        },
+        "configDigestSha256": "ec9d52dbc40c92b82e4610bcf07d164b31e92da0f59717f9fd5bc1ebbc24a517"
+      },
+      "reviewer": {
+        "identity": "ops-reviewer@example.invalid",
+        "role": "Operations reviewer",
+        "decision": "accepted",
+        "reviewedAt": "2026-08-05T11:05:00.000Z"
+      }
+    }
+  ]
+}

--- a/scripts/tests/release-evidence-binding.test.mjs
+++ b/scripts/tests/release-evidence-binding.test.mjs
@@ -1,0 +1,476 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  IDENTITY_DIMENSIONS,
+  assertCandidateBindable,
+  assertCrossRepositoryManifestBinding,
+  assertEvidenceIndexComplete,
+  canonicalDigest,
+  candidateIdentityDigest,
+  readCandidateManifest,
+  readJsonDocument,
+  validateCandidateManifest,
+  validateEvidenceIndex,
+} from '../check-release-evidence-binding.mjs';
+
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(TESTS_DIR, '../..');
+const FIXTURE_DIR = path.join(TESTS_DIR, 'fixtures/release-evidence');
+const MANIFEST_PATH = path.join(FIXTURE_DIR, 'candidate-manifest.json');
+const INDEX_PATH = path.join(FIXTURE_DIR, 'evidence-index.json');
+const NOW = '2026-08-05T12:00:00.000Z';
+
+const manifestFixture = () => structuredClone(readJsonDocument(MANIFEST_PATH));
+const indexFixture = () => structuredClone(readJsonDocument(INDEX_PATH));
+
+/** Rebinds an index to a manifest after the manifest identity was deliberately changed. */
+function rebind(index, manifest) {
+  const digest = candidateIdentityDigest(manifest);
+  index.candidateId = manifest.candidateId;
+  index.manifest.sha256 = digest;
+  index.environmentReport.manifestSha256 = digest;
+  index.environmentReport.configDigestSha256 = manifest.configDigest.sha256;
+  return index;
+}
+
+test('accepts the checked-in candidate manifest and evidence index fixtures', () => {
+  const manifest = readCandidateManifest(MANIFEST_PATH);
+  const index = validateEvidenceIndex(indexFixture(), manifest, { now: NOW });
+
+  assert.equal(manifest.owner.role, 'Release Owner');
+  assert.equal(index.entries.length, 2);
+  assert.doesNotThrow(() => assertEvidenceIndexComplete(index, ['REPORT-02', 'PROG-01']));
+});
+
+test('the candidate identity survives promotion but not an identity change', () => {
+  const candidate = manifestFixture();
+  const promoted = manifestFixture();
+  promoted.status = 'promoted';
+  promoted.approvals = [
+    {
+      role: 'Release Owner',
+      identity: 'release-owner@example.invalid',
+      decision: 'approved',
+      decidedAt: NOW,
+    },
+    {
+      role: 'Security reviewer',
+      identity: 'security@example.invalid',
+      decision: 'approved',
+      decidedAt: NOW,
+    },
+    {
+      role: 'Operations reviewer',
+      identity: 'ops@example.invalid',
+      decision: 'approved',
+      decidedAt: NOW,
+    },
+  ];
+
+  // Lifecycle metadata is not identity: evidence accepted for a candidate stays bound after promotion.
+  assert.equal(candidateIdentityDigest(promoted), candidateIdentityDigest(candidate));
+  assert.doesNotThrow(() => validateEvidenceIndex(indexFixture(), promoted, { now: NOW }));
+
+  const rebuilt = manifestFixture();
+  rebuilt.artifacts[0].digest = `sha256:${'b'.repeat(64)}`;
+  assert.notEqual(candidateIdentityDigest(rebuilt), candidateIdentityDigest(candidate));
+});
+
+test('rejects an evidence index bound to another build', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.manifest.sha256 = 'c'.repeat(64);
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /does not resolve to the promoted candidate identity/,
+  );
+});
+
+test('rejects an evidence index bound to another candidate', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.candidateId = 'cotsel-2026-07-01-earlier';
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /does not match manifest/,
+  );
+});
+
+/**
+ * REPORT-02 and PROG-01: a changed commit, artifact digest, environment, chain, contract address,
+ * migration, provider mode or configuration digest must invalidate the evidence.
+ */
+const staleMutations = {
+  sourceCommit: (entry) => {
+    entry.boundIdentity.sourceCommit = 'a'.repeat(40);
+  },
+  artifactDigests: (entry) => {
+    entry.boundIdentity.artifactDigests[0] = `sha256:${'d'.repeat(64)}`;
+  },
+  environment: (entry) => {
+    entry.boundIdentity.environment = 'local-ci';
+  },
+  chainId: (entry) => {
+    entry.boundIdentity.chainId = 31337;
+  },
+  contractAddress: (entry) => {
+    entry.boundIdentity.contractAddress = '0x000000000000000000000000000000000000dead';
+  },
+  migrationIdentities: (entry) => {
+    entry.boundIdentity.migrationIdentities[0] = 'indexer@0041_previous_head';
+  },
+  providerMode: (entry) => {
+    entry.boundIdentity.providerMode.fiatOffRamp = 'sandbox';
+  },
+  configDigestSha256: (entry) => {
+    entry.boundIdentity.configDigestSha256 = 'e'.repeat(64);
+  },
+};
+
+test('covers every identity dimension the SOW names', () => {
+  assert.deepEqual(Object.keys(staleMutations).sort(), [...IDENTITY_DIMENSIONS].sort());
+});
+
+for (const [dimension, mutate] of Object.entries(staleMutations)) {
+  test(`rejects evidence produced against a different ${dimension}`, () => {
+    const manifest = manifestFixture();
+    const index = indexFixture();
+    mutate(index.entries[0]);
+
+    assert.throws(
+      () => validateEvidenceIndex(index, manifest, { now: NOW }),
+      new RegExp(`was produced against a different ${dimension}`),
+    );
+  });
+
+  test(`accepts a bounded, unexpired equivalence for ${dimension}`, () => {
+    const manifest = manifestFixture();
+    const index = indexFixture();
+    mutate(index.entries[0]);
+    index.entries[0].equivalence = {
+      dimensions: [dimension],
+      acceptedBy: 'release-owner@example.invalid',
+      role: 'Release Owner',
+      rationale: `Reviewed ${dimension} difference and confirmed it cannot affect this control.`,
+      expiresAt: '2026-09-01T00:00:00.000Z',
+    };
+
+    assert.doesNotThrow(() => validateEvidenceIndex(index, manifest, { now: NOW }));
+  });
+}
+
+test('rejects an expired equivalence', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  staleMutations.sourceCommit(index.entries[0]);
+  index.entries[0].equivalence = {
+    dimensions: ['sourceCommit'],
+    acceptedBy: 'release-owner@example.invalid',
+    role: 'Release Owner',
+    rationale: 'Documentation-only difference.',
+    expiresAt: '2026-08-01T00:00:00.000Z',
+  };
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /equivalence expired at/,
+  );
+});
+
+test('rejects an equivalence that covers a different dimension than the one that drifted', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  staleMutations.contractAddress(index.entries[0]);
+  index.entries[0].equivalence = {
+    dimensions: ['sourceCommit'],
+    acceptedBy: 'release-owner@example.invalid',
+    role: 'Release Owner',
+    rationale: 'Wrong dimension accepted.',
+    expiresAt: '2026-09-01T00:00:00.000Z',
+  };
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /was produced against a different contractAddress/,
+  );
+});
+
+test('rejects an equivalence for a dimension that did not drift', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.entries[0].equivalence = {
+    dimensions: ['providerMode'],
+    acceptedBy: 'release-owner@example.invalid',
+    role: 'Release Owner',
+    rationale: 'Blanket acceptance attempt.',
+    expiresAt: '2026-09-01T00:00:00.000Z',
+  };
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /accepts equivalence for providerMode, which does not differ/,
+  );
+});
+
+test('refuses to carry rehearsal evidence across the Base mainnet boundary', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.entries[0].boundIdentity.chainId = 8453;
+  index.entries[0].equivalence = {
+    dimensions: ['chainId'],
+    acceptedBy: 'release-owner@example.invalid',
+    role: 'Release Owner',
+    rationale: 'Attempt to promote rehearsal proof to mainnet.',
+    expiresAt: '2026-09-01T00:00:00.000Z',
+  };
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /Base mainnet boundary, which is not waivable/,
+  );
+});
+
+test('rejects an environment report bound to a different candidate or configuration', () => {
+  const manifest = manifestFixture();
+
+  const staleManifestBinding = indexFixture();
+  staleManifestBinding.environmentReport.manifestSha256 = 'f'.repeat(64);
+  assert.throws(
+    () => validateEvidenceIndex(staleManifestBinding, manifest, { now: NOW }),
+    /environmentReport is bound to a different candidate identity/,
+  );
+
+  const staleConfigBinding = indexFixture();
+  staleConfigBinding.environmentReport.configDigestSha256 = '0'.repeat(64);
+  assert.throws(
+    () => validateEvidenceIndex(staleConfigBinding, manifest, { now: NOW }),
+    /environmentReport configuration digest does not match/,
+  );
+});
+
+test('rejects evidence accepted by its own producer', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.entries[0].reviewer.identity = index.entries[0].producedBy.identity;
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /four-eyes review is required/,
+  );
+});
+
+test('rejects the same artifact indexed twice for one control', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.entries[1].controlId = index.entries[0].controlId;
+  index.entries[1].artifact = structuredClone(index.entries[0].artifact);
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /duplicates an artifact/,
+  );
+});
+
+test('reports controls with no accepted evidence', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  index.entries[1].reviewer.decision = 'pending';
+  validateEvidenceIndex(index, manifest, { now: NOW });
+
+  assert.throws(
+    () => assertEvidenceIndexComplete(index, ['REPORT-02', 'PROG-01']),
+    /no accepted evidence for PROG-01/,
+  );
+});
+
+test('only a candidate or promoted manifest can bind evidence', () => {
+  const draft = manifestFixture();
+  draft.status = 'draft';
+  draft.activationBlockers = ['charter is not approved'];
+  assert.doesNotThrow(() => validateCandidateManifest(draft));
+  assert.throws(() => assertCandidateBindable(draft), /status draft cannot bind evidence/);
+
+  const superseded = manifestFixture();
+  superseded.status = 'superseded';
+  assert.throws(
+    () => validateEvidenceIndex(indexFixture(), superseded, { now: NOW }),
+    /status superseded cannot bind evidence/,
+  );
+});
+
+test('requires a draft to name its activation blockers', () => {
+  const manifest = manifestFixture();
+  manifest.status = 'draft';
+
+  assert.throws(
+    () => validateCandidateManifest(manifest),
+    /draft status requires at least one activation blocker/,
+  );
+});
+
+test('requires all three acceptance roles before a candidate is promoted', () => {
+  const manifest = manifestFixture();
+  manifest.status = 'promoted';
+  manifest.approvals = [
+    {
+      role: 'Release Owner',
+      identity: 'release-owner@example.invalid',
+      decision: 'approved',
+      decidedAt: NOW,
+    },
+    {
+      role: 'Security reviewer',
+      identity: 'security@example.invalid',
+      decision: 'rejected',
+      decidedAt: NOW,
+    },
+  ];
+
+  assert.throws(
+    () => validateCandidateManifest(manifest),
+    /promoted status requires approval from Security reviewer, Operations reviewer/,
+  );
+});
+
+test('keeps public participants and real commercial value out of rehearsal environments', () => {
+  const withPublicUsers = manifestFixture();
+  withPublicUsers.environment.publicParticipants = true;
+  assert.throws(
+    () => validateCandidateManifest(withPublicUsers),
+    /cannot admit public participants/,
+  );
+
+  const withRealValue = manifestFixture();
+  withRealValue.environment.realCommercialValue = true;
+  assert.throws(
+    () => validateCandidateManifest(withRealValue),
+    /cannot carry real commercial value/,
+  );
+
+  const misclassified = manifestFixture();
+  misclassified.environment.classification = 'production';
+  assert.throws(() => validateCandidateManifest(misclassified), /cannot be classified production/);
+});
+
+test('keeps the declared chain and environment in agreement about Base mainnet', () => {
+  const manifest = manifestFixture();
+  manifest.chain.chainId = 8453;
+
+  assert.throws(
+    () => validateCandidateManifest(manifest),
+    /chain\.chainId and environment\.name disagree about Base mainnet/,
+  );
+});
+
+test('requires the configuration digest to be redacted', () => {
+  const manifest = manifestFixture();
+  manifest.configDigest.redacted = false;
+
+  assert.throws(() => validateCandidateManifest(manifest), /raw configuration is never indexed/);
+});
+
+test('requires a rollback target that is not the candidate itself', () => {
+  const manifest = manifestFixture();
+  manifest.rollbackTarget = {
+    kind: 'candidate',
+    candidateId: manifest.candidateId,
+    compatibilityNote: 'Self reference.',
+  };
+
+  assert.throws(() => validateCandidateManifest(manifest), /cannot be its own rollback target/);
+});
+
+test('binds the candidate to the checked-in cross-repository release manifest', () => {
+  const releaseManifestPath = path.join(ROOT_DIR, 'integration/release-manifest.json');
+  const manifest = manifestFixture();
+
+  assert.throws(
+    () => assertCrossRepositoryManifestBinding(manifest, releaseManifestPath),
+    /crossRepositoryManifest\.sha256 .* does not match/,
+  );
+
+  manifest.crossRepositoryManifest.sha256 = canonicalDigest(readJsonDocument(releaseManifestPath));
+  assert.doesNotThrow(() => assertCrossRepositoryManifestBinding(manifest, releaseManifestPath));
+});
+
+/**
+ * The published JSON Schemas are the contract other repositories read. The hand-written validator
+ * is what CI enforces. This proves the two agree on what is mandatory.
+ */
+test('the validator enforces every required property the published schemas declare', () => {
+  const manifestSchema = readJsonDocument(
+    path.join(ROOT_DIR, 'integration/candidate-manifest.schema.json'),
+  );
+  for (const property of manifestSchema.required) {
+    const manifest = manifestFixture();
+    delete manifest[property];
+    assert.throws(
+      () => validateCandidateManifest(manifest),
+      /Candidate manifest invalid/,
+      `removing ${property} must be rejected`,
+    );
+  }
+
+  const indexSchema = readJsonDocument(
+    path.join(ROOT_DIR, 'integration/evidence-index.schema.json'),
+  );
+  for (const property of indexSchema.required) {
+    const index = indexFixture();
+    delete index[property];
+    assert.throws(
+      () => validateEvidenceIndex(index, manifestFixture(), { now: NOW }),
+      /Evidence index invalid/,
+      `removing ${property} must be rejected`,
+    );
+  }
+
+  const entrySchema = indexSchema.properties.entries.items;
+  for (const property of entrySchema.required) {
+    const index = indexFixture();
+    delete index.entries[0][property];
+    assert.throws(
+      () => validateEvidenceIndex(index, manifestFixture(), { now: NOW }),
+      /Evidence index invalid/,
+      `removing entry ${property} must be rejected`,
+    );
+  }
+});
+
+test('the command-line check passes for a bound pair and fails closed for a stale one', () => {
+  const script = path.join(TESTS_DIR, '../check-release-evidence-binding.mjs');
+  const run = (indexPath) =>
+    spawnSync(process.execPath, [script, '--manifest', MANIFEST_PATH, '--index', indexPath], {
+      encoding: 'utf8',
+    });
+
+  const passed = run(INDEX_PATH);
+  assert.equal(passed.status, 0, passed.stderr);
+  assert.match(passed.stdout, /Evidence index valid; 2 entries bound to/);
+
+  const stalePath = path.join(mkdtempSync(path.join(tmpdir(), 'cotsel-evidence-')), 'index.json');
+  const stale = indexFixture();
+  staleMutations.sourceCommit(stale.entries[0]);
+  writeFileSync(stalePath, JSON.stringify(stale, null, 2));
+
+  const failed = run(stalePath);
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /was produced against a different sourceCommit/);
+});
+
+test('rebinding helper keeps a deliberately changed manifest self-consistent', () => {
+  const manifest = manifestFixture();
+  manifest.providerMode.signer = 'mpc';
+  const index = rebind(indexFixture(), manifest);
+  index.entries[0].boundIdentity.providerMode.signer = 'mpc';
+  index.entries[1].boundIdentity.providerMode.signer = 'mpc';
+
+  assert.doesNotThrow(() => validateEvidenceIndex(index, manifest, { now: NOW }));
+});

--- a/scripts/tests/release-evidence-binding.test.mjs
+++ b/scripts/tests/release-evidence-binding.test.mjs
@@ -124,6 +124,10 @@ const staleMutations = {
   contractAddress: (entry) => {
     entry.boundIdentity.contractAddress = '0x000000000000000000000000000000000000dead';
   },
+  // A proxy upgrade or a different compiler setting moves the implementation under a stable address.
+  contractDeployedBytecodeSha256: (entry) => {
+    entry.boundIdentity.contractDeployedBytecodeSha256 = 'b'.repeat(64);
+  },
   migrationIdentities: (entry) => {
     entry.boundIdentity.migrationIdentities[0] = 'indexer@0041_previous_head';
   },
@@ -265,6 +269,79 @@ test('rejects evidence accepted by its own producer', () => {
     () => validateEvidenceIndex(index, manifest, { now: NOW }),
     /four-eyes review is required/,
   );
+});
+
+test('rejects an equivalence accepted by the producer of the evidence it waives', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  staleMutations.configDigestSha256(index.entries[0]);
+  index.entries[0].equivalence = {
+    dimensions: ['configDigestSha256'],
+    acceptedBy: index.entries[0].producedBy.identity,
+    role: 'Release Owner',
+    rationale: 'Producer certifying their own stale evidence.',
+    expiresAt: '2026-09-01T00:00:00.000Z',
+  };
+
+  assert.throws(
+    () => validateEvidenceIndex(index, manifest, { now: NOW }),
+    /equivalence was accepted by its own producer; four-eyes review is required/,
+  );
+});
+
+/** A reviewer accepting an equivalence for evidence someone else produced is still two people. */
+test('allows the reviewer of an entry to accept its equivalence', () => {
+  const manifest = manifestFixture();
+  const index = indexFixture();
+  staleMutations.configDigestSha256(index.entries[0]);
+  index.entries[0].equivalence = {
+    dimensions: ['configDigestSha256'],
+    acceptedBy: index.entries[0].reviewer.identity,
+    role: index.entries[0].reviewer.role,
+    rationale: 'Log verbosity only; no settlement, signer or provider setting changed.',
+    expiresAt: '2026-09-01T00:00:00.000Z',
+  };
+
+  assert.doesNotThrow(() => validateEvidenceIndex(index, manifest, { now: NOW }));
+});
+
+/**
+ * Four-eyes separation is string equality on identities, so the identity format is part of the
+ * control: one person must not be able to appear as `avitus`, `AvitusI` and `Avitus I`.
+ */
+test('rejects actor identities outside the canonical handle format', () => {
+  for (const mutate of [
+    (index) => {
+      index.entries[0].producedBy.identity = 'Avitus I';
+    },
+    (index) => {
+      index.entries[0].reviewer.identity = 'ReleaseOwner@Example.invalid';
+    },
+    (index) => {
+      staleMutations.sourceCommit(index.entries[0]);
+      index.entries[0].equivalence = {
+        dimensions: ['sourceCommit'],
+        acceptedBy: 'Release Owner',
+        role: 'Release Owner',
+        rationale: 'Non-canonical acceptor.',
+        expiresAt: '2026-09-01T00:00:00.000Z',
+      };
+    },
+  ]) {
+    const index = indexFixture();
+    mutate(index);
+    assert.throws(
+      () => validateEvidenceIndex(index, manifestFixture(), { now: NOW }),
+      /does not match/,
+    );
+  }
+
+  const manifest = manifestFixture();
+  manifest.status = 'promoted';
+  manifest.approvals = [
+    { role: 'Release Owner', identity: 'Release Owner', decision: 'approved', decidedAt: NOW },
+  ];
+  assert.throws(() => validateCandidateManifest(manifest), /identity does not match/);
 });
 
 test('rejects the same artifact indexed twice for one control', () => {
@@ -442,10 +519,44 @@ test('the validator enforces every required property the published schemas decla
       `removing entry ${property} must be rejected`,
     );
   }
+
+  const boundIdentitySchema = entrySchema.properties.boundIdentity;
+  // A dimension the schema records but the comparison loop ignores would bind nothing.
+  assert.deepEqual([...boundIdentitySchema.required].sort(), [...IDENTITY_DIMENSIONS].sort());
+  assert.deepEqual(
+    [...entrySchema.properties.equivalence.properties.dimensions.items.enum].sort(),
+    [...IDENTITY_DIMENSIONS].sort(),
+  );
+  for (const property of boundIdentitySchema.required) {
+    const index = indexFixture();
+    delete index.entries[0].boundIdentity[property];
+    assert.throws(
+      () => validateEvidenceIndex(index, manifestFixture(), { now: NOW }),
+      /Evidence index invalid/,
+      `removing boundIdentity ${property} must be rejected`,
+    );
+  }
 });
 
+const SCRIPT_PATH = path.join(TESTS_DIR, '../check-release-evidence-binding.mjs');
+
+function runCli(indexPath, ...extra) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, '--manifest', MANIFEST_PATH, '--index', indexPath, ...extra],
+    { encoding: 'utf8' },
+  );
+}
+
+/** Writes an index to a temporary file so the CLI can be exercised against it. */
+function writeIndex(index) {
+  const indexPath = path.join(mkdtempSync(path.join(tmpdir(), 'cotsel-evidence-')), 'index.json');
+  writeFileSync(indexPath, JSON.stringify(index, null, 2));
+  return indexPath;
+}
+
 test('the command-line check passes for a bound pair and fails closed for a stale one', () => {
-  const script = path.join(TESTS_DIR, '../check-release-evidence-binding.mjs');
+  const script = SCRIPT_PATH;
   const run = (indexPath) =>
     spawnSync(process.execPath, [script, '--manifest', MANIFEST_PATH, '--index', indexPath], {
       encoding: 'utf8',
@@ -454,15 +565,49 @@ test('the command-line check passes for a bound pair and fails closed for a stal
   const passed = run(INDEX_PATH);
   assert.equal(passed.status, 0, passed.stderr);
   assert.match(passed.stdout, /Evidence index valid; 2 entries bound to/);
+  assert.match(passed.stdout, /2 accepted/);
+  // Delivery completion is not acceptance: the plain run must say what it did not check.
+  assert.match(passed.stdout, /acceptance not checked/);
 
-  const stalePath = path.join(mkdtempSync(path.join(tmpdir(), 'cotsel-evidence-')), 'index.json');
   const stale = indexFixture();
   staleMutations.sourceCommit(stale.entries[0]);
-  writeFileSync(stalePath, JSON.stringify(stale, null, 2));
 
-  const failed = run(stalePath);
+  const failed = run(writeIndex(stale));
   assert.equal(failed.status, 1);
   assert.match(failed.stderr, /was produced against a different sourceCommit/);
+});
+
+/**
+ * The one command operators run must not report an index of entirely unreviewed entries as good.
+ * Binding is checked always; acceptance only when the required control set is named.
+ */
+test('the command line enforces acceptance when required controls are named', () => {
+  const accepted = runCli(INDEX_PATH, '--require-controls', 'REPORT-02,PROG-01');
+  assert.equal(accepted.status, 0, accepted.stderr);
+  assert.match(accepted.stdout, /Accepted evidence present for REPORT-02, PROG-01/);
+
+  const pending = indexFixture();
+  for (const entry of pending.entries) {
+    entry.reviewer.decision = 'pending';
+  }
+  const pendingPath = writeIndex(pending);
+
+  const unchecked = runCli(pendingPath);
+  assert.equal(unchecked.status, 0, unchecked.stderr);
+  assert.match(unchecked.stdout, /0 accepted/);
+
+  const required = runCli(pendingPath, '--require-controls', 'REPORT-02,PROG-01');
+  assert.equal(required.status, 1);
+  assert.match(required.stderr, /no accepted evidence for REPORT-02, PROG-01/);
+  assert.doesNotMatch(required.stdout, /Evidence index valid/);
+
+  const missingIndex = spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, '--manifest', MANIFEST_PATH, '--require-controls', 'REPORT-02'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(missingIndex.status, 1);
+  assert.match(missingIndex.stderr, /--require-controls also requires --index/);
 });
 
 test('rebinding helper keeps a deliberately changed manifest self-consistent', () => {


### PR DESCRIPTION
## Summary

- **What changed:** Adds two machine-readable contracts — `integration/candidate-manifest.schema.json` (`cotsel.candidate-manifest.v1`) and `integration/evidence-index.schema.json` (`cotsel.evidence-index.v1`) — the validator that enforces them, and a runbook.
- **Why:** Implements REPORT-02 and PROG-01 for #636 (WP-0, gate E-0). `integration/release-manifest.json` pins sibling-repository commits and two callback contract versions only, and no evidence-index contract exists at all, so a verification result cannot currently be bound to the exact artifact later promoted, and nothing prevents evidence from one build or environment being reused for another.

### Candidate manifest

The immutable identity of one deployable candidate: source commit, artifact digests, migration heads, chain, contract address with ABI and deployed-bytecode digests, provider mode, redacted configuration digest, environment, approvals and rollback target. It embeds the canonical digest of `integration/release-manifest.json`, so the sibling-repository pins are part of the candidate identity rather than a parallel record.

The identity digest deliberately covers only the dimensions that change what a run proves. `status`, `approvals` and `supersedes` are excluded, so promoting a candidate does not invalidate evidence already accepted against it, while a change to any real identity dimension does and produces a new candidate.

### Evidence index

Maps each SOW control to a reproducible artifact together with the identity it was produced against, its producer and its reviewer.

### What the validator rejects

`scripts/check-release-evidence-binding.mjs` fails closed on:

| | Rejected |
| --- | --- |
| Binding | An index bound to another build or another candidate; drift in any of `sourceCommit`, `artifactDigests`, `environment`, `chainId`, `contractAddress`, `migrationIdentities`, `providerMode`, `configDigestSha256`; an environment report not carrying both the identity digest and the redacted configuration digest |
| Equivalence | An expired record, one covering a dimension that did not drift, one covering a different dimension than the one that did, and — non-waivable — any claim of equivalence across the Base mainnet boundary |
| Acceptance | Evidence accepted by its own producer; a reviewer outside Release Owner, Security reviewer or Operations reviewer; `promoted` without all three role approvals; a `draft` or `superseded` manifest binding evidence |
| Boundaries | Public participants or real commercial value outside `base-mainnet`; a classification an environment may not declare; `chain.chainId` and `environment.name` disagreeing about Base mainnet; an unredacted configuration digest |

No new dependency is introduced; the validator is hand-written in the same style as `scripts/check-cross-repo-release-manifest.mjs`.

## Scope

Contracts, validation, tests and documentation. No behavior, ABI, escrow economics, token-flow or runtime change. The fixtures under `scripts/tests/fixtures/release-evidence/` are test data, not a pinned candidate — the contract address and ABI and bytecode digests are the recorded Base Sepolia deploy values, but artifact and configuration digests are synthetic and the candidate identity is `cotsel-2026-08-05-fixture`.

## Not in this change

This delivers the contract and its enforcement. Two things remain before #636 can be accepted, and neither is unblocked yet:

- **A producer.** Nothing emits a real candidate manifest and environment report from a build. That requires the environment owner, cloud and control plane (DEC-01) and provider mode to be fixed, all of which are owned by the release charter (#635).
- **Acceptance.** The Release Owner, Security reviewer and Operations reviewer must accept evidence for a pinned candidate. No candidate is pinned and no candidate-specific E-0 review exists.

The programme verdict remains NO-GO. This is implementation work and authorizes no rehearsal, pilot or mainnet release.

## Roadmap Governance

- [x] Linked to a repo Milestone
- [x] Added to `Cotsel Roadmap` Project v2
- [x] Mapped to correct roadmap area/status/priority in Project fields

## Validation

- [x] Lint passed for changed workspaces
- [x] Tests passed for changed workspaces
- [x] Build passed for changed workspaces
- [ ] CI checks are green on this PR
- [x] Docs updated for behavior/config changes
- [x] I have signed off all commits (DCO)

Run locally: `pnpm run lint`, `pnpm run release:evidence:check` (40 tests), `pnpm run integration:manifest:check`, `pnpm run readiness:cotsel:validate`, `pnpm run readiness:cotsel:test`, and the docs-profile, data-classification and architecture-coverage guards.

The suite includes a paired reject and equivalence-accept case for every identity dimension, a command-line exit-code check, and a drift guard that removes each schema-required property in turn and asserts the validator rejects it, so the published schemas and the enforced rules cannot diverge silently. `pnpm run release:evidence:check` is wired into `ci/repo-quality`.

## Safety checklist

- [x] No ABI-breaking changes unless explicitly approved
- [x] No escrow economics/payout-path changes
- [x] No token flow changes
- [x] No key material or secrets added to logs
- [x] Rollback path documented

The contracts require the configuration digest to be marked redacted; no raw configuration, secret or participant data enters either document. Rollback: reverting this change removes the `release:evidence:check` gate and the two schemas; nothing depends on them yet, and no deployed artifact or chain state is affected.

## Runtime checks (if infra touched)

Not applicable. No runtime, compose or environment configuration is touched.
